### PR TITLE
fix: build Unicode literals directly in ProcedureCaller (fix partial match bug)

### DIFF
--- a/diepxuan/laravel-simba/src/StoredProcedures/ProcedureCaller.php
+++ b/diepxuan/laravel-simba/src/StoredProcedures/ProcedureCaller.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-04-07 13:04:50
+ * @lastupdate 2026-04-07 13:49:23
  */
 
 namespace Diepxuan\Simba\StoredProcedures;
@@ -36,12 +36,15 @@ class ProcedureCaller
      * @param null|string $connection Optional connection name
      *
      * @return mixed kết quả trả về từ procedure (tùy thuộc vào procedure)
+     *
+     * @note UTF-8 Support: Build trực tiếp Unicode literals (N'...') vào SQL
+     *       Tránh lỗi partial match khi replace placeholders
+     *       Tham khảo: docs/SQLSRV-UTF8-ROOT-CAUSE.md
      */
     public static function call(string $name, array $params = [], ?string $connection = null)
     {
         $declareSql  = [];
         $execParts   = [];
-        $bindings    = [];
         $selectOut   = [];
         $hasOutput   = false;
         $outputTypes = [];
@@ -59,8 +62,9 @@ class ProcedureCaller
                 $execParts[]  = "@{$key} = @{$key} OUTPUT";
                 $selectOut[]  = "@{$key} as {$key}";
             } else {
-                $execParts[]    = "@{$key} = :{$key}";
-                $bindings[$key] = $value;
+                // INPUT param - Build trực tiếp Unicode literal vào SQL (không dùng placeholder)
+                $literal     = self::toUnicodeLiteral($value);
+                $execParts[] = "@{$key} = {$literal}";
             }
         }
 
@@ -83,14 +87,8 @@ class ProcedureCaller
 
         $conn = $connection ? DB::connection($connection) : DB::connection();
 
-        // Dùng select() để execute toàn bộ batch và fetch kết quả
-        if (empty($bindings)) {
-            $rows = $conn->select($sql);
-        } else {
-            // Replace :placeholder với Unicode literal (fix UTF-8 cho SQL Server)
-            $processedQuery = self::replacePlaceholders($sql, $bindings);
-            $rows           = $conn->select($processedQuery);
-        }
+        // Execute trực tiếp (không cần bindings vì đã build Unicode literal vào SQL)
+        $rows = $conn->select($sql);
 
         // Tự động ép kiểu các giá trị output trả về dựa trên type đã khai báo
         if ($hasOutput && !empty($rows)) {
@@ -122,7 +120,11 @@ class ProcedureCaller
 
     /**
      * Chuyển giá trị sang dạng Unicode literal (N'...')
-     * Dùng cho parameter binding bị lỗi UTF-8.
+     * Build trực tiếp vào SQL, không qua parameter binding.
+     *
+     * @param mixed $value Giá trị cần convert
+     *
+     * @return string Unicode literal (N'...' cho strings, NULL cho null, v.v.)
      */
     public static function toUnicodeLiteral(mixed $value): string
     {
@@ -143,23 +145,5 @@ class ProcedureCaller
         }
 
         return "N'" . self::escape((string) $value) . "'";
-    }
-
-    /**
-     * Replace :placeholder với Unicode literals (N'...')
-     * Fix UTF-8 cho SQL Server parameter binding trên Linux.
-     *
-     * @param string $query    SQL query với :named placeholders
-     * @param array  $bindings Associative array [paramName => value]
-     */
-    private static function replacePlaceholders(string $query, array $bindings): string
-    {
-        foreach ($bindings as $key => $value) {
-            $literal = self::toUnicodeLiteral($value);
-            $pattern = '/:' . preg_quote($key, '/') . '/';
-            $query   = preg_replace($pattern, $literal, $query);
-        }
-
-        return $query;
     }
 }


### PR DESCRIPTION
## Problem

PR #147 introduced a bug where `replacePlaceholders()` using `preg_replace()` caused partial match issues:

```sql
-- Parameters: pStt_rec, pStt_rec0
-- Bug: :pStt_rec matches inside :pStt_rec0

@pStt_rec0 = N'001wCA40000000698528'0  ← THỪA '0'!
@pPs_no_nt = N'10000000'_nt            ← THỪA '_nt'!
```

**Error:** `Incorrect syntax near '0'`

## Root Cause

```php
// Bug: preg_replace finds :pStt_rec inside :pStt_rec0
$pattern = '/:' . preg_quote($key, '/') . '/';
$query   = preg_replace($pattern, $literal, $query);
```

When replacing `:pStt_rec`, it also matched `:pStt_rec0`, leaving the trailing `0`.

## Solution

**Build Unicode literals directly into SQL - no placeholders, no replace:**

```php
// Before (BUG)
$execParts[]    = "@{$key} = :{$key}";
$bindings[$key] = $value;
// Later: replacePlaceholders() with preg_replace → partial match bug

// After (FIX)
$literal     = self::toUnicodeLiteral($value);
$execParts[] = "@{$key} = {$literal}";
// No replace needed, no bug possible
```

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `ProcedureCaller.php` | -16 net | Remove placeholder pattern, build literals directly |

**Removed:**
- `$bindings` array
- `replacePlaceholders()` method
- Conditional logic for empty/non-empty bindings

**Simplified:**
- Direct execution: `$conn->select($sql)` (no bindings)
- Cleaner code flow

## Benefits

| Aspect | Before | After |
|--------|--------|-------|
| **Bug risk** | ⚠️ Partial match possible | ✅ Impossible |
| **Complexity** | ⚠️ 2-step (build + replace) | ✅ 1-step (build only) |
| **Performance** | ⚠️ Regex overhead | ✅ No regex |
| **Maintainability** | ⚠️ Hard to debug | ✅ Simple, clear |

## Testing

Test with similar parameter names:

```php
ProcedureCaller::call('asCAInsCT2', [
    'pStt_rec'  => '001wCA40000000698528',
    'pStt_rec0' => '001wCA40000000698528',
    'pPs_no'    => '10000000',
    'pPs_no_nt' => '10000000',
]);
```

**Expected SQL:**
```sql
@pStt_rec  = N'001wCA40000000698528',
@pStt_rec0 = N'001wCA40000000698528',
@pPs_no    = N'10000000',
@pPs_no_nt = N'10000000',
```

## Related

- Fixes bug introduced in PR #147
- Complements PR #146 (SqlsrvDB helper)
