### PR TITLE
fix: build Unicode literals trực tiếp trong ProcedureCaller (fix partial match bug)

### DIFF
--- a/diepxuan/laravel-simba/src/StoredProcedures/ProcedureCaller.php
+++ b/diepxuan/laravel-simba/src/StoredProcedures/ProcedureCaller.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-04-07 13:04:50
+ * @lastupdate 2026-04-07 13:49:23
  */
 
 namespace Diepxuan\Simba\StoredProcedures;
@@ -36,12 +36,15 @@ class ProcedureCaller
      * @param null|string $connection Optional connection name
      *
      * @return mixed kết quả trả về từ procedure (tùy thuộc vào procedure)
+     *
+     * @note UTF-8 Support: Build trực tiếp Unicode literals (N'...') vào SQL
+     *       Tránh lỗi partial match khi replace placeholders
+     *       Tham khảo: docs/SQLSRV-UTF8-ROOT-CAUSE.md
      */
     public static function call(string $name, array $params = [], ?string $connection = null)
     {
         $declareSql  = [];
         $execParts   = [];
-        $bindings    = [];
         $selectOut   = [];
         $hasOutput   = false;
         $outputTypes = [];
@@ -59,8 +62,9 @@ class ProcedureCaller
                 $execParts[]  = "@{$key} = @{$key} OUTPUT";
                 $selectOut[]  = "@{$key} as {$key}";
             } else {
-                $execParts[]    = "@{$key} = :{$key}";
-                $bindings[$key] = $value;
+                // INPUT param - Build trực tiếp Unicode literal vào SQL (không dùng placeholder)
+                $literal     = self::toUnicodeLiteral($value);
+                $execParts[] = "@{$key} = {$literal}";
             }
         }
 
@@ -83,14 +87,8 @@ class ProcedureCaller
 
         $conn = $connection ? DB::connection($connection) : DB::connection();
 
-        // Dùng select() để execute toàn bộ batch và fetch kết quả
-        if (empty($bindings)) {
-            $rows = $conn->select($sql);
-        } else {
-            // Replace :placeholder với Unicode literal (fix UTF-8 cho SQL Server)
-            $processedQuery = self::replacePlaceholders($sql, $bindings);
-            $rows           = $conn->select($processedQuery);
-        }
+        // Execute trực tiếp (không cần bindings vì đã build Unicode literal vào SQL)
+        $rows = $conn->select($sql);
 
         // Tự động ép kiểu các giá trị output trả về dựa trên type đã khai báo
         if ($hasOutput && !empty($rows)) {
@@ -122,7 +120,11 @@ class ProcedureCaller
 
     /**
      * Chuyển giá trị sang dạng Unicode literal (N'...')
-     * Dùng cho parameter binding bị lỗi UTF-8.
+     * Build trực tiếp vào SQL, không qua parameter binding.
+     *
+     * @param mixed $value Giá trị cần convert
+     *
+     * @return string Unicode literal (N'...' cho strings, NULL cho null, v.v.)
      */
     public static function toUnicodeLiteral(mixed $value): string
     {
@@ -143,23 +145,5 @@ class ProcedureCaller
         }
 
         return "N'" . self::escape((string) $value) . "'";
-    }
-
-    /**
-     * Replace :placeholder với Unicode literals (N'...')
-     * Fix UTF-8 cho SQL Server parameter binding trên Linux.
-     *
-     * @param string $query    SQL query với :named placeholders
-     * @param array  $bindings Associative array [paramName => value]
-     */
-    private static function replacePlaceholders(string $query, array $bindings): string
-    {
-        foreach ($bindings as $key => $value) {
-            $literal = self::toUnicodeLiteral($value);
-            $pattern = '/:' . preg_quote($key, '/') . '/';
-            $query   = preg_replace($pattern, $literal, $query);
-        }
-
-        return $query;
     }
 }


### PR DESCRIPTION
## Vấn đề

PR #147 giới thiệu một bug khi `replacePlaceholders()` sử dụng `preg_replace()` gây ra lỗi partial match:

```sql
-- Parameters: pStt_rec, pStt_rec0
-- Bug: :pStt_rec match bên trong :pStt_rec0

@pStt_rec0 = N'001wCA40000000698528'0  ← THỪA '0'!
@pPs_no_nt = N'10000000'_nt            ← THỪA '_nt'!
```

**Lỗi:** `Incorrect syntax near '0'`

## Nguyên nhân gốc

```php
// Bug: preg_replace tìm thấy :pStt_rec bên trong :pStt_rec0
$pattern = '/:' . preg_quote($key, '/') . '/';
$query   = preg_replace($pattern, $literal, $query);
```

Khi replace `:pStt_rec`, nó cũng match vào `:pStt_rec0`, để lại phần `0` thừa.

## Giải pháp

**Build Unicode literals trực tiếp vào SQL - không placeholders, không replace:**

```php
// Trước (BUG)
$execParts[]    = "@{$key} = :{$key}";
$bindings[$key] = $value;
// Sau đó: replacePlaceholders() với preg_replace → bug partial match

// Sau (FIX)
$literal     = self::toUnicodeLiteral($value);
$execParts[] = "@{$key} = {$literal}";
// Không cần replace, không có bug
```

## Thay đổi

| File | Lines | Mô tả |
|------|-------|-------|
| `ProcedureCaller.php` | -16 net | Xóa pattern placeholder, build literals trực tiếp |

**Đã xóa:**
- Mảng `` (không cần nữa)
- Method `replacePlaceholders()` (không cần nữa)
- Logic điều kiện cho bindings rỗng/không rỗng

**Đã đơn giản hóa:**
- Execute trực tiếp: `->select()` (không cần bindings)
- Code flow rõ ràng hơn

## Lợi ích

| Khía cạnh | Trước | Sau |
|-----------|-------|-----|
| **Rủi ro bug** | ⚠️ Có thể bị partial match | ✅ Không thể xảy ra |
| **Độ phức tạp** | ⚠️ 2 bước (build + replace) | ✅ 1 bước (build thôi) |
| **Performance** | ⚠️ Có overhead regex | ✅ Không regex |
| **Dễ maintain** | ⚠️ Khó debug | ✅ Đơn giản, rõ ràng |

## Test

Test với các parameters có tên giống nhau:

```php
ProcedureCaller::call('asCAInsCT2', [
    'pStt_rec'  => '001wCA40000000698528',
    'pStt_rec0' => '001wCA40000000698528',
    'pPs_no'    => '10000000',
    'pPs_no_nt' => '10000000',
]);
```

**SQL mong đợi:**
```sql
@pStt_rec  = N'001wCA40000000698528',
@pStt_rec0 = N'001wCA40000000698528',
@pPs_no    = N'10000000',
@pPs_no_nt = N'10000000',
```

## Liên quan

- Fix bug được giới thiệu trong PR #147
- Bổ sung cho PR #146 (SqlsrvDB helper)