### PR TITLE
feat: Cấu hình TK mặc định cho phiếu báo nợ CA4

### DIFF
--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono/Phieubaono.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono/Phieubaono.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-04-12 17:10:45
+ * @lastupdate 2026-04-15 23:57:08
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Nganhang\Baono;
@@ -34,7 +34,8 @@ class Phieubaono extends Component
 {
     // Constants cho cấu hình
     const MA_CT          = 'CA4';
-    const DEFAULT_TK_CO  = 11_217;
+    const DEFAULT_TK_CO  = 11_217; // TK Có mặc định cho báo nợ
+    const DEFAULT_TK_NO  = '331';  // TK Nợ mặc định cho chi tiết
     const DEFAULT_MA_NT  = 'VND';
     const DEFAULT_TY_GIA = 1;
     // Property nhận từ bên ngoài (Baono component)
@@ -669,7 +670,7 @@ class Phieubaono extends Component
     {
         $newIndex = $this->pCts->count();
         $this->pCts->push([
-            'ma_tk'     => '',
+            'ma_tk'     => self::DEFAULT_TK_NO, // TK Nợ mặc định = 331
             'dien_giai' => $this->pDien_Giai,
             'ps_no'     => 0,
             'ps_co'     => 0,


### PR DESCRIPTION
## Thay đổi

Cấu hình tài khoản mặc định cho phiếu báo nợ (CA4):

| Thành phần | Giá trị |
|------------|---------|
| **TK Có mặc định** | 11217 |
| **TK Nợ chi tiết mặc định** | 331 |

## Chi tiết

### Trước
- TK Có: 11217
- TK Nợ chi tiết: để trống

### Sau
- TK Có: 11217 (giữ nguyên)
- TK Nợ chi tiết: 331 (tự động điền khi thêm dòng mới)

## Files thay đổi

- 

## Tham chiếu

- Issue: diepxuan/SimbaSql#59

---

## Checklist

- [ ] Code review
- [ ] Test chức năng tạo phiếu báo nợ
- [ ] Test chức năng sửa phiếu báo nợ
- [ ] Verify TK mặc định hiển thị đúng
