### PR TITLE
fix: create storage directories before composer install in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,12 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: none
 
+      - name: Create storage directories
+        run: |
+          mkdir -p storage/framework/{cache,sessions,views}
+          mkdir -p bootstrap/cache
+          chmod -R 777 storage bootstrap/cache
+
       - name: Install Composer dependencies
         run: |
           composer install --prefer-dist --no-interaction --no-progress


### PR DESCRIPTION
## Problem

CI workflow failed with error:

```
In Compiler.php line 67:
 Please provide a valid cache path.
Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1
```

## Solution

Create required Laravel storage directories before running `composer install`:

```yaml
- name: Create storage directories
  run: |
    mkdir -p storage/framework/{cache,sessions,views}
    mkdir -p bootstrap/cache
    chmod -R 777 storage bootstrap/cache
```

## Related

Fix for PR #156 which was merged before this fix was added.