### PR TITLE
chore: update Docker image tag to ghcr.io/diepxuan/portal:latest

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
         WWWGROUP: "${WWWGROUP}"
       # DNS config for build process
       network: host
-    image: sail-8.2/app
+    image: ghcr.io/diepxuan/portal:latest
     # DNS servers for container runtime
     dns:
       - 8.8.8.8


### PR DESCRIPTION
## Thay đổi

- Đổi image tag từ sail-8.2/app sang ghcr.io/diepxuan/portal:latest
- Giữ nguyên build context cho local development
- Hỗ trợ pull từ registry khi local image không có

## Workflow

| Lệnh | Hành động |
|------|-----------|
| sail build | Build từ Dockerfile_sqlsrv → tag ghcr.io/diepxuan/portal:latest |
| sail up | Dùng image local (nếu có) hoặc pull từ registry |

## Testing

- [ ] sail build thành công
- [ ] sail up hoạt động
- [ ] Image tag đúng ghcr.io/diepxuan/portal:latest