### PR TITLE
chore: bổ sung simba-docs mount vào workspace identity và docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,4 @@ portal-fixed.service
 
 # OpenClaw
 .openclaw/workspace-state.json
-
+simba-docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,11 +202,13 @@ docs/add-laravel-rules
 | `scripts/` | Scripts riêng cho Portal |
 | `docs/` | Documentation |
 | `memory/` | Daily memory logs |
+| `simba-docs/` | Mount ZFS từ SimbaSql repo — domain knowledge (readonly) |
 
 ### 10.2 Cấm
 
 - ❌ Tạo file ngoài `/root/.openclaw/workspace/projects/portal/`
 - ❌ Sửa core Laravel files (trừ khi được yêu cầu)
+- ❌ Ghi đè hoặc sửa file trong `simba-docs/` (mount readonly từ SimbaSql)
 
 ---
 

--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -8,12 +8,12 @@
 
 ## 1. Vai trò
 
-| Thuộc tính | Giá trị |
-|------------|---------|
-| **Tên** | Bột |
-| **Vai trò** | Trợ lý máy tính / Coder / Developer cho Portal Project |
-| **Cấp bậc** | Anh cả (quản lý sub-agents) |
-| **Workspace** | `/root/.openclaw/workspace/projects/portal/` |
+| Thuộc tính    | Giá trị                                                |
+| ------------- | ------------------------------------------------------ |
+| **Tên**       | Bột                                                    |
+| **Vai trò**   | Trợ lý máy tính / Coder / Developer cho Portal Project |
+| **Cấp bậc**   | Anh cả (quản lý sub-agents)                            |
+| **Workspace** | `/root/.openclaw/workspace/projects/portal/`           |
 
 ---
 
@@ -30,10 +30,10 @@
 
 ### 3.1 Phạm vi cho phép
 
-| Ưu tiên | Vị trí | Ghi chú |
-|---------|--------|---------|
-| **Cao nhất** | `diepxuan/` | 14 core business packages |
-| **Hạn chế** | Core Laravel files | Chỉ khi được Sếp yêu cầu |
+| Ưu tiên      | Vị trí             | Ghi chú                   |
+| ------------ | ------------------ | ------------------------- |
+| **Cao nhất** | `diepxuan/`        | 14 core business packages |
+| **Hạn chế**  | Core Laravel files | Chỉ khi được Sếp yêu cầu  |
 
 ### 3.2 Files hạn chế sửa
 
@@ -50,11 +50,11 @@
 
 ### 4.1 BẮT BUỘC cho mọi package/module
 
-| File | Nội dung tối thiểu |
-|------|-------------------|
-| `README.md` | Mục đích, cách dùng, cấu trúc, dependencies, troubleshooting |
-| `CHANGELOG.md` | Versioning (nếu có) |
-| `docs/UPDATE-YYYY-MM-DD.md` | Thay đổi config/behavior quan trọng |
+| File                        | Nội dung tối thiểu                                           |
+| --------------------------- | ------------------------------------------------------------ |
+| `README.md`                 | Mục đích, cách dùng, cấu trúc, dependencies, troubleshooting |
+| `CHANGELOG.md`              | Versioning (nếu có)                                          |
+| `docs/UPDATE-YYYY-MM-DD.md` | Thay đổi config/behavior quan trọng                          |
 
 ### 4.2 Nội dung tài liệu
 
@@ -70,17 +70,63 @@
 
 ---
 
+## 4b. Simba Domain Knowledge
+
+### Mount `simba-docs/`
+
+| Thuộc tính     | Giá trị                                                              |
+| -------------- | -------------------------------------------------------------------- |
+| **Đường dẫn**  | `simba-docs/` (trong workspace)                                      |
+| **Mục đích**   | Toàn bộ tài liệu SimbaSql .NET — domain knowledge cho Portal Project |
+| **Trạng thái** | Readonly — không ghi đè                                              |
+
+### Cấu trúc simba-docs
+
+| Thư mục              | Nội dung                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| `asia/`              | 10 module ERP (AR, AP, CA, CO, SO, PO, SI, IN, FA, GL) — summaries, vouchers, reports |
+| `asia/{module}/`     | Chi tiết từng module: danh sách voucher, report, master, business logic               |
+| `decompiled/asia/`   | 338 DLL đã decompile — mỗi DLL có README riêng (forms, methods, SP calls, logic)      |
+| `procedures/`        | Stored Procedures theo module (AR, AP, CA, CO, SO, PO, SI, IN, FA, GL, System)        |
+| `procedures/guides/` | Kiến trúc core SQL, naming conventions                                                |
+| `data/`              | System tables documentation (sysMenu, sysVoucherInfo, sysDictionaryInfo, ...)         |
+| `reference/`         | Tài liệu tra cứu: ASIA_SIMBA_MAPPING, QUICK_REFERENCE, CODE_REFERENCE, FILE_INDEX     |
+| `follows/`           | SQL scripts mẫu (PhieuBaoNo, ChuyenSoDu, ...)                                         |
+| `tasks/`             | Task tracking, analysis reports                                                       |
+
+### Khi nào dùng simba-docs
+
+| Nhu cầu                      | Nguồn trong simba-docs                       |
+| ---------------------------- | -------------------------------------------- |
+| Hiểu logic nghiệp vụ module  | `asia/{MODULE}_SUMMARY.md`, `asia/{module}/` |
+| Tìm stored procedure         | `procedures/{MODULE}/`, `asia/SP_INDEX.md`   |
+| Hiểu bảng CSDL               | `asia/TABLES_INDEX.md`, `dbo/Tables/`        |
+| Trace business logic từ DLL  | `decompiled/asia/{DLL}.dll/README.md`        |
+| Luồng dữ liệu liên module    | `asia/CROSS_MODULE_INTERACTIONS.md`          |
+| Tra cứu nhanh theo nghiệp vụ | `reference/QUICK_REFERENCE.md`               |
+| Danh mục chứng từ, menu      | `data/sysMenu.md`, `data/SiDmCt.md`          |
+| Mapping giữa App và SQL      | `reference/ASIA_SIMBA_MAPPING.md`            |
+
+### Nguyên tắc
+
+1. simba-docs là **nguồn sự thật** về logic nghiệp vụ Simba ERP
+2. Khi implement task Portal → luôn đối chiếu với simba-docs trước
+3. Không sửa file trong simba-docs — đây là mount readonly
+4. Tài liệu tham chiếu thêm tại `docs/SIMBA-DOCS.md`
+
+---
+
 ## 5. Laravel Best Practices
 
 **Tham chiếu chi tiết:** `.agent/rules/laravel.md` (cross-tool foundation)
 
 ### 5.1 Kiến trúc
 
-| Pattern | Mô tả |
-|---------|-------|
-| **MVC** | Skinny controllers, business logic trong Services |
-| **Dependency Injection** | Inject qua constructor |
-| **Service Pattern** | Logic nghiệp vụ trong Service classes |
+| Pattern                  | Mô tả                                             |
+| ------------------------ | ------------------------------------------------- |
+| **MVC**                  | Skinny controllers, business logic trong Services |
+| **Dependency Injection** | Inject qua constructor                            |
+| **Service Pattern**      | Logic nghiệp vụ trong Service classes             |
 
 ### 5.2 Eloquent ORM
 
@@ -107,12 +153,12 @@ public function scopeActive($query) {
 
 ### 5.4 Performance
 
-| Technique | Example |
-|-----------|---------|
-| Eager loading | `with()` |
-| Select columns | `select('id', 'name')` |
-| Chunking | `User::chunk(200, callback)` |
-| Caching | `config:cache`, `route:cache` |
+| Technique      | Example                       |
+| -------------- | ----------------------------- |
+| Eager loading  | `with()`                      |
+| Select columns | `select('id', 'name')`        |
+| Chunking       | `User::chunk(200, callback)`  |
+| Caching        | `config:cache`, `route:cache` |
 
 ### 5.5 Testing
 
@@ -142,11 +188,11 @@ Bột (em)
 
 ## 7. Khi spawn sub-agent
 
-| Yêu cầu | Mô tả |
-|---------|-------|
-| **Gọi là** | **đệ** |
-| **Mô tả** | Mục tiêu, Input, Output mong đợi, Giới hạn quyền |
-| **Giám sát** | Không để đệ tự quyết định vượt thẩm quyền |
+| Yêu cầu      | Mô tả                                            |
+| ------------ | ------------------------------------------------ |
+| **Gọi là**   | **đệ**                                           |
+| **Mô tả**    | Mục tiêu, Input, Output mong đợi, Giới hạn quyền |
+| **Giám sát** | Không để đệ tự quyết định vượt thẩm quyền        |
 
 ---
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,52 @@
 # MEMORY.md - Long-Term Memory
 
+## Simba-docs Mount (2026-05-05)
+
+- Chứa toàn bộ tài liệu SimbaSql .NET: 10 module ERP, 338 decompiled DLLs, SPs, system tables
+- Read-only — nguồn sự thật về logic nghiệp vụ Simba
+- Hướng dẫn chi tiết: `docs/SIMBA-DOCS.md`
+- Identity files đã cập nhật: `SOUL.md`, `IDENTITY.md`, `AGENTS.md`, `TOOLS.md`
+
+---
+
+## 2026-05-05: Cac task co yeu cau CRUD khach hang
+
+### Task 001: AR - Danh muc khach hang
+
+- **Yeu cau:** Nhap, sua thong tin khach hang
+- **Chuc nang:** Quan ly danh muc khach hang (CRUD)
+- **Form classes:** frmARDMKH (xem danh sach voi btnAdd, btnEdit, btnDelete), frmARDMKHEdit (them/sua)
+- **Stored Procedures:** SP_AR_DMKH_GET, INSERT, UPDATE, DELETE
+- **Business Rules:**
+    - Khong cho phep sua khi da co giao dich
+    - Khong cho phep xoa khi da co giao dich
+- **Trang thai:** HOAN THANH (da xac nhan)
+
+### Task 38: Ban hang | khach hang | them, sua, xoa
+
+- **Yeu cau:** Task CRUD cho khach hang trong module ban hang
+- **Trang thai:** OPEN
+- **Tien do:**
+    - [ ] Phan tich yeu cau
+    - [ ] Thiet ke co so du lieu (neu can)
+    - [ ] Implement CRUD methods
+    - [ ] Tao Livewire component (list, create, edit)
+    - [ ] Them route
+    - [ ] Viet test
+    - [ ] Review va merge
+
+### Task 002: AR - Danh muc nhom khach hang
+
+- **Lien quan:** Co rang buoc voi khach hang
+- **Business Rules:** Khong cho phep sua/xoa khi da co khach hang thuoc nhom
+
+### Task 003: AR - Danh muc phan loai khach hang
+
+- **Lien quan:** Co rang buoc voi khach hang
+- **Business Rules:** Khong cho phep sua/xoa khi da co khach hang su dung
+
+---
+
 ## 2026-05-04: Hoan thanh docs/tasks/
 
 ### Noi dung
@@ -8,34 +55,34 @@ Da hoan thanh viec tao **298 task files** trong `docs/tasks/` cho Portal Project
 
 ### Chi tiet
 
-| Chi so | Gia tri |
-|--------|---------|
-| Tong so task | 298 |
-| DLLs decompiled | 338 |
-| DLLs da co task | 336 |
-| Ty le hoan thanh | 99.4% |
+| Chi so           | Gia tri |
+| ---------------- | ------- |
+| Tong so task     | 298     |
+| DLLs decompiled  | 338     |
+| DLLs da co task  | 336     |
+| Ty le hoan thanh | 99.4%   |
 
 ### Cau truc
 
-| Nhom | So DLL | Task IDs |
-|------|--------|----------|
-| AR | ~16 | 001-018, 158 |
-| AP | ~4 | 017-020 |
-| CA | ~12 | 021-032, 159-165 |
-| CO | ~20 | 039-042, 166-180 |
-| SO | ~40 | 043-061, 197-216, 338-340 |
-| PO | ~20 | 063-080, 217 |
-| SI | ~26 | 081-099, 218-224 |
-| IN | ~29 | 100-117, 225-235 |
-| FA | ~36 | 051 (da rename 341), 118-137, 236-253 |
-| GL | ~95 | 049, 138-157, 254-337 |
-| System | ~18 | 181-196 |
+| Nhom   | So DLL | Task IDs                              |
+| ------ | ------ | ------------------------------------- |
+| AR     | ~16    | 001-018, 158                          |
+| AP     | ~4     | 017-020                               |
+| CA     | ~12    | 021-032, 159-165                      |
+| CO     | ~20    | 039-042, 166-180                      |
+| SO     | ~40    | 043-061, 197-216, 338-340             |
+| PO     | ~20    | 063-080, 217                          |
+| SI     | ~26    | 081-099, 218-224                      |
+| IN     | ~29    | 100-117, 225-235                      |
+| FA     | ~36    | 051 (da rename 341), 118-137, 236-253 |
+| GL     | ~95    | 049, 138-157, 254-337                 |
+| System | ~18    | 181-196                               |
 
 ### Lưu ý
 
 - File 049-SO-phieuxuat-banle.md da rename thanh 340-SO-phieuxuat-banle.md
 - File 051-FA-daocao-phantich-tscd-01.md da rename thanh 341-FA-baocao-phantich-tscd-01.md
-- Simba.exe va INDMVT_ khong phai DLL, khong can tao task
+- Simba.exe va INDMVT\_ khong phai DLL, khong can tao task
 
 ### Quy tac
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -65,6 +65,7 @@ Nếu có xung đột giữa các file → SOUL.md được ưu tiên.
 | Git workflow | `AGENTS.md` §7 |
 | Documentation rules | `IDENTITY.md` §5 |
 | Memory system | `AGENTS.md` §2 |
+| Simba domain knowledge | `docs/SIMBA-DOCS.md`, `simba-docs/` (mount) |
 
 ---
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -20,14 +20,26 @@ Skills are shared. Your setup is yours. Keeping them apart means you can update 
 ## SSH Hosts
 
 ### Development Servers
+
 - **web** → `ssh root@web` (Portal development server)
-  - Primary database server for Portal application
-  - Contains production-like data for development
+    - Primary database server for Portal application
+    - Contains production-like data for development
 
 ### Database Connections
+
 - **Portal Database**: SQL Server on web server
 
 ### Notes
+
 - SSH key: `~/.ssh/id_rsa` (existing key)
 - Default port: 22
 - Use `ssh root@web` for direct connection
+
+---
+
+## simba-docs
+
+- **Mount point:** `simba-docs/` (trong workspace)
+- **Mục đích:** Toàn bộ tài liệu SimbaSql .NET — domain knowledge
+- **Trạng thái:** Readonly
+- **Chi tiết:** `docs/SIMBA-DOCS.md`

--- a/docs/SIMBA-DOCS.md
+++ b/docs/SIMBA-DOCS.md
@@ -1,0 +1,243 @@
+# SIMBA-DOCS.md — Hướng dẫn sử dụng SimbaSql Documentation Mount
+
+## 1. Tổng quan
+
+`simba-docs/` là ZFS mount trong workspace, trỏ đến toàn bộ tài liệu của dự án **SimbaSql .NET** — hệ thống ERP gốc mà Portal đang được xây dựng lại.
+
+| Thuộc tính         | Giá trị                              |
+| ------------------ | ------------------------------------ |
+| **Workspace path** | `simba-docs/`                        |
+| **Trạng thái**     | Readonly — không ghi đè              |
+| **Repo gốc**       | https://github.com/diepxuan/SimbaSql |
+
+---
+
+## 2. Cấu trúc tổng thể
+
+```
+simba-docs/
+├── README.md                    # Index chính của toàn bộ docs
+├── asia/                        # 10 module ERP
+│   ├── {AR,AP,CA,CO,SO,PO,SI,IN,FA,GL}_SUMMARY.md
+│   ├── CROSS_MODULE_INTERACTIONS.md
+│   ├── SP_INDEX.md
+│   ├── TABLES_INDEX.md
+│   ├── guides/
+│   ├── common/
+│   └── {ar,ap,ca,co,so,po,si,in,fa,gl}/   # Chi tiết từng module
+├── decompiled/asia/             # 338 DLL đã decompile
+├── procedures/                  # Stored Procedures theo module
+│   ├── {AR,AP,CA,CO,SO,PO,SI,IN,FA,GL,System}/
+│   └── guides/
+├── data/                        # System tables documentation
+│   ├── sysMenu.md
+│   ├── sysVoucherInfo.md
+│   ├── sysDictionaryInfo.md
+│   └── ...
+├── reference/                   # Tài liệu tra cứu
+│   ├── ASIA_SIMBA_MAPPING.md
+│   ├── QUICK_REFERENCE.md
+│   ├── CODE_REFERENCE.md
+│   └── FILE_INDEX.md
+├── follows/                     # SQL scripts mẫu
+└── tasks/                       # Task tracking, analysis
+```
+
+---
+
+## 3. 10 Module ERP (thư mục `asia/`)
+
+| Code   | Module              | Summary              | Mô tả                                                        |
+| ------ | ------------------- | -------------------- | ------------------------------------------------------------ |
+| **AR** | Accounts Receivable | `asia/AR_SUMMARY.md` | Công nợ phải thu, danh mục khách hàng, nhóm KH, phân loại KH |
+| **AP** | Accounts Payable    | `asia/AP_SUMMARY.md` | Công nợ phải trả, nhà cung cấp                               |
+| **CA** | Cash & Bank         | `asia/CA_SUMMARY.md` | Tiền mặt, tiền gửi ngân hàng, phiếu thu/chi                  |
+| **CO** | Costing/Production  | `asia/CO_SUMMARY.md` | Sản xuất, tính giá thành, BOM                                |
+| **SO** | Sales Order         | `asia/SO_SUMMARY.md` | Bán hàng, phiếu xuất, đơn hàng                               |
+| **PO** | Purchase Order      | `asia/PO_SUMMARY.md` | Mua hàng, phiếu nhập, đơn đặt hàng                           |
+| **SI** | System              | `asia/SI_SUMMARY.md` | Hệ thống, login, danh mục chung, phân quyền                  |
+| **IN** | Inventory           | `asia/IN_SUMMARY.md` | Quản lý kho, vật tư, danh mục hàng hóa                       |
+| **FA** | Fixed Assets        | `asia/FA_SUMMARY.md` | Tài sản cố định, khấu hao, dao cáo TSCĐ                      |
+| **GL** | General Ledger      | `asia/GL_SUMMARY.md` | Kế toán tổng hợp, sổ cái, báo cáo tài chính                  |
+
+### Chi tiết mỗi module
+
+Mỗi module trong `asia/{module}/` có cấu trúc:
+
+```
+asia/ar/
+├── masters/     # Danh mục (customers, groups, classifications)
+├── vouchers/    # Chứng từ (phiếu, hóa đơn)
+└── reports/     # Báo cáo
+```
+
+---
+
+## 4. Decompiled DLL Analysis (`decompiled/asia/`)
+
+**338 DLL** đã được decompile và phân tích. Mỗi DLL có thư mục riêng chứa `README.md` với:
+
+- Danh sách Forms
+- Methods chính
+- Stored Procedure calls
+- Business logic
+
+### Ví dụ DLL quan trọng
+
+| DLL            | Module | Chức năng                     |
+| -------------- | ------ | ----------------------------- |
+| `ARDMKH.dll`   | AR     | Danh mục khách hàng           |
+| `ARDMNHKH.dll` | AR     | Danh mục nhóm khách hàng      |
+| `ARDMPLKH.dll` | AR     | Danh mục phân loại khách hàng |
+| `ARTT.dll`     | AR     | Thanh toán công nợ            |
+| `SOVchSO1.dll` | SO     | Chứng từ bán hàng             |
+| `POVchPO1.dll` | PO     | Chứng từ mua hàng             |
+| `SiTools.dll`  | SI     | Tiện ích hệ thống             |
+
+### Cách đọc DLL docs
+
+```bash
+# Xem thông tin DLL cụ thể
+cat simba-docs/decompiled/asia/ARDMKH.dll/README.md
+
+# Tìm DLL theo module
+ls simba-docs/decompiled/asia/ | grep "^AR"
+
+# Tìm SP calls trong tất cả DLL
+grep -r "SP_" simba-docs/decompiled/asia/*/README.md
+```
+
+---
+
+## 5. Stored Procedures (`procedures/`)
+
+### Cấu trúc
+
+```
+procedures/
+├── AR/     # SP cho module AR
+├── AP/     # SP cho module AP
+├── CA/     # SP cho module CA
+├── CO/     # SP cho module CO
+├── SO/     # SP cho module SO
+├── PO/     # SP cho module PO
+├── SI/     # SP cho module SI
+├── IN/     # SP cho module IN
+├── FA/     # SP cho module FA
+├── GL/     # SP cho module GL
+├── System/ # SP hệ thống
+├── Dash/   # Dashboard
+├── HR/     # Nhân sự
+├── SA/     # Sales Admin
+├── Ta/     # Tax
+└── UTILITIES/
+```
+
+### Index SP
+
+- **Toàn bộ:** `asia/SP_INDEX.md`
+- **Theo module:** `procedures/{MODULE}/procedures.md`
+- **Kiến trúc & naming:** `procedures/guides/CORE.md`
+
+### Ví dụ tìm SP
+
+```bash
+# Tìm SP liên quan đến khách hàng
+grep -ri "khach hang\|customer\|DMKH" simba-docs/procedures/AR/
+
+# Xem SP GET cho danh mục KH
+cat simba-docs/procedures/AR/SP_AR_DMKH_GET.sql 2>/dev/null || \
+  grep -l "SP_AR_DMKH" simba-docs/procedures/AR/*
+```
+
+---
+
+## 6. System Data (`data/`)
+
+| File                   | Nội dung           | Ứng dụng                       |
+| ---------------------- | ------------------ | ------------------------------ |
+| `sysMenu.md`           | Hệ thống menu      | Xây dựng navigation Portal     |
+| `sysVoucherInfo.md`    | Thông tin chứng từ | Định nghĩa voucher types       |
+| `sysDictionaryInfo.md` | Từ điển dữ liệu    | Map field names, data types    |
+| `sysReportInfo.md`     | Danh sách báo cáo  | Replicate reports trong Portal |
+| `sysSetupModule.md`    | Cấu hình module    | Setup flow                     |
+| `SiDmCt.md`            | Danh mục chứng từ  | Master list of vouchers        |
+
+---
+
+## 7. Tài liệu tra cứu (`reference/`)
+
+| File                    | Mục đích                                   |
+| ----------------------- | ------------------------------------------ |
+| `ASIA_SIMBA_MAPPING.md` | Liên kết giữa Asia App (.NET) và Simba SQL |
+| `QUICK_REFERENCE.md`    | Tham khảo nhanh SP theo nghiệp vụ          |
+| `CODE_REFERENCE.md`     | Reference code patterns                    |
+| `FILE_INDEX.md`         | Index file nhanh                           |
+
+---
+
+## 8. Luồng nghiệp vụ liên module
+
+File `asia/CROSS_MODULE_INTERACTIONS.md` mô tả:
+
+| Flow            | Modules           | Mô tả                                   |
+| --------------- | ----------------- | --------------------------------------- |
+| Bán hàng        | SO → SI → AR → GL | Đơn hàng → xuất kho → công nợ → kế toán |
+| Mua hàng        | PO → IN → AP → GL | Đặt hàng → nhập kho → công nợ → kế toán |
+| Thu/Chi tiền    | CA → GL           | Thu chi → ghi sổ kế toán                |
+| Tài sản cố định | FA → GL           | Khấu hao → bút toán                     |
+| Tính giá thành  | CO → GL           | Giá thành → kế toán                     |
+
+---
+
+## 9. Database Schema
+
+| Object           | Path                                | Count |
+| ---------------- | ----------------------------------- | ----- |
+| Tables           | `../dbo/Tables/README.md`           | 440   |
+| StoredProcedures | `../dbo/StoredProcedures/README.md` | 2,031 |
+| Functions        | `../dbo/Functions/README.md`        | 89    |
+| Views            | `../dbo/Views/README.md`            | 4     |
+
+**Lưu ý:** `dbo/` nằm trong repo SimbaSql, không phải trong simba-docs mount.
+Xem tại: https://github.com/diepxuan/SimbaSql/tree/main/dbo
+
+---
+
+## 10. Workflow khi implement task
+
+Khi nhận task Portal, Bột làm theo thứ tự:
+
+1. **Xác định module** — task thuộc module nào (AR, SO, IN, ...)
+2. **Đọc summary** — `asia/{MODULE}_SUMMARY.md` để hiểu tổng quan
+3. **Tra DLL** — `decompiled/asia/{DLL}.dll/README.md` để biết logic gốc
+4. **Tra SP** — `procedures/{MODULE}/` để biết database calls
+5. **Tra cross-module** — `asia/CROSS_MODULE_INTERACTIONS.md` nếu liên quan nhiều module
+6. **Tra tables** — `asia/TABLES_INDEX.md` để biết bảng CSDL
+7. **Implement** — dựa trên domain knowledge đã thu thập
+
+---
+
+## 11. Quy tắc
+
+- `simba-docs/` là **readonly** — không ghi, sửa, xóa file trong mount
+- Đây là **nguồn sự thật** về logic nghiệp vụ Simba ERP
+- Luôn đối chiếu với simba-docs trước khi implement logic mới
+- Nếu thông tin trong simba-docs không đủ → báo Sếp
+
+---
+
+## 12. Liên kết ngoài
+
+| Resource        | URL                                         |
+| --------------- | ------------------------------------------- |
+| SimbaSql Repo   | https://github.com/diepxuan/SimbaSql        |
+| SimbaSql Issues | https://github.com/diepxuan/SimbaSql/issues |
+| SimbaSql PRs    | https://github.com/diepxuan/SimbaSql/pulls  |
+| Portal Repo     | https://github.com/diepxuan/portal          |
+| Portal Issues   | https://github.com/diepxuan/portal/issues   |
+| Portal Project  | https://github.com/orgs/diepxuan/projects/2 |
+
+---
+
+_Last updated: 2026-05-05_


### PR DESCRIPTION
## Mục đích

Bổ sung thông tin về ZFS mount `simba-docs/` (toàn bộ tài liệu SimbaSql .NET) vào các file identity và tạo tài liệu hướng dẫn chi tiết.

## Thay đổi

### Identity files
| File | Thay đổi |
|------|----------|
| `SOUL.md` | Thêm tham chiếu simba domain knowledge |
| `IDENTITY.md` | Thêm section **4b. Simba Domain Knowledge** — cấu trúc, mapping, nguyên tắc sử dụng |
| `AGENTS.md` | Workspace scope: cho phép đọc `simba-docs/`, cấm ghi đè |
| `TOOLS.md` | Thêm mục ZFS mounts |
| `MEMORY.md` | Ghi nhận sự kiện mount |
| `.gitignore` | Thêm `simba-docs/` |

### Tài liệu mới
- **`docs/SIMBA-DOCS.md`** — Hướng dẫn chi tiết 12 section:
  1. Tổng quan mount
  2. Cấu trúc tổng thể
  3. 10 module ERP (AR, AP, CA, CO, SO, PO, SI, IN, FA, GL)
  4. Decompiled DLL analysis (338 DLLs)
  5. Stored Procedures theo module
  6. System Data documentation
  7. Tài liệu tra cứu
  8. Luồng nghiệp vụ liên module
  9. Database Schema
  10. Workflow khi implement task
  11. Quy tắc
  12. Liên kết ngoài

## Nguồn simba-docs

- **Mount:** ZFS `rpool/data/subvol-122-disk-0`
- **Real path:** `/root/.openclaw/workspace/projects/SimbaSql/docs`
- **Workspace path:** `simba-docs/`
- **Trạng thái:** Readonly