### PR TITLE
refactor: replace Eloquent query with SP for customer list

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/banhang/khachhang.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/banhang/khachhang.blade.php
@@ -12,7 +12,7 @@
             'ma_kh' => 'Mã khách hàng',
             'ten_kh' => 'Tên khách hàng',
             'dia_chi' => 'Địa chỉ',
-            'dien_thoai' => 'Điện thoại',
+            'tel' => 'Điện thoại',
             'nguoi_gd' => 'Người giao dịch',
             'ma_httt_po' => 'Hình thức TT',
         ],

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php
@@ -8,16 +8,23 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-01-11 21:25:10
+ * @lastupdate 2026-05-07 11:55:25
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Banhang;
 
-use Diepxuan\Catalog\Models\ArDmKh;
+use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
 use Diepxuan\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Component;
 
+/**
+ * Component Khachhang.
+ *
+ * Hiển thị danh sách khách hàng.
+ * Sử dụng Stored Procedure asARGetDMKH thay vì Eloquent query.
+ */
 class Khachhang extends Component
 {
     public $pTk_List   = '';
@@ -26,11 +33,13 @@ class Khachhang extends Component
     public $pMa_Bp;
     protected $arDmKhs;
 
+    /**
+     * Khởi tạo: Lấy danh sách khách hàng từ SP.
+     */
     public function mount(): void
     {
-        $this->arDmKhs = ArDmKh::where('isKh', true)
-            ->get()
-        ;
+        // Gọi SP asARGetDMKH với module AR, lọc theo công ty hiện tại
+        $this->arDmKhs = AsARGetDMKH::getCustomers(maCty: SModel::CTY);
     }
 
     public function updated($property): void
@@ -49,7 +58,6 @@ class Khachhang extends Component
             ? $this->arDmKhs
             : Collection::make($this->arDmKhs->all());
 
-        // diepxuan/laravel-catalog/resources/views/banhang/khachhang.blade.php
         return view('catalog::banhang.khachhang', [
             'arDmKhs' => $this->arDmKhs,
         ])->layout('catalog::layouts.app');

--- a/diepxuan/laravel-simba/src/StoredProcedures/AsARGetDMKH.php
+++ b/diepxuan/laravel-simba/src/StoredProcedures/AsARGetDMKH.php
@@ -8,20 +8,30 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-02-12 09:16:00
+ * @lastupdate 2026-05-07 11:55:26
  */
 
 namespace Diepxuan\Simba\StoredProcedures;
 
+use Diepxuan\Simba\Helper\ParamHelper;
 use Diepxuan\Simba\SModel\SModel;
 use Illuminate\Support\Collection;
-use Diepxuan\Simba\Helper\ParamHelper;
 
+/**
+ * Stored Procedure: asARGetDMKH.
+ *
+ * Lấy danh mục khách hàng/nhà cung cấp/nhân viên.
+ * Uses static SQL với OPTION (RECOMPILE) cho optimal execution plan.
+ *
+ * @param null|string $pMa_cty   Mã công ty (default: current company)
+ * @param null|string $pMa_kh    Mã khách hàng prefix search (null/empty = all)
+ * @param string      $pModuleId 'AR'=khách hàng, 'AP'=nhà cung cấp, 'CA'=nhân viên
+ */
 class AsARGetDMKH
 {
     public static function call(array $params): Collection
     {
-        $paramObj = ParamHelper::fromArray($params);
+        $paramObj   = ParamHelper::fromArray($params);
         $connection = (new SModel())->getConnectionName();
 
         return ProcedureCaller::call('asARGetDMKH', [
@@ -30,5 +40,21 @@ class AsARGetDMKH
             'pStruct'   => $paramObj->pStruct ?? '0',
             'pModuleId' => $paramObj->pModuleId ?? '',
         ], $connection);
+    }
+
+    /**
+     * Lấy danh sách khách hàng (module AR).
+     *
+     * @param null|string $maCty  Mã công ty
+     * @param null|string $search Prefix search theo mã khách hàng
+     */
+    public static function getCustomers(?string $maCty = null, ?string $search = null): Collection
+    {
+        return self::call([
+            'pMa_cty'   => $maCty ?? SModel::CTY,
+            'pMa_kh'    => $search,
+            'pStruct'   => '0',
+            'pModuleId' => 'AR',
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

Thay thế Eloquent query bằng Stored Procedure `asARGetDMKH` cho danh sách khách hàng.

## Changes

| File | Thay đổi |
|------|----------|
| `laravel-simba/src/StoredProcedures/AsARGetDMKH.php` | Thêm `getCustomers()` convenience method |
| `laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php\| `mount()` dùng SP thay vì `ArDmKh::where('isKh', true)->get()` |
| `laravel-catalog/resources/views/banhang/khachhang.blade.php\| Fix column name `dien_thoai` → `tel` (match SP output) |

## Before vs After

**Before (Eloquent):**
```php
ArDmKh::where('isKh', true)->get()
// Load toàn bộ records, hydrate thành Eloquent models
```

**After (Stored Procedure):**
```php
AsARGetDMKH::getCustomers(maCty: SModel::CTY)
// SP xử lý filter, JOIN, sorting ở database layer
```

## Benefits

- Static SQL với OPTION (RECOMPILE) cho optimal execution plan
- SP xử lý JOINs (ARDMNHKH, ARDMPLKH, GLDMTK, SIDMHTTT, ARDMKHNGH) ở DB layer
- Không cần Eloquent hydration overhead cho read-only display
- Tránh global scope complications (ksd, ma_cty, orderBy)