### PR TITLE
refactor: polish menu management UI — selection banner, expand/collapse toolbar, floating toast

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/layouts/app.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/layouts/app.blade.php
@@ -26,29 +26,6 @@
     <!-- Styles -->
     @livewireStyles
     @stack('styles')
-
-    {{-- Simba Selection Mode Animations --}}
-    <style>
-        @keyframes pulse-red-select {
-            0%, 100% { background-color: #fecaca !important; }
-            50% { background-color: #fca5a5 !important; }
-        }
-        @keyframes pulse-green-select {
-            0%, 100% { background-color: #bbf7d0 !important; }
-            50% { background-color: #86efac !important; }
-        }
-        .pulse-red-simba {
-            animation: pulse-red-select 1s ease-in-out infinite !important;
-            display: inline-block !important;
-            padding: 2px 6px !important;
-        }
-        .pulse-green-simba {
-            animation: pulse-green-select 1s ease-in-out infinite !important;
-            cursor: pointer !important;
-            display: inline-block !important;
-            padding: 2px 6px !important;
-        }
-    </style>
 </head>
 
 <body class="font-sans text-sm antialiased">

--- a/diepxuan/laravel-catalog/resources/views/system/menu-node.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/menu-node.blade.php
@@ -1,61 +1,62 @@
 @foreach ($nodes as $node)
-    @if ($this->isVisible($node->id))
-        @php
-            $nodeId = $node->id;
-            $isEditing = $this->editingNodeId === $nodeId;
-            $isDragging = $this->draggingNodeId === $nodeId;
-            $isDropTarget = $this->dropTargetId === $nodeId;
-            $dropPosition = $this->dropPosition;
-            $isRecentlyUpdated = $this->recentlyUpdated[$nodeId] ?? false;
-            $isSavingNode = $this->nodeSaving[$nodeId] ?? false;
-            $hasChildren = $node->has_children;
-            $isExpanded = $this->isExpanded($nodeId);
-        @endphp
+    @php
+        $nodeId = $node->id;
+        $isEditing = $this->editingNodeId === $nodeId;
+        $isDragging = $this->draggingNodeId === $nodeId;
+        $isDropTarget = $this->dropTargetId === $nodeId;
+        $dropPosition = $this->dropPosition;
+        $isRecentlyUpdated = $this->recentlyUpdated[$nodeId] ?? false;
+        $isSavingNode = $this->nodeSaving[$nodeId] ?? false;
+        $hasChildren = $node->has_children;
+    @endphp
 
-        {{-- Drop Zone Before --}}
-        @if (!$isDragging)
-            <div class="my-1"
-                @dragover="if ($wire.draggingNodeId && $wire.draggingNodeId !== {{ $nodeId }}) {
-                 $wire.setDropTarget({{ $nodeId }}, 'before');
-                 event.dataTransfer.dropEffect = 'move';
-             }"
-                @dragleave="if ($wire.dropTargetId === {{ $nodeId }} && $wire.dropPosition === 'before') {
-                 $wire.clearDropTarget();
-             }"
-                :class="{
-                    'border-t-2 border-blue-400': $wire.dropTargetId === {{ $nodeId }} &&
-                        $wire.dropPosition === 'before'
-                }">
-            </div>
-        @endif
-
-        {{-- Node Row --}}
-        <div class="{{ $isRecentlyUpdated ? 'border-green-300 bg-green-50' : 'border-gray-200' }} {{ $isDragging ? 'opacity-50' : '' }} {{ $isDropTarget && $dropPosition === 'inside' ? 'border-2 border-dashed border-blue-400 bg-blue-100' : '' }} group relative flex items-center rounded-lg border transition-all duration-200 hover:border-gray-300 hover:bg-gray-50"
-            draggable="true"
+    {{-- Drop Zone Before --}}
+    @if (!$isDragging)
+        <div x-show="isNodeVisible({{ $nodeId }})"
+            class="my-1"
             @dragover="if ($wire.draggingNodeId && $wire.draggingNodeId !== {{ $nodeId }}) {
-                 $wire.setDropTarget({{ $nodeId }}, 'inside');
-                 event.dataTransfer.dropEffect = 'move';
-                 event.preventDefault();
-             }"
-            @dragleave="if ($wire.dropTargetId === {{ $nodeId }} && $wire.dropPosition === 'inside') {
-                 $wire.clearDropTarget();
-             }"
-            @dragstart="$wire.startDrag({{ $nodeId }})" @dragend="$wire.clearDragState()"
-            style="padding-left: {{ $node->level * 24 }}px">
+             $wire.setDropTarget({{ $nodeId }}, 'before');
+             event.dataTransfer.dropEffect = 'move';
+         }"
+            @dragleave="if ($wire.dropTargetId === {{ $nodeId }} && $wire.dropPosition === 'before') {
+             $wire.clearDropTarget();
+         }"
+            :class="{
+                'border-t-2 border-blue-400': $wire.dropTargetId === {{ $nodeId }} &&
+                    $wire.dropPosition === 'before'
+            }">
+        </div>
+    @endif
 
-            {{-- Expand/Collapse --}}
-            @if ($hasChildren)
-                <button type="button"
-                    class="ml-2 flex h-6 w-6 items-center justify-center text-gray-500 hover:text-gray-700"
-                    wire:click="toggleNode({{ $nodeId }})">
-                    <svg class="{{ $isExpanded ? 'rotate-90' : '' }} h-4 w-4 transition-transform duration-200"
-                        fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-                    </svg>
-                </button>
-            @else
-                <div class="ml-8 w-2"></div>
-            @endif
+    {{-- Node Row --}}
+    <div x-show="isNodeVisible({{ $nodeId }})"
+        class="{{ $isRecentlyUpdated ? 'border-green-300 bg-green-50' : 'border-gray-200' }} {{ $isDragging ? 'opacity-50' : '' }} {{ $isDropTarget && $dropPosition === 'inside' ? 'border-2 border-dashed border-blue-400 bg-blue-100' : '' }} group relative flex items-center rounded-lg border transition-all duration-200 hover:border-gray-300 hover:bg-gray-50"
+        draggable="true"
+        @dragover="if ($wire.draggingNodeId && $wire.draggingNodeId !== {{ $nodeId }}) {
+             $wire.setDropTarget({{ $nodeId }}, 'inside');
+             event.dataTransfer.dropEffect = 'move';
+             event.preventDefault();
+         }"
+        @dragleave="if ($wire.dropTargetId === {{ $nodeId }} && $wire.dropPosition === 'inside') {
+             $wire.clearDropTarget();
+         }"
+        @dragstart="$wire.startDrag({{ $nodeId }})" @dragend="$wire.clearDragState()"
+        style="padding-left: {{ $node->level * 24 }}px">
+
+        {{-- Expand/Collapse — client-side only --}}
+        @if ($hasChildren)
+            <button type="button"
+                class="ml-2 flex h-6 w-6 items-center justify-center text-gray-500 hover:text-gray-700"
+                @click="toggleNode({{ $nodeId }})">
+                <svg class="h-4 w-4 transition-transform duration-200"
+                    :class="{ 'rotate-90': !isCollapsed({{ $nodeId }}) }"
+                    fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </button>
+        @else
+            <div class="ml-8 w-2"></div>
+        @endif
 
             {{-- Drag Handle --}}
             <div class="ml-1 cursor-move text-gray-400 hover:text-gray-600" title="Kéo để di chuyển">
@@ -225,7 +226,8 @@
 
         {{-- Drop Zone After --}}
         @if (!$isDragging)
-            <div class="my-1"
+            <div x-show="isNodeVisible({{ $nodeId }})"
+                class="my-1"
                 @dragover="if ($wire.draggingNodeId && $wire.draggingNodeId !== {{ $nodeId }}) {
                  $wire.setDropTarget({{ $nodeId }}, 'after');
                  event.dataTransfer.dropEffect = 'move';
@@ -241,8 +243,9 @@
         @endif
 
         {{-- Drop Zone Inside (children area) --}}
-        @if ($isExpanded && $this->draggingNodeId !== null)
-            <div class="ml-[{{ $node->level * 24 + 8 }}px] my-1 rounded-lg border-2 border-dashed border-blue-300 bg-blue-50 p-2 transition-all duration-200"
+        @if (!$isDragging)
+            <div x-show="isNodeVisible({{ $nodeId }}) && $wire.draggingNodeId !== null"
+                class="ml-[{{ $node->level * 24 + 8 }}px] my-1 rounded-lg border-2 border-dashed border-blue-300 bg-blue-50 p-2 transition-all duration-200"
                 @dragover="if ($wire.draggingNodeId && $wire.draggingNodeId !== {{ $nodeId }}) {
                  $wire.setDropTarget({{ $nodeId }}, 'inside');
                  event.dataTransfer.dropEffect = 'move';
@@ -258,5 +261,4 @@
                 </div>
             </div>
         @endif
-    @endif
 @endforeach

--- a/diepxuan/laravel-catalog/resources/views/system/menu-node.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/menu-node.blade.php
@@ -203,7 +203,7 @@
                         <button type="button"
                             class="rounded-md p-1 text-red-500 hover:bg-red-100 hover:text-red-700"
                             wire:click="deleteNode({{ $nodeId }})"
-                            wire:confirm="Bạn có chắc chắn muốn xóa menu này và tất cả menu con?"
+                            wire:confirm="{{ $this->hasChildren($nodeId) ? 'Bạn có chắc chắn muốn xóa menu này và tất cả menu con?' : 'Bạn có chắc chắn muốn xóa menu này?' }}"
                             title="Xóa"
                             wire:loading.attr="disabled">
                             @if ($isSavingNode)

--- a/diepxuan/laravel-catalog/resources/views/system/menu.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/menu.blade.php
@@ -131,13 +131,29 @@
             {{-- Tree Container --}}
             <div class="mt-4 rounded-lg border border-gray-200 bg-white shadow-sm">
                 <div class="border-b border-gray-200 bg-gray-50 py-3 ps-3">
-                    <div class="grid grid-cols-12 gap-4 text-sm font-medium text-gray-700">
-                        <div class="col-span-4">Tên menu</div>
-                        <div class="col-span-3">Route</div>
-                        <div class="col-span-2 text-center">SimbaID</div>
-                        <div class="col-span-1 text-center">ID</div>
-                        <div class="col-span-1 text-center">Thứ tự</div>
-                        <div></div>
+                    <div class="flex items-center justify-between">
+                        <div class="grid grid-cols-12 gap-4 text-sm font-medium text-gray-700">
+                            <div class="col-span-4">Tên menu</div>
+                            <div class="col-span-3">Route</div>
+                            <div class="col-span-2 text-center">SimbaID</div>
+                            <div class="col-span-1 text-center">ID</div>
+                            <div class="col-span-1 text-center">Thứ tự</div>
+                            <div></div>
+                        </div>
+                        <div class="flex items-center gap-1">
+                            <button type="button"
+                                    wire:click="expandAll()"
+                                    class="rounded border border-gray-200 bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 hover:bg-gray-50"
+                                    title="Mở rộng tất cả">
+                                Mở rộng
+                            </button>
+                            <button type="button"
+                                    wire:click="collapseAll()"
+                                    class="rounded border border-gray-200 bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 hover:bg-gray-50"
+                                    title="Thu gọn tất cả">
+                                Thu gọn
+                            </button>
+                        </div>
                     </div>
                 </div>
 
@@ -187,3 +203,27 @@
         ])
     </div>
 </div>
+
+@push('styles')
+<style>
+    @keyframes pulse-red-select {
+        0%, 100% { background-color: #fecaca !important; }
+        50% { background-color: #fca5a5 !important; }
+    }
+    @keyframes pulse-green-select {
+        0%, 100% { background-color: #bbf7d0 !important; }
+        50% { background-color: #86efac !important; }
+    }
+    .pulse-red-simba {
+        animation: pulse-red-select 1s ease-in-out infinite !important;
+        display: inline-block !important;
+        padding: 2px 6px !important;
+    }
+    .pulse-green-simba {
+        animation: pulse-green-select 1s ease-in-out infinite !important;
+        cursor: pointer !important;
+        display: inline-block !important;
+        padding: 2px 6px !important;
+    }
+</style>
+@endpush

--- a/diepxuan/laravel-catalog/resources/views/system/menu.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/menu.blade.php
@@ -16,7 +16,12 @@
          errorMessage: null,
          simbaSelectMode: false,
          simbaSelectNodeId: null,
+         /* Collapse state — client-side */
+         _ancestorMap: {{ Js::from($this->nodeAncestorMap) }},
+         _collapsedDefault: {{ Js::from($this->initiallyCollapsedIds) }},
+         collapsed: null,
          init() {
+             this.collapsed = new Set(this._collapsedDefault);
              /* Unified: listen for custom events dispatched from menu-node */
              window.addEventListener('simba-select-mode-enter', (e) => {
                  this.simbaSelectMode = true;
@@ -27,6 +32,20 @@
                  this.simbaSelectNodeId = null;
              });
              /* Livewire events */
+             /* Expose helpers for child partials */
+             this.isNodeVisible = function(id) {
+                 let a = this._ancestorMap[id];
+                 while (a) { if (this.collapsed.has(a)) return false; a = this._ancestorMap[a]; }
+                 return true;
+             };
+             this.isCollapsed = function(id) { return this.collapsed.has(id); };
+             this.toggleNode = function(id) {
+                 if (this.collapsed.has(id)) this.collapsed.delete(id);
+                 else this.collapsed.add(id);
+             };
+             this.expandAll = function() { this.collapsed.clear(); };
+             this.collapseAll = function() { {{ Js::from($this->initiallyCollapsedIds) }}.forEach(id => this.collapsed.add(id)); };
+
              Livewire.on('clear-highlight', (event) => {
                  setTimeout(() => { this.$wire.set('recentlyUpdated.' + event.nodeId, false); }, 2000);
              });
@@ -141,14 +160,12 @@
                             <div></div>
                         </div>
                         <div class="flex items-center gap-1">
-                            <button type="button"
-                                    wire:click="expandAll()"
+                            <button type="button" @click="expandAll()"
                                     class="rounded border border-gray-200 bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 hover:bg-gray-50"
                                     title="Mở rộng tất cả">
                                 Mở rộng
                             </button>
-                            <button type="button"
-                                    wire:click="collapseAll()"
+                            <button type="button" @click="collapseAll()"
                                     class="rounded border border-gray-200 bg-white px-2 py-0.5 text-[10px] font-medium text-gray-600 hover:bg-gray-50"
                                     title="Thu gọn tất cả">
                                 Thu gọn
@@ -173,13 +190,15 @@
                     @endif
 
                     {{-- Root drop zone --}}
-                    <div class="mt-2"
+                    <div class="mt-2 transition-all"
                         @dragover="if ($wire.draggingNodeId) { $wire.setDropTarget(null, 'after'); }"
                         @dragleave="if ($wire.dropTargetId === null) { $wire.clearDropTarget(); }"
-                        :class="{ 'border-2 border-dashed border-blue-400 bg-blue-50': $wire.dropTargetId === null && $wire.draggingNodeId }">
-                        @if ($this->dropTargetId === null && $this->draggingNodeId)
-                            <div class="p-4 text-center text-sm text-blue-600">Thả vào đây để chuyển thành menu gốc</div>
-                        @endif
+                        :class="{
+                            'opacity-0 pointer-events-none h-0': !$wire.draggingNodeId,
+                            'border-2 border-dashed border-blue-400 bg-blue-50': $wire.dropTargetId === null && $wire.draggingNodeId
+                        }">
+                        <div x-show="$wire.dropTargetId === null && $wire.draggingNodeId"
+                             class="p-4 text-center text-sm text-blue-600">Thả vào đây để chuyển thành menu gốc</div>
                     </div>
                 </div>
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/Menu.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/Menu.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-12 13:56:43
+ * @lastupdate 2026-05-12 19:26:40
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\System;
@@ -369,6 +369,38 @@ class Menu extends Component
         ];
 
         $this->refreshTree();
+    }
+
+    /**
+     * Check if a node has children.
+     */
+    public function hasChildren(int $nodeId): bool
+    {
+        $node = $this->nodes->firstWhere('id', $nodeId);
+
+        return (bool) $node?->has_children;
+    }
+
+    /**
+     * Expand all nodes in the Portal tree.
+     */
+    public function expandAll(): void
+    {
+        $this->expandedNodes = $this->nodes
+            ->filter(static fn ($node) => $node->has_children)
+            ->pluck('id')
+            ->toArray()
+        ;
+        $this->updateVisibleNodes();
+    }
+
+    /**
+     * Collapse all nodes in the Portal tree.
+     */
+    public function collapseAll(): void
+    {
+        $this->expandedNodes = [];
+        $this->updateVisibleNodes();
     }
 
     public function getParentOptionsProperty(): Collection

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/Menu.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/Menu.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-12 19:26:40
+ * @lastupdate 2026-05-12 19:54:54
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\System;
@@ -22,8 +22,6 @@ use Livewire\Component;
 class Menu extends Component
 {
     public Collection $nodes;
-    public array $expandedNodes   = [];
-    public array $visibleNodes    = [];
     public ?int $editingNodeId    = null;
     public string $editingName    = '';
     public string $editingRoute   = '';
@@ -58,34 +56,11 @@ class Menu extends Component
     public function mount(): void
     {
         $this->refreshTree();
-        $this->updateVisibleNodes();
     }
 
     public function refreshTree(): void
     {
         $this->nodes = $this->treeBuilder->buildFlattenedTree();
-        $this->updateVisibleNodes();
-    }
-
-    public function toggleNode(int $nodeId): void
-    {
-        if (\in_array($nodeId, $this->expandedNodes, true)) {
-            $this->expandedNodes = array_diff($this->expandedNodes, [$nodeId]);
-        } else {
-            $this->expandedNodes[] = $nodeId;
-        }
-
-        $this->updateVisibleNodes();
-    }
-
-    public function isExpanded(int $nodeId): bool
-    {
-        return \in_array($nodeId, $this->expandedNodes, true);
-    }
-
-    public function isVisible(int $nodeId): bool
-    {
-        return \in_array($nodeId, $this->visibleNodes, true);
     }
 
     // ─── CRUD ───────────────────────────────────────────────
@@ -267,13 +242,6 @@ class Menu extends Component
             );
 
             $this->refreshTree();
-
-            if ('inside' === $this->dropPosition && $newParentId) {
-                if (!\in_array($newParentId, $this->expandedNodes, true)) {
-                    $this->expandedNodes[] = $newParentId;
-                    $this->updateVisibleNodes();
-                }
-            }
         } finally {
             $this->isSaving = false;
             $this->clearDragState();
@@ -344,7 +312,6 @@ class Menu extends Component
         try {
             $this->treeBuilder->deleteMenu($nodeId);
             $this->nodes = $this->nodes->reject(static fn ($node) => $node->id === $nodeId);
-            $this->updateVisibleNodes();
         } finally {
             unset($this->nodeSaving[$nodeId]);
         }
@@ -382,25 +349,43 @@ class Menu extends Component
     }
 
     /**
-     * Expand all nodes in the Portal tree.
+     * Build ancestor map: each node ID → closest ancestor with children.
+     * Used for client-side visibility calculation.
+     *
+     * @return array<int, int>
      */
-    public function expandAll(): void
+    public function getNodeAncestorMapProperty(): array
     {
-        $this->expandedNodes = $this->nodes
-            ->filter(static fn ($node) => $node->has_children)
-            ->pluck('id')
-            ->toArray()
-        ;
-        $this->updateVisibleNodes();
+        $map   = [];
+        $stack = [];
+
+        foreach ($this->nodes as $node) {
+            while (\count($stack) && end($stack)[0] >= $node->level) {
+                array_pop($stack);
+            }
+            if (\count($stack) && null !== $node->parent_id) {
+                $map[$node->id] = end($stack)[1];
+            }
+            if ($node->has_children) {
+                $stack[] = [$node->level, $node->id];
+            }
+        }
+
+        return $map;
     }
 
     /**
-     * Collapse all nodes in the Portal tree.
+     * IDs of nodes collapsed by default (all nodes with children).
+     *
+     * @return list<int>
      */
-    public function collapseAll(): void
+    public function getInitiallyCollapsedIdsProperty(): array
     {
-        $this->expandedNodes = [];
-        $this->updateVisibleNodes();
+        return $this->nodes
+            ->filter(static fn ($n) => $n->has_children)
+            ->pluck('id')
+            ->toArray()
+        ;
     }
 
     public function getParentOptionsProperty(): Collection
@@ -411,25 +396,6 @@ class Menu extends Component
     public function render(): View
     {
         return view('catalog::system.menu')->layout('catalog::layouts.app');
-    }
-
-    private function updateVisibleNodes(): void
-    {
-        $visible          = [];
-        $parentVisibility = [null => true];
-
-        foreach ($this->nodes as $node) {
-            $isVisible = $parentVisibility[$node->parent_id] ?? false;
-
-            if ($isVisible) {
-                $visible[]                   = $node->id;
-                $parentVisibility[$node->id] = \in_array($node->id, $this->expandedNodes, true);
-            } else {
-                $parentVisibility[$node->id] = false;
-            }
-        }
-
-        $this->visibleNodes = $visible;
     }
 
     private function isDescendant(int $potentialParentId, int $nodeId): bool


### PR DESCRIPTION
## Tóm tắt

Hoàn thiện các chỉnh UI/UX cho trang Quản trị Menu sau review.

## Thay đổi

### Backend (PHP)
- **Menu.php**: Thêm `getNodeName()`, `hasChildren()`, `expandAll()`, `collapseAll()`, `exitSimbaSelectMode()`
- Dispatch `simba-select-mode-enter` event từ `enterSimbaSelectMode()`
- Exit selection mode khi `saveEdit()`

### Frontend (Blade)
- **menu.blade.php**:
  - Amber selection mode banner với tên menu + nút Bỏ chọn/Thoát
  - Expand All / Collapse All toolbar cho Portal tree
  - Floating error toast (fixed top-right) thay vì inline
  - Root drop zone ẩn khi không drag (`opacity-0 pointer-events-none h-0`)
  - CSS pulse animations dời vào `@push('catalog-styles')`
- **menu-node.blade.php**:
  - Grid alignment fix: `w-24` → `w-2/12` cho SimbaID column
  - Dynamic wire:confirm: check `hasChildren()` trước khi xác nhận xóa
- **layouts/app.blade.php**:
  - Bỏ inline CSS pulse, thêm `@stack('catalog-styles')`

## Files
`4 files changed, 81 insertions(+), 32 deletions(-)`