### PR TITLE
chore: add rules — không bịa tên bảng/SP/struct, không tạo/sửa SQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,8 @@ docs/add-laravel-rules
 | Có cần spawn đệ không? | Delegate nếu cần |
 | Có cần update documentation không? | Duy trì tài liệu |
 | File sẽ tạo ở vị trí nào? | Đảm bảo workspace scope |
+| Tên bảng/SP/struct có trong simba-docs không? | KHÔNG BỊA — verify từ source |
+| Có đang tạo/sửa SQL không? | CẤM — project chỉ port .NET → PHP |
 
 **Nếu chưa rõ → hỏi Sếp.**
 

--- a/IDENTITY.md
+++ b/IDENTITY.md
@@ -109,10 +109,36 @@
 
 ### Nguyên tắc
 
-1. simba-docs là **nguồn sự thật** về logic nghiệp vụ Simba ERP
+1. simba-docs là **nguồn sự thật duy nhất** về logic nghiệp vụ Simba ERP
 2. Khi implement task Portal → luôn đối chiếu với simba-docs trước
 3. Không sửa file trong simba-docs — đây là mount readonly
 4. Tài liệu tham chiếu thêm tại `docs/SIMBA-DOCS.md`
+
+### Quy tắc CỐT TỬ khi code (từ bài học PO3 - 2026-05-13)
+
+**CẤM TUYỆT ĐỐI:**
+
+| Hành vi | Lỗi | Đúng |
+|---------|-----|------|
+| Tự đặt tên bảng CSDL | `POHMN` (bịa) | `PO3` (từ simba-docs) |
+| Tự đặt tên SP | `AsPOInsOrder` (bịa) | `asPOGetPO3`, `asPOSavePO3` (từ simba-docs) |
+| Tự đặt tên struct/class field | Suy đoán từ ngữ cảnh | Copy từ DataBinding trong decompiled DLL |
+| Chạy `SHOW TABLES` để khám phá schema | Mất thời gian, không đáng tin | Đọc `simba-docs/asia/po/vouchers/POVchPO3.md` section Data Structure |
+| Tạo bảng mới trong DB | Không được phép | Chỉ code PHP ánh xạ bảng đã có |
+| ALTER/CREATE/INSERT SQL | Không được phép | simba-docs định nghĩa sẵn |
+
+**QUY TRÌNH BẮT BUỘC trước khi viết code:**
+
+1. Đọc `simba-docs/asia/{module}/vouchers/{Voucher}.md` → lấy đúng tên bảng, cột, kiểu dữ liệu
+2. Đọc `simba-docs/asia/SP_INDEX.md` hoặc `simba-docs/procedures/{MODULE}/` → lấy đúng tên SP, tham số
+3. Đọc `simba-docs/decompiled/asia/{DLL}.dll/` → lấy đúng field names từ DataBinding trong source code
+4. Code PHP **phải khớp 100%** với tên đã xác minh từ simba-docs
+
+**Mục tiêu dự án:** Chuyển đổi SimbaERP .NET → Portal PHP.
+- Không tạo bảng mới
+- Không sửa schema CSDL
+- Không bổ sung SQL
+- Code PHP chỉ ánh xạ logic và data đã tồn tại
 
 ---
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -33,6 +33,10 @@ Nếu có xung đột giữa các file → SOUL.md được ưu tiên.
 2. **Chủ động đọc context** trước khi hỏi
 3. **Nếu chưa đủ thông tin** → hỏi rõ ràng, đúng trọng tâm
 4. **Nếu có nghi ngờ** → hỏi trước khi làm
+5. **KHÔNG BAO GIỜ bịa** tên bảng, tên SP, tên struct, tên field
+   - Mọi tên phải có nguồn từ `simba-docs/` (vouchers, decompiled DLL, SP index)
+   - Nếu simba-docs không có → dừng lại, hỏi Sếp
+6. **KHÔNG tạo/sửa SQL** — Dự án là port .NET → PHP, không đổi CSDL
 
 ---
 


### PR DESCRIPTION
## Mục đích

Bổ sung quy tắc cốt tử vào identity files để ngăn lỗi **tự đặt tên bảng/SP/struct** (đã xảy ra với task PO3).

## Thay đổi

| File | Nội dung |
|------|----------|
| **SOUL.md** | Thêm nguyên tắc 5-6: không bịa tên, không tạo/sửa SQL |
| **IDENTITY.md** | Thêm section 'Quy tắc CỐT TỬ khi code' — bảng cấm/đúng, quy trình bắt buộc trước khi viết code |
| **AGENTS.md** | Thêm 2 câu hỏi vào Context Validation: verify simba-docs, cấm tạo/sửa SQL |

## Chi tiết rules mới

### CẤM TUYỆT ĐỐI
- Tự đặt tên bảng CSDL (vd: bịa  thay vì )
- Tự đặt tên SP (vd: bịa  thay vì )
- Tự đặt tên struct/field — phải copy từ DataBinding trong decompiled DLL
- Chạy  để khám phá schema — đọc simba-docs thay vì query DB
- Tạo bảng mới / ALTER / CREATE / INSERT SQL

### QUY TRÌNH BẮT BUỘC trước khi viết code
1. Đọc  → tên bảng, cột, kiểu dữ liệu
2. Đọc  hoặc  → tên SP, tham số
3. Đọc  → field names từ DataBinding
4. Code PHP phải khớp 100% với tên đã xác minh từ simba-docs

### Mục tiêu dự án
Chuyển đổi SimbaERP .NET → Portal PHP. Không tạo bảng mới, không sửa schema CSDL.