### PR TITLE
fix: add NCC autocomplete and standardize input-khachhang style for PO3

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php
@@ -10,32 +10,30 @@
             @focus="showDropdown = true"
             @blur="setTimeout(() => showDropdown = false, 200)"
             placeholder="{{ $placeholder }}"
-            class="w-full rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 shadow-sm transition-all placeholder:text-gray-400 hover:border-gray-300 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-xs text-gray-700 shadow-sm transition-all placeholder:text-gray-400 hover:border-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         />
 
-        {{-- Clear button --}}
-        @if($value)
-            <button
-                type="button"
-                @click="$wire.clear()"
-                class="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-            >
-                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                </svg>
-            </button>
-        @endif
-
-        {{-- Search icon --}}
-        <div class="absolute right-3 top-1/2 -translate-y-1/2" wire:loading.remove wire:target="updatedSearch">
-            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        {{-- Search & loading icons --}}
+        <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1" wire:loading.remove wire:target="updatedSearch">
+            @if($value)
+                <button
+                    type="button"
+                    @click="$wire.clear()"
+                    class="rounded-full p-0.5 text-gray-400 hover:text-gray-600"
+                >
+                    <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                    </svg>
+                </button>
+            @endif
+            <svg class="h-3.5 w-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
             </svg>
         </div>
 
         {{-- Loading spinner --}}
-        <div wire:loading wire:target="updatedSearch" class="absolute right-3 top-1/2 -translate-y-1/2">
-            <svg class="h-4 w-4 animate-spin text-indigo-500" fill="none" viewBox="0 0 24 24">
+        <div wire:loading wire:target="updatedSearch" class="absolute right-2 top-1/2 -translate-y-1/2">
+            <svg class="h-3.5 w-3.5 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
             </svg>
@@ -44,12 +42,12 @@
 
     {{-- Dropdown results --}}
     @if($showDropdown && count($results) > 0)
-        <div class="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+        <div class="absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-gray-300 bg-white shadow-lg">
             <ul class="max-h-64 overflow-y-auto">
                 @foreach($results as $kh)
                     <li
                         wire:click="selectCustomer('{{ $kh['ma_kh'] }}', '{{ addslashes($kh['ten_kh']) }}')"
-                        class="cursor-pointer border-b border-gray-100 px-4 py-2.5 transition-colors last:border-b-0 hover:bg-indigo-50"
+                        class="cursor-pointer border-b border-gray-100 px-3 py-2 transition-colors last:border-b-0 hover:bg-blue-50"
                     >
                         <div class="flex items-center justify-between">
                             <div class="flex-1">
@@ -68,8 +66,8 @@
 
     {{-- No results --}}
     @if($showDropdown && !$searching && count($results) === 0 && strlen(trim($search)) > 0)
-        <div class="absolute z-50 mt-1 w-full rounded-lg border border-gray-200 bg-white px-4 py-3 text-center text-sm text-gray-500 shadow-lg">
-            Không tìm thấy khách hàng
+        <div class="absolute z-50 mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-center text-xs text-gray-500 shadow-lg">
+            Không tìm thấy
         </div>
     @endif
 </div>

--- a/diepxuan/laravel-catalog/resources/views/muahang/hoadonmua-edit.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/muahang/hoadonmua-edit.blade.php
@@ -78,8 +78,8 @@
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div>
                     <label class="block text-xs font-medium text-gray-700 mb-1">Mã NCC <span class="text-red-500">*</span></label>
-                    <input type="text" wire:model.live="pMa_kh" required
-                        class="w-full border-gray-300 rounded-md shadow-sm text-xs focus:border-blue-500 focus:ring-blue-500" />
+                    <livewire:catalog::component.input-khachhang mode="nhacungcap" wire:model.live="pMa_kh"
+                        placeholder="Chọn nhà cung cấp..." />
                     @error('pMa_kh') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
                 </div>
                 <div>

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
@@ -105,6 +105,11 @@ class InputKhachhang extends Component
 
         $search = trim($this->search);
 
+        if ($this->value) {
+            $this->value = null;
+            $this->dispatch('value-updated', null);
+        }
+
         if ('' === $search) {
             $this->results   = [];
             $this->searching = false;
@@ -193,6 +198,7 @@ class InputKhachhang extends Component
         $this->search       = '';
         $this->results      = [];
         $this->showDropdown = false;
+        $this->dispatch('value-updated', null);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Thay input text `pMa_kh` bằng component `input-khachhang` với `mode="nhacungcap"` trên form PO3
- Chuẩn hóa style component `input-khachhang.blade.php` cho đồng nhất với các form input khác trong hệ thống
- Fix case người dùng sửa text autocomplete sau khi đã chọn NCC: component clear selected value để tránh submit/lưu mã NCC cũ

## Style changes (input-khachhang.blade.php)

| Thuộc tính | Trước | Sau (đồng nhất) |
|---|---|---|
| Border radius | `rounded-lg` | `rounded-md` |
| Border color | `border-gray-200` | `border-gray-300` |
| Padding | `px-4 py-2.5` | `px-3 py-2` |
| Font size | `text-sm` | `text-xs` |
| Focus ring | `indigo-500` | `blue-500` |
| Dropdown hover | `bg-indigo-50` | `bg-blue-50` |
| Icon color | `text-indigo-500` | `text-blue-500` |
| Icon size | `h-4 w-4` | `h-3.5 w-3.5` |
| Clear button | Nút riêng bên phải | Gọn trong icon container |

## Files changed

- `diepxuan/laravel-catalog/resources/views/muahang/hoadonmua-edit.blade.php`
- `diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php`
- `diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php`

## Notes

- Component `input-khachhang` dùng ở 3 trang: PO3, báo nợ, hóa đơn bán hàng — style mới áp dụng cho cả 3 trang
- Khi text autocomplete thay đổi sau selection, selected `value` được đưa về `null`; form bắt buộc user chọn lại item hợp lệ trước khi lưu