### PR TITLE
fix: return support collection for customer search

### DIFF
--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php
@@ -143,7 +143,7 @@ class Khachhang extends Component
     {
         $search = mb_strtolower($this->search);
 
-        return collect($results)->filter(static function ($item) use ($search): bool {
+        return new Collection(collect($results)->filter(static function ($item) use ($search): bool {
             $fields = [
                 $item->MA_KH ?? '',
                 $item->TEN_KH ?? '',
@@ -158,7 +158,7 @@ class Khachhang extends Component
             }
 
             return false;
-        })->values();
+        })->values());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Convert filtered customer search results to `Diepxuan\Support\Collection` before returning.
- Fix strict return type mismatch in `Banhang\Khachhang::filterSearchResults()`.

## Verification
- `php -l diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php`
- `git diff --check`
- `LOG_CHANNEL=stderr php artisan test tests/Unit/Packages/CatalogPackageTest.php`