### PR TITLE
feat(catalog): add ARDMKH trading object screens

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/cash/danhmuc/nhanvien-form.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/cash/danhmuc/nhanvien-form.blade.php
@@ -1,0 +1,29 @@
+<div class="mx-auto max-w-4xl">
+    <x-head-title>{{ 'Nhân viên' }}</x-head-title>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">{{ 'Nhân viên' }}</h2>
+        <p class="text-sm text-gray-500">Theo Simba menu 04.90.05 / ARDMKH / frmARDMKH</p>
+    </x-slot>
+
+    <form wire:submit="save" class="mt-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label class="block"><span class="text-sm font-medium text-gray-700">Mã NV</span><input wire:model="ma_kh" @if($mode === 'edit') readonly @endif class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Tên nhân viên</span><input wire:model="ten_kh" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block md:col-span-2"><span class="text-sm font-medium text-gray-700">Địa chỉ</span><input wire:model="dia_chi" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Mã số thuế</span><input wire:model="ma_so_thue" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Điện thoại</span><input wire:model="dien_thoai" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Fax</span><input wire:model="fax" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Email</span><input wire:model="email" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Người giao dịch</span><input wire:model="nguoi_gd" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">TK công nợ</span><input wire:model="tk_cn" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block md:col-span-2"><span class="text-sm font-medium text-gray-700">Ghi chú</span><textarea wire:model="ghi_chu" rows="3" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm"></textarea></label>
+        </div>
+        @if ($errors->any())
+            <div class="mt-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{{ $errors->first() }}</div>
+        @endif
+        <div class="mt-6 flex justify-end gap-2">
+            <a href="{{ route('ca.nhanvien') }}" class="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">Hủy</a>
+            <button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">Lưu</button>
+        </div>
+    </form>
+</div>

--- a/diepxuan/laravel-catalog/resources/views/cash/danhmuc/nhanvien.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/cash/danhmuc/nhanvien.blade.php
@@ -1,0 +1,39 @@
+<div class="phieuthu-container w-full">
+    <x-head-title>{{ 'Nhân viên - Tiền mặt' }}</x-head-title>
+    <x-slot name="header">
+        <div class="flex items-center justify-between">
+            <div>
+                <h2 class="text-xl font-semibold leading-tight text-gray-800">{{ 'Danh mục nhân viên' }}</h2>
+                <p class="text-sm text-gray-500">Theo Simba menu 04.90.05 / ARDMKH / frmARDMKH</p>
+            </div>
+            <a href="{{ route('ca.nhanvien.create') }}" class="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">+ Thêm nhân viên</a>
+        </div>
+    </x-slot>
+
+    <div class="mt-4 flex items-center gap-4">
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Tìm theo mã, tên, địa chỉ, điện thoại, mã số thuế..." class="w-full max-w-md rounded-md border-gray-300 py-2 pl-3 pr-10 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+        <span class="text-xs text-gray-500">{{ $arDmKhs->total() }} kết quả</span>
+    </div>
+
+    <div class="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        <table class="w-full text-sm">
+            <thead class="bg-gray-50"><tr><th class="border-b px-3 py-2 text-left font-medium text-gray-500">#</th><th class="border-b px-3 py-2 text-left font-medium text-gray-500">Mã NV</th><th class="border-b px-3 py-2 text-left font-medium text-gray-500">Tên nhân viên</th><th class="border-b px-3 py-2 text-left font-medium text-gray-500">Địa chỉ</th><th class="border-b px-3 py-2 text-left font-medium text-gray-500">Điện thoại</th><th class="border-b px-3 py-2 text-left font-medium text-gray-500">Người GD</th><th class="border-b px-3 py-2 text-right font-medium text-gray-500">Thao tác</th></tr></thead>
+            <tbody>
+                @forelse ($arDmKhs as $index => $arDmKh)
+                    <tr class="hover:bg-sky-50" wire:key="nv-{{ $arDmKh->ma_kh }}">
+                        <td class="border-b border-gray-100 px-3 py-2 text-gray-500">{{ $arDmKhs->firstItem() + $index }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 font-mono text-xs">{{ $arDmKh->ma_kh }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 font-medium text-gray-900">{{ $arDmKh->ten_kh }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 text-gray-600">{{ Str::limit($arDmKh->dia_chi, 40) }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 text-gray-600">{{ $arDmKh->tel }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 text-gray-600">{{ $arDmKh->nguoi_gd }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 text-right"><div class="flex justify-end gap-2"><a href="{{ route('ca.nhanvien.edit', $arDmKh->ma_kh) }}" class="rounded bg-yellow-100 px-2 py-1 text-xs text-yellow-700 hover:bg-yellow-200">Sửa</a><button wire:click="deleteDoiTuong('{{ $arDmKh->ma_kh }}')" wire:confirm="Bạn có chắc chắn muốn xóa nhân viên {{ $arDmKh->ma_kh }}?" class="rounded bg-red-100 px-2 py-1 text-xs text-red-700 hover:bg-red-200">Xóa</button></div></td>
+                    </tr>
+                @empty
+                    <tr><td colspan="7" class="px-3 py-8 text-center text-gray-500">Không tìm thấy nhân viên nào.</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4">{{ $arDmKhs->links() }}</div>
+</div>

--- a/diepxuan/laravel-catalog/resources/views/muahang/cungcap-form.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/muahang/cungcap-form.blade.php
@@ -1,0 +1,30 @@
+<div class="mx-auto max-w-4xl">
+    <x-head-title>{{ 'Nhà cung cấp' }}</x-head-title>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800">{{ 'Nhà cung cấp' }}</h2>
+        <p class="text-sm text-gray-500">Theo Simba menu 10.90.22 / ARDMKH / frmARDMKH</p>
+    </x-slot>
+
+    <form wire:submit="save" class="mt-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label class="block"><span class="text-sm font-medium text-gray-700">Mã NCC</span><input wire:model="ma_kh" @if($mode === 'edit') readonly @endif class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Tên nhà cung cấp</span><input wire:model="ten_kh" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block md:col-span-2"><span class="text-sm font-medium text-gray-700">Địa chỉ</span><input wire:model="dia_chi" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Mã số thuế</span><input wire:model="ma_so_thue" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Điện thoại</span><input wire:model="dien_thoai" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Fax</span><input wire:model="fax" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Email</span><input wire:model="email" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">Người giao dịch</span><input wire:model="nguoi_gd" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">TK công nợ</span><input wire:model="tk_cn" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block"><span class="text-sm font-medium text-gray-700">HTTT mua</span><input wire:model="ma_httt_po" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" /></label>
+            <label class="block md:col-span-2"><span class="text-sm font-medium text-gray-700">Ghi chú</span><textarea wire:model="ghi_chu" rows="3" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm"></textarea></label>
+        </div>
+        @if ($errors->any())
+            <div class="mt-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{{ $errors->first() }}</div>
+        @endif
+        <div class="mt-6 flex justify-end gap-2">
+            <a href="{{ route('po.cungcap') }}" class="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">Hủy</a>
+            <button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">Lưu</button>
+        </div>
+    </form>
+</div>

--- a/diepxuan/laravel-catalog/resources/views/muahang/cungcap.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/muahang/cungcap.blade.php
@@ -1,10 +1,20 @@
 <div class="phieuthu-container w-full">
     <x-head-title>{{ 'Nhà cung cấp - Mua hàng' }}</x-head-title>
     <x-slot name="header">
-        <h2 class="text-xl font-semibold leading-tight text-gray-800">
-            {{ 'Nhà cung cấp' }}
-        </h2>
-        <p>{{ 'Danh sách nhà cung cấp' }}</p>
+        <div class="flex items-center justify-between">
+            <div>
+                <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                    {{ 'Nhà cung cấp' }}
+                </h2>
+                <p>{{ 'Danh sách nhà cung cấp' }}</p>
+            </div>
+            <a
+                href="{{ route('po.cungcap.create') }}"
+                class="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+            >
+                + Thêm nhà cung cấp
+            </a>
+        </div>
     </x-slot>
 
     <div class="mt-4 flex items-center gap-4">
@@ -30,6 +40,7 @@
                     <th class="border-b border-gray-200 px-3 py-2 text-left font-medium text-gray-500">Điện thoại</th>
                     <th class="border-b border-gray-200 px-3 py-2 text-left font-medium text-gray-500">Người GD</th>
                     <th class="border-b border-gray-200 px-3 py-2 text-left font-medium text-gray-500">Hình thức TT</th>
+                    <th class="border-b border-gray-200 px-3 py-2 text-right font-medium text-gray-500">Thao tác</th>
                 </tr>
             </thead>
             <tbody>
@@ -44,10 +55,16 @@
                         <td class="border-b border-gray-100 px-3 py-2 text-gray-600">{{ $arDmKh->tel }}</td>
                         <td class="border-b border-gray-100 px-3 py-2 text-gray-600">{{ $arDmKh->nguoi_gd }}</td>
                         <td class="border-b border-gray-100 px-3 py-2 text-gray-600">{{ $arDmKh->ma_httt_po }}</td>
+                        <td class="border-b border-gray-100 px-3 py-2 text-right">
+                            <div class="flex justify-end gap-2">
+                                <a href="{{ route('po.cungcap.edit', $arDmKh->ma_kh) }}" class="rounded bg-yellow-100 px-2 py-1 text-xs text-yellow-700 hover:bg-yellow-200">Sửa</a>
+                                <button wire:click="deleteDoiTuong('{{ $arDmKh->ma_kh }}')" wire:confirm="Bạn có chắc chắn muốn xóa nhà cung cấp {{ $arDmKh->ma_kh }}?" class="rounded bg-red-100 px-2 py-1 text-xs text-red-700 hover:bg-red-200">Xóa</button>
+                            </div>
+                        </td>
                     </tr>
                 @empty
                     <tr>
-                        <td colspan="7" class="px-3 py-8 text-center text-gray-500">
+                        <td colspan="8" class="px-3 py-8 text-center text-gray-500">
                             Không tìm thấy nhà cung cấp nào.
                         </td>
                     </tr>

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -29,6 +29,8 @@ use Diepxuan\Catalog\Http\Livewire\Cash\Baocao\Chi;
 use Diepxuan\Catalog\Http\Livewire\Cash\Baocao\Nganhang;
 use Diepxuan\Catalog\Http\Livewire\Cash\Baocao\Thu;
 use Diepxuan\Catalog\Http\Livewire\Cash\Baocao\Tienmat;
+use Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc\Nhanvien;
+use Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc\NhanvienForm;
 use Diepxuan\Catalog\Http\Livewire\Cash\Nganhang\Baoco;
 use Diepxuan\Catalog\Http\Livewire\Cash\Nganhang\Baono;
 use Diepxuan\Catalog\Http\Livewire\Cash\Tienmat\Phieuchi;
@@ -51,6 +53,7 @@ use Diepxuan\Catalog\Http\Livewire\In\Dmvt;
 use Diepxuan\Catalog\Http\Livewire\In\InVoucherIndex;
 use Diepxuan\Catalog\Http\Livewire\Muahang\ApReportIndex;
 use Diepxuan\Catalog\Http\Livewire\Muahang\Cungcap;
+use Diepxuan\Catalog\Http\Livewire\Muahang\CungcapForm;
 use Diepxuan\Catalog\Http\Livewire\Muahang\Hoadonmua;
 use Diepxuan\Catalog\Http\Livewire\Muahang\HoadonmuaEdit;
 use Diepxuan\Catalog\Http\Livewire\Muahang\PoDmCpIndex;
@@ -136,6 +139,9 @@ Route::middleware(['auth'])->group(static function (): void {
     Route::get('/cash/thu', Thu::class)->name('ca.thu');
     Route::get('/cash/chi', Chi::class)->name('ca.chi');
     Route::get('/cash/quy', static fn () => view('catalog::dashboard'))->name('ca.quy');
+    Route::get('/cash/nhanvien', Nhanvien::class)->name('ca.nhanvien');
+    Route::get('/cash/nhanvien/create', NhanvienForm::class)->name('ca.nhanvien.create');
+    Route::get('/cash/nhanvien/edit/{id}', NhanvienForm::class)->name('ca.nhanvien.edit');
 
     Route::get('banhang/hoadonbanhang', Hoadonbanhang::class)->name('ar.ph.hdbh');
     Route::get('banhang/dondathang', SoVoucherIndex::class)->defaults('voucherCode', 'SO1')->name('banhang.so1');
@@ -367,6 +373,8 @@ Route::middleware(['auth'])->group(static function (): void {
 
     Route::get('/muahang/cungcap', Cungcap::class)->name('ar.cungcap');
     Route::get('/muahang/nhacungcap', Cungcap::class)->name('po.cungcap');
+    Route::get('/muahang/nhacungcap/create', CungcapForm::class)->name('po.cungcap.create');
+    Route::get('/muahang/nhacungcap/edit/{id}', CungcapForm::class)->name('po.cungcap.edit');
     Route::get('/muahang/chiphimuahang/danhmuc', PoDmCpIndex::class)->name('po.dmcp');
     Route::get('/po/danhmuc/dieu-khoan-thanh-toan', TaskShell::class)->defaults('title', 'Điều khoản thanh toán mua')->defaults('dll', 'PODMDKTT.dll')->defaults('task', 'Task 064')->name('po.dict.dktt');
     Route::get('/po/danhmuc/hinh-thuc-thanh-toan', TaskShell::class)->defaults('title', 'Hình thức thanh toán mua')->defaults('dll', 'PODMHTTT.dll')->defaults('task', 'Task 068')->name('po.dict.httt');

--- a/diepxuan/laravel-catalog/src/Config/SimbaDictionaryRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SimbaDictionaryRegistry.php
@@ -52,6 +52,13 @@ final class SimbaDictionaryRegistry
                 'pk'        => ['MA_CTY', 'MA_KH'],
                 'fields'    => ['ma_cty', 'ma_kh', 'loai', 'ten_kh', 'ma_so_thue', 'dia_chi', 'tel', 'fax', 'email', 'home_page', 'nguoi_gd', 'so_tk_nh', 'ten_nh', 'tinh_tp_nh', 'tk', 'ma_plkh1', 'ma_plkh2', 'ma_plkh3', 'ma_nhkh', 'ma_tt', 'ma_httt', 'ma_httt_po', 'gh_no', 'han_ck', 'tl_ck', 'han_tt', 'ls_qh', 'ghi_chu', 'tinh_dt_nb', 'iskh', 'isncc', 'isnv'],
             ],
+            'ca.nhanvien' => [
+                'code_name' => 'MA_NV',
+                'table'     => 'ARDMKH',
+                'menuid'    => '04.90.05',
+                'pk'        => ['MA_CTY', 'MA_KH'],
+                'fields'    => ['ma_cty', 'ma_kh', 'loai', 'ten_kh', 'ma_so_thue', 'dia_chi', 'tel', 'fax', 'email', 'home_page', 'nguoi_gd', 'so_tk_nh', 'ten_nh', 'tinh_tp_nh', 'tk', 'ma_plkh1', 'ma_plkh2', 'ma_plkh3', 'ma_nhkh', 'ma_tt', 'ma_httt', 'ma_httt_po', 'gh_no', 'han_ck', 'tl_ck', 'han_tt', 'ls_qh', 'ghi_chu', 'tinh_dt_nb', 'iskh', 'isncc', 'isnv'],
+            ],
             'po.dmcp' => [
                 'code_name' => 'MA_CP',
                 'table'     => 'PODMCP',

--- a/diepxuan/laravel-catalog/src/Config/SimbaDictionaryRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SimbaDictionaryRegistry.php
@@ -53,7 +53,7 @@ final class SimbaDictionaryRegistry
                 'fields'    => ['ma_cty', 'ma_kh', 'loai', 'ten_kh', 'ma_so_thue', 'dia_chi', 'tel', 'fax', 'email', 'home_page', 'nguoi_gd', 'so_tk_nh', 'ten_nh', 'tinh_tp_nh', 'tk', 'ma_plkh1', 'ma_plkh2', 'ma_plkh3', 'ma_nhkh', 'ma_tt', 'ma_httt', 'ma_httt_po', 'gh_no', 'han_ck', 'tl_ck', 'han_tt', 'ls_qh', 'ghi_chu', 'tinh_dt_nb', 'iskh', 'isncc', 'isnv'],
             ],
             'ca.nhanvien' => [
-                'code_name' => 'MA_NV',
+                'code_name' => 'MA_KH',
                 'table'     => 'ARDMKH',
                 'menuid'    => '04.90.05',
                 'pk'        => ['MA_CTY', 'MA_KH'],

--- a/diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
@@ -771,6 +771,13 @@ final class SimbaRouteRegistry
                 'dictionary_key'  => 'MA_NCC',
                 'simba_code_name' => 'ARDMKH',
             ],
+            'ca.nhanvien' => [
+                'module'          => 'CA',
+                'menuid'          => '04.90.05',
+                'source_type'     => self::TYPE_DICTIONARY,
+                'dictionary_key'  => 'MA_NV',
+                'simba_code_name' => 'ARDMKH',
+            ],
             'po.dmcp' => [
                 'module'          => 'PO',
                 'menuid'          => '10.90.14',

--- a/diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
@@ -775,7 +775,7 @@ final class SimbaRouteRegistry
                 'module'          => 'CA',
                 'menuid'          => '04.90.05',
                 'source_type'     => self::TYPE_DICTIONARY,
-                'dictionary_key'  => 'MA_NV',
+                'dictionary_key'  => 'MA_KH',
                 'simba_code_name' => 'ARDMKH',
             ],
             'po.dmcp' => [

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/Nhanvien.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/Nhanvien.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-05 00:00:00
+ */
+
+namespace Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc;
+
+use Diepxuan\Catalog\Http\Livewire\Muahang\Cungcap;
+use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
+use Illuminate\View\View;
+
+class Nhanvien extends Cungcap
+{
+    public function deleteDoiTuong(string $maKh): void
+    {
+        $nhanVien = \Diepxuan\Catalog\Models\ArDmKh::withoutGlobalScopes()
+            ->where('ma_kh', $maKh)
+            ->first()
+        ;
+
+        if (!$nhanVien) {
+            $this->dispatch('error', message: 'Không tìm thấy nhân viên.');
+
+            return;
+        }
+
+        if ($nhanVien->hasTransactions()) {
+            $this->dispatch('error', message: 'Không thể xóa nhân viên đã có giao dịch.');
+
+            return;
+        }
+
+        try {
+            \Diepxuan\Simba\StoredProcedures\AsARDelDMKH::call([
+                'pMa_cty' => SModel::CTY,
+                'pMa_kh'  => $maKh,
+            ]);
+            $this->dispatch('success', message: 'Đã xóa nhân viên ' . $maKh);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể xóa nhân viên: ' . $e->getMessage());
+        }
+    }
+
+    public function render(): View
+    {
+        return view('catalog::cash.danhmuc.nhanvien', [
+            'arDmKhs' => $this->getEmployeesPaginated(),
+        ])->layout('catalog::layouts.app');
+    }
+
+    protected function getEmployeesPaginated()
+    {
+        $results = AsARGetDMKH::call([
+            'pMa_cty' => SModel::CTY,
+            'pMa_kh' => '' !== $this->search ? $this->search : null,
+            'pStruct' => '0',
+            'pModuleId' => 'CA',
+        ]);
+
+        $results = $this->normalizeRows($results);
+
+        if ('' !== $this->search) {
+            $results = $this->filterSearchResults($results);
+        }
+
+        return $this->paginateCollection($results);
+    }
+}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/NhanvienForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/NhanvienForm.php
@@ -79,7 +79,7 @@ class NhanvienForm extends CungcapForm
                 'pIskh' => 0,
                 'pIsncc' => 0,
                 'pIsnv' => 1,
-                'pKsd' => 1,
+                'pKsd' => 0,
                 'pLUser' => $user,
             ]);
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/NhanvienForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/NhanvienForm.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-05 00:00:00
+ */
+
+namespace Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc;
+
+use Diepxuan\Catalog\Http\Livewire\Muahang\CungcapForm;
+use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
+use Diepxuan\Simba\StoredProcedures\AsARInsDMKH;
+use Diepxuan\Simba\StoredProcedures\AsARUpdDMKH;
+use Illuminate\View\View;
+
+class NhanvienForm extends CungcapForm
+{
+    public function loadDoiTuong(string $maKh): void
+    {
+        try {
+            $result = AsARGetDMKH::call([
+                'pMa_cty' => SModel::CTY,
+                'pMa_kh' => $maKh,
+                'pModuleId' => 'CA',
+            ]);
+
+            if ($result->isEmpty()) {
+                $this->dispatch('error', message: 'Không tìm thấy nhân viên.');
+                return;
+            }
+
+            $row = $result->first();
+            $this->ma_kh = $row['MA_KH'] ?? $maKh;
+            $this->ten_kh = $row['TEN_KH'] ?? '';
+            $this->dia_chi = $row['DIA_CHI'] ?? '';
+            $this->ma_so_thue = $row['MA_SO_THUE'] ?? '';
+            $this->dien_thoai = $row['TEL'] ?? '';
+            $this->fax = $row['FAX'] ?? '';
+            $this->email = $row['EMAIL'] ?? '';
+            $this->nguoi_gd = $row['NGUOI_GD'] ?? null;
+            $this->tk_cn = $row['TK'] ?? null;
+            $this->ghi_chu = $row['GHI_CHU'] ?? null;
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể tải nhân viên: ' . $e->getMessage());
+        }
+    }
+
+    public function render(): View
+    {
+        return view('catalog::cash.danhmuc.nhanvien-form')->layout('catalog::layouts.app');
+    }
+
+    protected function persist(string $procedureClass): void
+    {
+        $maKh = strtoupper(trim((string) $this->ma_kh));
+        $user = auth()->user()->name ?? 'system';
+
+        try {
+            $procedureClass::call([
+                'pMa_cty' => SModel::CTY,
+                'pMa_kh' => $maKh,
+                'pLoai' => 1,
+                'pTen_kh' => $this->ten_kh,
+                'pMa_so_thue' => $this->ma_so_thue,
+                'pDia_chi' => $this->dia_chi,
+                'pTel' => $this->dien_thoai,
+                'pFax' => $this->fax,
+                'pEmail' => $this->email,
+                'pNguoi_gd' => $this->nguoi_gd,
+                'pTk' => $this->tk_cn,
+                'pGhi_chu' => $this->ghi_chu,
+                'pIskh' => 0,
+                'pIsncc' => 0,
+                'pIsnv' => 1,
+                'pKsd' => 1,
+                'pLUser' => $user,
+            ]);
+
+            $this->dispatch('success', message: 'Đã lưu nhân viên ' . $maKh);
+            $this->redirect(route('ca.nhanvien'), navigate: true);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể lưu nhân viên: ' . $e->getMessage());
+        }
+    }
+}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php
@@ -95,7 +95,7 @@ class Cungcap extends Component
 
     protected function normalizeRows($results): Collection
     {
-        return collect($results)->map(static fn ($item) => (object) [
+        return new Collection(collect($results)->map(static fn ($item) => (object) [
             'ma_kh'      => $item->ma_kh ?? $item->MA_KH ?? '',
             'ten_kh'     => $item->ten_kh ?? $item->TEN_KH ?? '',
             'dia_chi'    => $item->dia_chi ?? $item->DIA_CHI ?? '',
@@ -104,14 +104,14 @@ class Cungcap extends Component
             'ma_httt_po' => $item->ma_httt_po ?? $item->MA_HTTT_PO ?? '',
             'ma_so_thue' => $item->ma_so_thue ?? $item->MA_SO_THUE ?? '',
             'ma_nhkh'    => $item->ma_nhkh ?? $item->MA_NHKH ?? '',
-        ]);
+        ]));
     }
 
     protected function filterSearchResults(Collection $results): Collection
     {
         $search = mb_strtolower($this->search);
 
-        return $results->filter(static function ($item) use ($search): bool {
+        return new Collection($results->filter(static function ($item) use ($search): bool {
             foreach ([$item->ma_kh, $item->ten_kh, $item->dia_chi, $item->tel, $item->ma_so_thue] as $field) {
                 if (str_contains(mb_strtolower((string) $field), $search)) {
                     return true;
@@ -119,7 +119,7 @@ class Cungcap extends Component
             }
 
             return false;
-        })->values();
+        })->values());
     }
 
     protected function paginateCollection($items): LengthAwarePaginatorContract

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php
@@ -42,18 +42,18 @@ class Cungcap extends Component
 
     public function deleteDoiTuong(string $maKh): void
     {
-        $khachHang = \Diepxuan\Catalog\Models\ArDmKh::withoutGlobalScopes()
+        $nhaCungCap = \Diepxuan\Catalog\Models\ArDmKh::withoutGlobalScopes()
             ->where('ma_kh', $maKh)
             ->first()
         ;
 
-        if (!$khachHang) {
+        if (!$nhaCungCap) {
             $this->dispatch('error', message: 'Không tìm thấy nhà cung cấp.');
 
             return;
         }
 
-        if ($khachHang->hasTransactions()) {
+        if ($nhaCungCap->hasTransactions()) {
             $this->dispatch('error', message: 'Không thể xóa nhà cung cấp đã có giao dịch.');
 
             return;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php
@@ -40,6 +40,36 @@ class Cungcap extends Component
         $this->resetPage();
     }
 
+    public function deleteDoiTuong(string $maKh): void
+    {
+        $khachHang = \Diepxuan\Catalog\Models\ArDmKh::withoutGlobalScopes()
+            ->where('ma_kh', $maKh)
+            ->first()
+        ;
+
+        if (!$khachHang) {
+            $this->dispatch('error', message: 'Không tìm thấy nhà cung cấp.');
+
+            return;
+        }
+
+        if ($khachHang->hasTransactions()) {
+            $this->dispatch('error', message: 'Không thể xóa nhà cung cấp đã có giao dịch.');
+
+            return;
+        }
+
+        try {
+            \Diepxuan\Simba\StoredProcedures\AsARDelDMKH::call([
+                'pMa_cty' => SModel::CTY,
+                'pMa_kh'  => $maKh,
+            ]);
+            $this->dispatch('success', message: 'Đã xóa nhà cung cấp ' . $maKh);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể xóa nhà cung cấp: ' . $e->getMessage());
+        }
+    }
+
     public function render(): View
     {
         return view('catalog::muahang.cungcap', [

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/CungcapForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/CungcapForm.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-05 00:00:00
+ */
+
+namespace Diepxuan\Catalog\Http\Livewire\Muahang;
+
+use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class CungcapForm extends Component
+{
+    public string $mode = 'create';
+    public ?string $ma_kh = null;
+    public string $ten_kh = '';
+    public string $dia_chi = '';
+    public string $ma_so_thue = '';
+    public string $dien_thoai = '';
+    public string $fax = '';
+    public string $email = '';
+    public ?string $nguoi_gd = null;
+    public ?string $tk_cn = null;
+    public ?string $ma_httt_po = null;
+    public ?string $ghi_chu = null;
+
+    protected $messages = [
+        'ma_kh.required' => 'Mã nhà cung cấp không được để trống.',
+        'ten_kh.required' => 'Tên nhà cung cấp không được để trống.',
+        'email.email' => 'Email không đúng định dạng.',
+    ];
+
+    public function mount(?string $id = null): void
+    {
+        if ($id) {
+            $this->mode = 'edit';
+            $this->loadDoiTuong($id);
+        }
+    }
+
+    public function loadDoiTuong(string $maKh): void
+    {
+        try {
+            $result = AsARGetDMKH::call([
+                'pMa_cty' => SModel::CTY,
+                'pMa_kh' => $maKh,
+                'pModuleId' => 'AP',
+            ]);
+
+            if ($result->isEmpty()) {
+                $this->dispatch('error', message: 'Không tìm thấy nhà cung cấp.');
+                return;
+            }
+
+            $row = $result->first();
+            $this->ma_kh = $row['MA_KH'] ?? $maKh;
+            $this->ten_kh = $row['TEN_KH'] ?? '';
+            $this->dia_chi = $row['DIA_CHI'] ?? '';
+            $this->ma_so_thue = $row['MA_SO_THUE'] ?? '';
+            $this->dien_thoai = $row['TEL'] ?? '';
+            $this->fax = $row['FAX'] ?? '';
+            $this->email = $row['EMAIL'] ?? '';
+            $this->nguoi_gd = $row['NGUOI_GD'] ?? null;
+            $this->tk_cn = $row['TK'] ?? null;
+            $this->ma_httt_po = $row['MA_HTTT_PO'] ?? null;
+            $this->ghi_chu = $row['GHI_CHU'] ?? null;
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể tải nhà cung cấp: ' . $e->getMessage());
+        }
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+        $procedureClass = 'create' === $this->mode
+            ? 'Diepxuan\\Simba\\StoredProcedures\\AsARInsDMKH'
+            : 'Diepxuan\\Simba\\StoredProcedures\\AsARUpdDMKH';
+
+        $this->persist($procedureClass);
+    }
+
+    public function render(): View
+    {
+        return view('catalog::muahang.cungcap-form')->layout('catalog::layouts.app');
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'ma_kh' => 'required|string|max:50',
+            'ten_kh' => 'required|string|max:200',
+            'dia_chi' => 'nullable|string|max:500',
+            'ma_so_thue' => 'nullable|string|max:50',
+            'dien_thoai' => 'nullable|string|max:50',
+            'fax' => 'nullable|string|max:50',
+            'email' => 'nullable|email|max:100',
+            'nguoi_gd' => 'nullable|string|max:100',
+            'tk_cn' => 'nullable|string|max:20',
+            'ma_httt_po' => 'nullable|string|max:20',
+            'ghi_chu' => 'nullable|string|max:500',
+        ];
+    }
+
+    protected function persist(string $procedureClass): void
+    {
+        $maKh = strtoupper(trim((string) $this->ma_kh));
+        $user = auth()->user()->name ?? 'system';
+
+        try {
+            $procedureClass::call([
+                'pMa_cty' => SModel::CTY,
+                'pMa_kh' => $maKh,
+                'pLoai' => 1,
+                'pTen_kh' => $this->ten_kh,
+                'pMa_so_thue' => $this->ma_so_thue,
+                'pDia_chi' => $this->dia_chi,
+                'pTel' => $this->dien_thoai,
+                'pFax' => $this->fax,
+                'pEmail' => $this->email,
+                'pNguoi_gd' => $this->nguoi_gd,
+                'pTk' => $this->tk_cn,
+                'pMa_httt_po' => $this->ma_httt_po,
+                'pGhi_chu' => $this->ghi_chu,
+                'pIskh' => 0,
+                'pIsncc' => 1,
+                'pIsnv' => 0,
+                'pKsd' => 1,
+                'pLUser' => $user,
+            ]);
+
+            $this->dispatch('success', message: 'Đã lưu nhà cung cấp ' . $maKh);
+            $this->redirect(route('po.cungcap'), navigate: true);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể lưu nhà cung cấp: ' . $e->getMessage());
+        }
+    }
+}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/CungcapForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Muahang/CungcapForm.php
@@ -133,7 +133,7 @@ class CungcapForm extends Component
                 'pIskh' => 0,
                 'pIsncc' => 1,
                 'pIsnv' => 0,
-                'pKsd' => 1,
+                'pKsd' => 0,
                 'pLUser' => $user,
             ]);
 

--- a/docs/tasks/356[done]-ardmkh-doi-tuong-giao-dich-khach-hang-ncc-nhan-vien.md
+++ b/docs/tasks/356[done]-ardmkh-doi-tuong-giao-dich-khach-hang-ncc-nhan-vien.md
@@ -12,7 +12,7 @@ Hoàn thiện nhóm menu/dictionary dùng chung bảng Simba `ARDMKH` / form `fr
 |------------|--------------|-----------|------------|---------|
 | `06.90.02` | `ar.khachhang` | Khách hàng / người mua | `MA_KH` | Đã có danh sách, thêm, sửa, xóa |
 | `10.90.22` | `po.cungcap` / `ar.cungcap` | Nhà cung cấp / người bán | `MA_NCC` | Bổ sung thêm, sửa, xóa |
-| `04.90.05` | `ca.nhanvien` | Nhân viên | `MA_NV` | Bổ sung danh sách, thêm, sửa, xóa |
+| `04.90.05` | `ca.nhanvien` | Nhân viên | `MA_KH` | Bổ sung danh sách, thêm, sửa, xóa; phân loại bằng `pModuleId=CA` và cờ `isnv` |
 
 ## Nguồn Simba đã dùng
 
@@ -21,10 +21,15 @@ Hoàn thiện nhóm menu/dictionary dùng chung bảng Simba `ARDMKH` / form `fr
   - `10.90.22` - Danh mục nhà cung cấp.
   - `04.90.05` - Danh mục nhân viên.
 - `simba-docs/data/sysDictionaryInfo.md`
-  - Các menu trên cùng trỏ nhóm ARDMKH / `frmARDMKH`.
+  - `MA_KH` trỏ ARDMKH / `frmARDMKH`.
+  - `MA_NCC` trỏ ARDMKH / `frmARDMKH`.
+  - Lưu ý: `MA_NV` trong sysDictionaryInfo là nguồn vốn `FADMNV` menu `20.90.02`, không dùng cho nhân viên ARDMKH menu `04.90.05`.
+- `simba-docs/data/sysMenu.md`
+  - Menu `04.90.05` dùng command/code `MA_KH` trên `ARDMKH`, phân biệt nhân viên qua module `CA` / cờ `isnv`.
 - Stored procedures có sẵn:
   - `asARGetDMKH`: tham số `pModuleId` phân loại `AR` khách hàng, `AP` nhà cung cấp, `CA` nhân viên.
   - `asARInsDMKH`, `asARUpdDMKH`, `asARDelDMKH`: lưu/xóa mềm theo field cờ `pIskh`, `pIsncc`, `pIsnv`.
+  - `pKsd=0` là đang sử dụng; lookup chứng từ validate ARDMKH với điều kiện `KSd=0`.
 
 ## Thay đổi chính
 
@@ -39,7 +44,7 @@ Hoàn thiện nhóm menu/dictionary dùng chung bảng Simba `ARDMKH` / form `fr
   - `/muahang/nhacungcap/edit/{id}` -> `po.cungcap.edit`.
 - Bổ sung mapping vào registry:
   - `SimbaRouteRegistry`: `ca.nhanvien` -> menu `04.90.05`.
-  - `SimbaDictionaryRegistry`: `ca.nhanvien` -> `MA_NV` / `ARDMKH`.
+  - `SimbaDictionaryRegistry`: `ca.nhanvien` -> `MA_KH` / `ARDMKH` theo command/code của menu `04.90.05`.
 
 ### Component/view
 

--- a/docs/tasks/356[done]-ardmkh-doi-tuong-giao-dich-khach-hang-ncc-nhan-vien.md
+++ b/docs/tasks/356[done]-ardmkh-doi-tuong-giao-dich-khach-hang-ncc-nhan-vien.md
@@ -1,0 +1,61 @@
+# Task 356: Hoàn thiện nhóm ARDMKH đối tượng giao dịch
+
+## Trạng thái
+
+Done - 2026-06-05.
+
+## Phạm vi
+
+Hoàn thiện nhóm menu/dictionary dùng chung bảng Simba `ARDMKH` / form `frmARDMKH`:
+
+| Simba menu | Portal route | Đối tượng | Dictionary | Ghi chú |
+|------------|--------------|-----------|------------|---------|
+| `06.90.02` | `ar.khachhang` | Khách hàng / người mua | `MA_KH` | Đã có danh sách, thêm, sửa, xóa |
+| `10.90.22` | `po.cungcap` / `ar.cungcap` | Nhà cung cấp / người bán | `MA_NCC` | Bổ sung thêm, sửa, xóa |
+| `04.90.05` | `ca.nhanvien` | Nhân viên | `MA_NV` | Bổ sung danh sách, thêm, sửa, xóa |
+
+## Nguồn Simba đã dùng
+
+- `simba-docs/data/sysMenu.md`
+  - `06.90.02` - Danh mục khách hàng.
+  - `10.90.22` - Danh mục nhà cung cấp.
+  - `04.90.05` - Danh mục nhân viên.
+- `simba-docs/data/sysDictionaryInfo.md`
+  - Các menu trên cùng trỏ nhóm ARDMKH / `frmARDMKH`.
+- Stored procedures có sẵn:
+  - `asARGetDMKH`: tham số `pModuleId` phân loại `AR` khách hàng, `AP` nhà cung cấp, `CA` nhân viên.
+  - `asARInsDMKH`, `asARUpdDMKH`, `asARDelDMKH`: lưu/xóa mềm theo field cờ `pIskh`, `pIsncc`, `pIsnv`.
+
+## Thay đổi chính
+
+### Route/menu
+
+- Bổ sung route nhân viên:
+  - `/cash/nhanvien` -> `ca.nhanvien`.
+  - `/cash/nhanvien/create` -> `ca.nhanvien.create`.
+  - `/cash/nhanvien/edit/{id}` -> `ca.nhanvien.edit`.
+- Bổ sung route CRUD nhà cung cấp:
+  - `/muahang/nhacungcap/create` -> `po.cungcap.create`.
+  - `/muahang/nhacungcap/edit/{id}` -> `po.cungcap.edit`.
+- Bổ sung mapping vào registry:
+  - `SimbaRouteRegistry`: `ca.nhanvien` -> menu `04.90.05`.
+  - `SimbaDictionaryRegistry`: `ca.nhanvien` -> `MA_NV` / `ARDMKH`.
+
+### Component/view
+
+- `Muahang\Cungcap`: bổ sung delete action và action buttons trên view.
+- `Muahang\CungcapForm`: form thêm/sửa nhà cung cấp dùng `pModuleId=AP`, set `pIsncc=1`.
+- `Cash\Danhmuc\Nhanvien`: danh sách nhân viên dùng `pModuleId=CA`.
+- `Cash\Danhmuc\NhanvienForm`: form thêm/sửa nhân viên, set `pIsnv=1`.
+
+## Liên quan task cũ
+
+- Task 001: danh mục khách hàng.
+- Task 038: khách hàng thêm/sửa/xóa.
+- Task 034: khách hàng liên kết ngân hàng, hiện vẫn là shell/task docs; chưa mở rộng thành CRUD ngân hàng khách hàng vì cần xác nhận metadata chi tiết `ARDMKHNGH`/`ARDMKH_NH` trước khi ghi dữ liệu.
+- Task 210: danh mục nhân viên kinh doanh; task này bổ sung lớp danh mục nhân viên ARDMKH theo Simba menu `04.90.05`.
+
+## Kiểm chứng
+
+- `php -l` pass cho các file PHP được sửa/thêm.
+- Không tạo bảng mới, không ALTER/INSERT SQL, không tự đặt tên SP/table/field ngoài metadata đã có.

--- a/docs/tasks/README[done].md
+++ b/docs/tasks/README[done].md
@@ -10,12 +10,19 @@ Toàn bộ 325 task files đã được audit (xem `AUDIT-2026-05-10.md`).
 
 > Cập nhật triển khai 2026-05-15: xem `../project/task-execution-coverage.md`, `../project/remaining-process-shells.md` và `../project/simba-router-menu-matrix.md` để đối chiếu route anchors theo `simba-docs`. Coverage mới tách rõ static screen, generic report/dictionary shell, read-only process shell và blocker chưa được phép execute. Các số PENDING/TODO bên dưới là snapshot audit cũ, không còn là trạng thái route/menu hiện tại.
 
+**Cập nhật nhóm ARDMKH đối tượng giao dịch (2026-06-05):**
+- Bổ sung Task 356: hoàn thiện nhóm `ARDMKH` / `frmARDMKH` cho khách hàng, nhà cung cấp, nhân viên.
+- `06.90.02` / `MA_KH` / `ar.khachhang`: đã có danh sách, thêm, sửa, xóa khách hàng.
+- `10.90.22` / `MA_NCC` / `po.cungcap`: bổ sung route form thêm/sửa và action xóa nhà cung cấp.
+- `04.90.05` / `MA_NV` / `ca.nhanvien`: bổ sung route danh sách, form thêm/sửa và action xóa nhân viên.
+- Ngân hàng khách hàng Task 034 vẫn giữ shell/task docs; chưa mở CRUD ghi dữ liệu khi chưa xác nhận đầy đủ metadata `ARDMKHNGH`/`ARDMKH_NH`.
+
 **Kết quả route/menu hiện tại (2026-05-15):**
-- `SimbaRouteRegistry::routes()` có 302 route anchors.
+- `SimbaRouteRegistry::routes()` có 302 route anchors trước cập nhật Task 356; sau Task 356 bổ sung thêm route anchor `ca.nhanvien`.
 - Active menu có metadata report/dictionary/voucher hoặc DLL/command/code_name đều có route anchor.
 - Còn 57 active menu không route; toàn bộ là root/group/section/dòng trống không có DLL/command/code_name.
 - Còn 48 generic `simba.process` read-only shell; không execute SQL/SP/function vì còn thiếu metadata hoặc có side effect.
-- Full registry/menu/voucher batch pass: `29 tests, 2805 assertions`.
+- Full registry/menu/voucher batch pass: `29 tests, 2805 assertions` là snapshot cũ, không phải test của Task 356.
 
 **Kết quả nhanh:**
 - **298/318 files PENDING** (chưa implement)

--- a/docs/tasks/README[done].md
+++ b/docs/tasks/README[done].md
@@ -14,7 +14,7 @@ Toàn bộ 325 task files đã được audit (xem `AUDIT-2026-05-10.md`).
 - Bổ sung Task 356: hoàn thiện nhóm `ARDMKH` / `frmARDMKH` cho khách hàng, nhà cung cấp, nhân viên.
 - `06.90.02` / `MA_KH` / `ar.khachhang`: đã có danh sách, thêm, sửa, xóa khách hàng.
 - `10.90.22` / `MA_NCC` / `po.cungcap`: bổ sung route form thêm/sửa và action xóa nhà cung cấp.
-- `04.90.05` / `MA_NV` / `ca.nhanvien`: bổ sung route danh sách, form thêm/sửa và action xóa nhân viên.
+- `04.90.05` / `MA_KH` / `ca.nhanvien`: bổ sung route danh sách, form thêm/sửa và action xóa nhân viên; `MA_NV` trong sysDictionaryInfo là nguồn vốn `FADMNV`, không phải nhân viên ARDMKH.
 - Ngân hàng khách hàng Task 034 vẫn giữ shell/task docs; chưa mở CRUD ghi dữ liệu khi chưa xác nhận đầy đủ metadata `ARDMKHNGH`/`ARDMKH_NH`.
 
 **Kết quả route/menu hiện tại (2026-05-15):**


### PR DESCRIPTION
## Tổng quan
- Hoàn thiện màn hình danh mục đối tượng giao dịch theo ARDMKH cho khách hàng, nhà cung cấp, nhân viên.
- Bổ sung route, registry dictionary/route và Livewire form/list cho NCC + nhân viên.
- Cập nhật tài liệu task hoàn thành và index task done.

## Phạm vi thay đổi
- Khách hàng: dùng lại màn hình `cash.danhmuc.khachhang`, đăng ký ARDMKH theo schema `dmkh`.
- Nhà cung cấp: bổ sung list/form `Muahang\\Cungcap` và `Muahang\\CungcapForm`, action thêm/sửa/xóa/lưu.
- Nhân viên: bổ sung list/form `Cash\\Danhmuc\\Nhanvien` và `Cash\\Danhmuc\\NhanvienForm`.

## Kiểm chứng
- `git diff --check`
- `php -l diepxuan/laravel-catalog/src/Http/Livewire/Muahang/Cungcap.php`
- `php -l diepxuan/laravel-catalog/src/Http/Livewire/Muahang/CungcapForm.php`
- `php -l diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/Nhanvien.php`
- `php -l diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/NhanvienForm.php`
- `php -l diepxuan/laravel-catalog/src/Config/SimbaDictionaryRegistry.php`
- `php -l diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php`
- `php -l diepxuan/laravel-catalog/routes/web.php`

## Ghi chú
- Dữ liệu ARDMKH lấy theo Simba docs/SP hiện có; không tạo bảng/SP/field mới.
- Chưa chạy full test suite do task tập trung vào Livewire/package catalog và đã chạy syntax check cho file PHP liên quan.
