### PR TITLE
feat(simba): add metadata models

### DIFF
--- a/diepxuan/laravel-simba/src/Models/SiDmCt.php
+++ b/diepxuan/laravel-simba/src/Models/SiDmCt.php
@@ -62,6 +62,7 @@ class SiDmCt extends SModel
         'PhFieldlist2IN',
         'CtFieldlist2IN',
         'kieu_trung_so_ct',
+        'VoucherGetWhenOpenForm',
     ];
 
     protected $casts = [
@@ -76,9 +77,10 @@ class SiDmCt extends SModel
         'bp'              => 'boolean',
         'lo'              => 'boolean',
         'sd'              => 'boolean',
-        'vn_sequence'     => 'integer',
-        'vn_width'        => 'integer',
-        'kieu_trung_so_ct' => 'integer',
+        'vn_sequence'            => 'integer',
+        'vn_width'               => 'integer',
+        'kieu_trung_so_ct'       => 'integer',
+        'VoucherGetWhenOpenForm' => 'boolean',
     ];
 
     /**

--- a/diepxuan/laravel-simba/src/Models/SiDmCt.php
+++ b/diepxuan/laravel-simba/src/Models/SiDmCt.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-05 20:58:00
+ */
+
+namespace Diepxuan\Simba\Models;
+
+use Diepxuan\Simba\SModel\SModel;
+
+/**
+ * Model SiDmCt - Khai báo màn hình nhập chứng từ.
+ *
+ * Source: simba-docs/tables/SiDmCt.md.
+ */
+class SiDmCt extends SModel
+{
+    public $incrementing  = false;
+    public $timestamps    = false;
+    protected $table      = 'SiDmCt';
+    protected $primaryKey = 'ma_ct';
+    protected $keyType    = 'string';
+
+    protected $fillable = [
+        'ma_cty',
+        'ma_ct',
+        'phan_he',
+        'ma_ct_me',
+        'ten_ct',
+        'tk_no',
+        'tk_co',
+        'ma_nt',
+        'so_lien',
+        'stt_nkc',
+        'stt_ntxt',
+        'ct_dc',
+        'loc_nsd',
+        'vv',
+        'spct',
+        'phi',
+        'bp',
+        'lo',
+        'sp_post',
+        'sp_process',
+        'ph',
+        'ct',
+        'sd',
+        'nxt',
+        'menuid',
+        'vn_prefix',
+        'vn_postfix',
+        'vn_sequence',
+        'vn_pattern',
+        'vn_width',
+        'PhFieldlist2IN',
+        'CtFieldlist2IN',
+        'kieu_trung_so_ct',
+    ];
+
+    protected $casts = [
+        'so_lien'         => 'integer',
+        'stt_nkc'         => 'integer',
+        'stt_ntxt'        => 'integer',
+        'ct_dc'           => 'boolean',
+        'loc_nsd'         => 'boolean',
+        'vv'              => 'boolean',
+        'spct'            => 'boolean',
+        'phi'             => 'boolean',
+        'bp'              => 'boolean',
+        'lo'              => 'boolean',
+        'sd'              => 'boolean',
+        'vn_sequence'     => 'integer',
+        'vn_width'        => 'integer',
+        'kieu_trung_so_ct' => 'integer',
+    ];
+
+    /**
+     * Scope: find voucher metadata by company and voucher code.
+     *
+     * @param mixed $query
+     */
+    public function scopeVoucher($query, string $maCt, string $maCty = SModel::CTY)
+    {
+        return $query->where('ma_cty', $maCty)->where('ma_ct', $maCt);
+    }
+
+    /**
+     * Scope: find voucher metadata by Simba menuid.
+     *
+     * @param mixed $query
+     */
+    public function scopeMenuId($query, string $menuId)
+    {
+        return $query->where('menuid', $menuId);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function headerFieldsForInventory(): array
+    {
+        return array_values(array_filter(array_map('trim', explode(',', (string) $this->PhFieldlist2IN))));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function detailFieldsForInventory(): array
+    {
+        return array_values(array_filter(array_map('trim', explode(',', (string) $this->CtFieldlist2IN))));
+    }
+}

--- a/diepxuan/laravel-simba/src/Models/SysDictionaryInfo.php
+++ b/diepxuan/laravel-simba/src/Models/SysDictionaryInfo.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-05 20:58:00
+ */
+
+namespace Diepxuan\Simba\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * SimbaERP sysDictionaryInfo table model.
+ *
+ * Source: simba-docs/tables/sysDictionaryInfo.md.
+ */
+class SysDictionaryInfo extends Model
+{
+    public $incrementing  = false;
+    public $timestamps    = false;
+    protected $connection = 'sqlsrv';
+    protected $table      = 'sysDictionaryInfo';
+    protected $primaryKey = 'code_name';
+    protected $keyType    = 'string';
+
+    protected $fillable = [
+        'code_name',
+        'PK',
+        'code_fname',
+        'code_length',
+        'name_fname',
+        'table_name',
+        'menuid',
+        'lookup_when_invalid',
+        'allow_merge_code',
+        'dllname',
+        'view_class_name',
+        'edit_class_name',
+        'carry_field_list',
+        'default_sort',
+        'copy_vaora',
+        'par0',
+        'par1',
+        'par2',
+        'par3',
+        'par4',
+        'par5',
+        'par6',
+        'par7',
+        'par8',
+        'par9',
+        'description',
+    ];
+
+    protected $casts = [
+        'code_length'         => 'integer',
+        'lookup_when_invalid' => 'boolean',
+        'allow_merge_code'    => 'boolean',
+        'copy_vaora'          => 'boolean',
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public function primaryKeyFields(): array
+    {
+        return array_values(array_filter(array_map('trim', explode(',', (string) $this->PK))));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function carryFields(): array
+    {
+        return array_values(array_filter(array_map('trim', explode(',', (string) $this->carry_field_list))));
+    }
+
+    /**
+     * Scope: find dictionary metadata by Simba code_name.
+     *
+     * @param mixed $query
+     */
+    public function scopeCodeName($query, string $codeName)
+    {
+        return $query->where('code_name', $codeName);
+    }
+
+    /**
+     * Scope: find dictionary metadata by Simba menuid.
+     *
+     * @param mixed $query
+     */
+    public function scopeMenuId($query, string $menuId)
+    {
+        return $query->where('menuid', $menuId);
+    }
+}


### PR DESCRIPTION
## Mục tiêu

Bổ sung model đọc metadata thực tế từ SimbaERP SQL Server để phục vụ hướng giảm hard-code registry:

- `SysDictionaryInfo` map bảng `sysDictionaryInfo`
- `SiDmCt` map bảng `SiDmCt`

## Source đối chiếu

- `simba-docs/tables/sysDictionaryInfo.md`
- `simba-docs/tables/SiDmCt.md`

## Kiểm chứng

```bash
php -l diepxuan/laravel-simba/src/Models/SysMenu.php
php -l diepxuan/laravel-simba/src/Models/SysDictionaryInfo.php
php -l diepxuan/laravel-simba/src/Models/SiDmCt.php
php -r 'require "vendor/autoload.php"; echo class_exists("Diepxuan\\Simba\\Models\\SysMenu") ? "SysMenu ok\n" : "SysMenu missing\n"; echo class_exists("Diepxuan\\Simba\\Models\\SysDictionaryInfo") ? "SysDictionaryInfo ok\n" : "SysDictionaryInfo missing\n"; echo class_exists("Diepxuan\\Simba\\Models\\SiDmCt") ? "SiDmCt ok\n" : "SiDmCt missing\n";'
```

Kết quả: syntax pass, autoload class ok.

## Lưu ý

PR này chỉ commit 2 file model mới, không bao gồm các thay đổi local khác đang có trong workspace.
