### PR TITLE
feat(simba): load voucher registries from SQL

### DIFF
--- a/diepxuan/laravel-catalog/src/Config/FinanceVoucherRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/FinanceVoucherRegistry.php
@@ -8,26 +8,26 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-16 00:27:45
+ * @lastupdate 2026-06-06 23:34:00
  */
 
 namespace Diepxuan\Catalog\Config;
 
+use Diepxuan\Catalog\Services\SimbaVoucherMetadata;
+
 final class FinanceVoucherRegistry
 {
     /**
-     * Voucher metadata verified from simba-docs/data/SiDmCt.md and sysVoucherInfo.md.
-     *
      * @return array<string, array<string, string>>
      */
     public static function vouchers(): array
     {
-        return [
-            'GL1' => ['title' => 'Phiếu kế toán', 'route' => 'gl.vch.gl1', 'menuid' => '02.10.02', 'ph' => 'glPh1', 'ct' => 'glCt1', 'table_ph' => 'GLPH1', 'table_ct' => 'GLCT1'],
-            'NB1' => ['title' => 'Chứng từ ngoại bảng', 'route' => 'gl.vch.nb1', 'menuid' => '02.10.17', 'ph' => '', 'ct' => '', 'table_ph' => 'GLNB', 'table_ct' => 'GLNB'],
-            'AR4' => ['title' => 'Phiếu bù trừ công nợ phải thu', 'route' => 'ar.vch.ar4', 'menuid' => '06.10.29', 'sidmct_menuid' => '08.10.11', 'ph' => 'arPh4', 'ct' => 'arCt4', 'table_ph' => 'ARPH4', 'table_ct' => 'ARCT4'],
-            'AP4' => ['title' => 'Phiếu bù trừ công nợ phải trả', 'route' => 'ap.vch.ap4', 'menuid' => '10.10.38', 'sidmct_menuid' => '10.10.38', 'sys_menuid' => '12.10.11', 'ph' => 'apPh4', 'ct' => 'apCt4', 'table_ph' => 'APPH4', 'table_ct' => 'APCT4'],
-        ];
+        return SimbaVoucherMetadata::forCodes(['GL1', 'NB1', 'AR4', 'AP4'], [
+            'GL1' => ['route' => 'gl.vch.gl1'],
+            'NB1' => ['route' => 'gl.vch.nb1', 'table_ph' => 'GLNB', 'table_ct' => 'GLNB'],
+            'AR4' => ['route' => 'ar.vch.ar4', 'menuid' => '06.10.29', 'sys_menuid' => '08.10.11'],
+            'AP4' => ['route' => 'ap.vch.ap4', 'sys_menuid' => '12.10.11'],
+        ]);
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Config/InVoucherRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/InVoucherRegistry.php
@@ -8,28 +8,28 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-16 00:27:45
+ * @lastupdate 2026-06-06 23:34:00
  */
 
 namespace Diepxuan\Catalog\Config;
 
+use Diepxuan\Catalog\Services\SimbaVoucherMetadata;
+
 final class InVoucherRegistry
 {
     /**
-     * IN voucher metadata verified from simba-docs/data/SiDmCt.md and sysVoucherInfo.md.
-     *
      * @return array<string, array<string, string>>
      */
     public static function vouchers(): array
     {
-        return [
-            'IN1' => ['title' => 'Phiếu nhập kho', 'route' => 'in.vch.in1', 'menuid' => '14.10.02', 'ph' => 'inPh1', 'ct' => 'inCt1', 'table_ph' => 'INPH1', 'table_ct' => 'INCT1'],
-            'IN2' => ['title' => 'Phiếu xuất kho', 'route' => 'in.vch.in2', 'menuid' => '14.10.05', 'ph' => 'inPh2', 'ct' => 'inCt2', 'table_ph' => 'INPH2', 'table_ct' => 'INCT2'],
-            'IN3' => ['title' => 'Phiếu xuất chuyển kho', 'route' => 'in.vch.in3', 'menuid' => '14.10.08', 'ph' => 'inPh3', 'ct' => 'inCt3', 'table_ph' => 'INPH3', 'table_ct' => 'INCT3'],
-            'IN4' => ['title' => 'Phiếu nhập điều chuyển', 'route' => 'in.vch.in4', 'menuid' => '14.10.08', 'ph' => 'inPh3', 'ct' => 'inCt3', 'table_ph' => 'INPH3', 'table_ct' => 'INCT3'],
-            'IN5' => ['title' => 'Phiếu xuất công cụ dụng cụ', 'route' => 'in.vch.in5', 'menuid' => '14.10.11', 'ph' => 'inPh5', 'ct' => 'inCt5', 'table_ph' => 'INPH5', 'table_ct' => 'INCT5'],
-            'IN6' => ['title' => 'Phiếu tháo dỡ lắp ráp', 'route' => 'in.vch.in6', 'menuid' => '', 'sys_menuid' => '14.10.14', 'ph' => 'inPh6', 'ct' => 'inCt6', 'table_ph' => 'INPH6', 'table_ct' => 'INCT6M'],
-        ];
+        return SimbaVoucherMetadata::forCodes(['IN1', 'IN2', 'IN3', 'IN4', 'IN5', 'IN6'], [
+            'IN1' => ['route' => 'in.vch.in1'],
+            'IN2' => ['route' => 'in.vch.in2'],
+            'IN3' => ['route' => 'in.vch.in3'],
+            'IN4' => ['route' => 'in.vch.in4'],
+            'IN5' => ['route' => 'in.vch.in5'],
+            'IN6' => ['route' => 'in.vch.in6', 'sys_menuid' => '14.10.14', 'table_ct' => 'INCT6M'],
+        ]);
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Config/PoVoucherRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/PoVoucherRegistry.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-16 00:27:46
+ * @lastupdate 2026-06-06 23:34:00
  */
 
 namespace Diepxuan\Catalog\Config;
 
+use Diepxuan\Catalog\Services\SimbaVoucherMetadata;
 use Diepxuan\Simba\Models\PoPh0;
 use Diepxuan\Simba\Models\PoPh1;
 use Diepxuan\Simba\Models\PoPh2;
@@ -25,100 +26,21 @@ use Diepxuan\Simba\Models\PoPh8;
 final class PoVoucherRegistry
 {
     /**
-     * PO voucher metadata verified from simba-docs/data/SiDmCt.md.
-     *
      * @return array<string, array<string, string>>
      */
     public static function vouchers(): array
     {
-        return [
-            'PO0' => [
-                'title'       => 'Phiếu đề nghị mua hàng',
-                'route'       => 'muahang.po0',
-                'menuid'      => '10.10.01',
-                'ph'          => 'poPh0',
-                'ct'          => 'poCt0',
-                'model'       => PoPh0::class,
-                'description' => 'Phiếu đề nghị mua hàng',
-            ],
-            'PO1' => [
-                'title'       => 'Đơn hàng mua',
-                'route'       => 'muahang.po1',
-                'menuid'      => '10.10.02',
-                'sys_menuid'  => '10.10.05',
-                'ph'          => 'poPh1',
-                'ct'          => 'poCt1',
-                'model'       => PoPh1::class,
-                'description' => 'Đơn hàng mua',
-            ],
-            'PO2' => [
-                'title'       => 'Phiếu nhập mua',
-                'route'       => 'muahang.po2',
-                'menuid'      => '10.10.04',
-                'ph'          => 'poPh2',
-                'ct'          => 'poCt2',
-                'model'       => PoPh2::class,
-                'description' => 'Phiếu nhập mua',
-            ],
-            'PO3' => [
-                'title'       => 'Hoá đơn mua hàng trong nước',
-                'route'       => 'muahang.hoadonmua',
-                'menuid'      => '10.10.14',
-                'ph'          => 'poPh3',
-                'ct'          => 'poCt3',
-                'cp'          => 'poCp3',
-                'model'       => PoPh3::class,
-                'description' => 'Hoá đơn mua hàng trong nước',
-            ],
-            'PO4' => [
-                'title'       => 'Phiếu chi phí mua hàng',
-                'route'       => 'muahang.po4',
-                'menuid'      => '10.10.20',
-                'ph'          => 'poPh4',
-                'ct'          => 'poCt4',
-                'cp'          => 'poCp4',
-                'model'       => PoPh4::class,
-                'description' => 'Phiếu chi phí mua hàng',
-            ],
-            'PO5' => [
-                'title'       => 'Phiếu xuất trả lại nhà cung cấp',
-                'route'       => 'muahang.po5',
-                'menuid'      => '10.10.23',
-                'ph'          => 'poPh5',
-                'ct'          => 'poCt5',
-                'model'       => PoPh5::class,
-                'description' => 'Phiếu xuất trả lại nhà cung cấp',
-            ],
-            'PO6' => [
-                'title'       => 'Hoá đơn mua dịch vụ',
-                'route'       => 'muahang.po6',
-                'menuid'      => '10.10.26',
-                'ph'          => 'poPh6',
-                'ct'          => 'poCt6',
-                'model'       => PoPh6::class,
-                'description' => 'Hoá đơn mua dịch vụ',
-            ],
-            'PO7' => [
-                'title'       => 'Hoá đơn mua hàng nhập khẩu',
-                'route'       => 'muahang.po7',
-                'menuid'      => '10.10.17',
-                'ph'          => 'poPh3',
-                'ct'          => 'poCt3',
-                'cp'          => 'poCp3',
-                'model'       => PoPh3::class,
-                'description' => 'Hoá đơn mua hàng nhập khẩu',
-            ],
-            'PO8' => [
-                'title'       => 'Phiếu nhập mua xuất thẳng',
-                'route'       => 'muahang.po8',
-                'menuid'      => '10.10.05',
-                'ph'          => 'poPh3',
-                'ct'          => 'poCt3',
-                'cp'          => 'poCp8',
-                'model'       => PoPh8::class,
-                'description' => 'Phiếu nhập mua xuất thẳng',
-            ],
-        ];
+        return SimbaVoucherMetadata::forCodes(['PO0', 'PO1', 'PO2', 'PO3', 'PO4', 'PO5', 'PO6', 'PO7', 'PO8'], [
+            'PO0' => ['route' => 'muahang.po0', 'model' => PoPh0::class],
+            'PO1' => ['route' => 'muahang.po1', 'sys_menuid' => '10.10.05', 'model' => PoPh1::class],
+            'PO2' => ['route' => 'muahang.po2', 'model' => PoPh2::class],
+            'PO3' => ['route' => 'muahang.hoadonmua', 'cp' => 'poCp3', 'model' => PoPh3::class],
+            'PO4' => ['route' => 'muahang.po4', 'cp' => 'poCp4', 'model' => PoPh4::class],
+            'PO5' => ['route' => 'muahang.po5', 'model' => PoPh5::class],
+            'PO6' => ['route' => 'muahang.po6', 'model' => PoPh6::class],
+            'PO7' => ['route' => 'muahang.po7', 'cp' => 'poCp3', 'model' => PoPh3::class],
+            'PO8' => ['route' => 'muahang.po8', 'cp' => 'poCp8', 'model' => PoPh8::class],
+        ]);
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Config/SoVoucherRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SoVoucherRegistry.php
@@ -8,50 +8,25 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-16 00:27:51
+ * @lastupdate 2026-06-06 23:34:00
  */
 
 namespace Diepxuan\Catalog\Config;
 
+use Diepxuan\Catalog\Services\SimbaVoucherMetadata;
+
 final class SoVoucherRegistry
 {
     /**
-     * SO voucher metadata verified from simba-docs/data/SiDmCt.md and sysVoucherInfo.md.
-     *
      * @return array<string, array<string, string>>
      */
     public static function vouchers(): array
     {
-        return [
-            'SO1' => [
-                'title'      => 'Đơn đặt hàng',
-                'route'      => 'banhang.so1',
-                'menuid'     => '06.10.01',
-                'sys_menuid' => '06.10.02',
-                'ph'         => 'soPh1',
-                'ct'         => 'soCt1',
-                'table_ph'   => 'SOPH1',
-                'table_ct'   => 'SOCT1',
-            ],
-            'SO4' => [
-                'title'    => 'Phiếu nhập hàng bán bị trả lại',
-                'route'    => 'banhang.so4',
-                'menuid'   => '06.10.11',
-                'ph'       => 'soPh4',
-                'ct'       => 'soCt4',
-                'table_ph' => 'SOPH4',
-                'table_ct' => 'SOCT4',
-            ],
-            'SO5' => [
-                'title'    => 'Hoá đơn dịch vụ',
-                'route'    => 'banhang.so5',
-                'menuid'   => '06.10.14',
-                'ph'       => 'soPh5',
-                'ct'       => 'soCt5',
-                'table_ph' => 'SOPH5',
-                'table_ct' => 'SOCT5',
-            ],
-        ];
+        return SimbaVoucherMetadata::forCodes(['SO1', 'SO4', 'SO5'], [
+            'SO1' => ['route' => 'banhang.so1', 'sys_menuid' => '06.10.02'],
+            'SO4' => ['route' => 'banhang.so4'],
+            'SO5' => ['route' => 'banhang.so5'],
+        ]);
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Services/SimbaVoucherMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaVoucherMetadata.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Services;
 
 use Diepxuan\Simba\Models\SiDmCt;
+use Diepxuan\Simba\SModel\SModel;
 
 final class SimbaVoucherMetadata
 {
@@ -27,6 +28,7 @@ final class SimbaVoucherMetadata
     {
         $normalizedCodes = array_values(array_unique(array_map('strtoupper', $codes)));
         $rows = SiDmCt::query()
+            ->where('ma_cty', self::companyCode())
             ->whereIn('ma_ct', $normalizedCodes)
             ->get()
             ->keyBy(static fn (SiDmCt $voucher): string => strtoupper((string) $voucher->ma_ct))
@@ -58,5 +60,14 @@ final class SimbaVoucherMetadata
     private static function tableName(string $source): string
     {
         return '' === trim($source) ? '' : strtoupper($source);
+    }
+
+    private static function companyCode(): string
+    {
+        if (class_exists(\CatalogService::class) && method_exists(\CatalogService::class, 'company')) {
+            return (string) (\CatalogService::company()?->ma_cty ?? SModel::CTY);
+        }
+
+        return SModel::CTY;
     }
 }

--- a/diepxuan/laravel-catalog/src/Services/SimbaVoucherMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaVoucherMetadata.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-06 23:34:00
+ */
+
+namespace Diepxuan\Catalog\Services;
+
+use Diepxuan\Simba\Models\SiDmCt;
+
+final class SimbaVoucherMetadata
+{
+    /**
+     * @param list<string>                         $codes
+     * @param array<string, array<string, string>> $overrides
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function forCodes(array $codes, array $overrides = []): array
+    {
+        $normalizedCodes = array_values(array_unique(array_map('strtoupper', $codes)));
+        $rows = SiDmCt::query()
+            ->whereIn('ma_ct', $normalizedCodes)
+            ->get()
+            ->keyBy(static fn (SiDmCt $voucher): string => strtoupper((string) $voucher->ma_ct))
+        ;
+
+        $metadata = [];
+        foreach ($normalizedCodes as $code) {
+            $voucher = $rows->get($code);
+            $override = $overrides[$code] ?? [];
+
+            $metadata[$code] = array_filter([
+                'title'       => (string) ($voucher?->ten_ct ?: ($override['title'] ?? $code)),
+                'route'       => $override['route'] ?? '',
+                'menuid'      => (string) ($override['menuid'] ?? $voucher?->menuid ?? ''),
+                'sys_menuid'  => $override['sys_menuid'] ?? null,
+                'ph'          => (string) ($voucher?->ph ?? ''),
+                'ct'          => (string) ($voucher?->ct ?? ''),
+                'cp'          => $override['cp'] ?? null,
+                'table_ph'    => $override['table_ph'] ?? self::tableName((string) ($voucher?->ph ?? '')),
+                'table_ct'    => $override['table_ct'] ?? self::tableName((string) ($voucher?->ct ?? '')),
+                'model'       => $override['model'] ?? null,
+                'description' => $override['description'] ?? (string) ($voucher?->ten_ct ?: ''),
+            ], static fn (?string $value): bool => null !== $value);
+        }
+
+        return $metadata;
+    }
+
+    private static function tableName(string $source): string
+    {
+        return '' === trim($source) ? '' : strtoupper($source);
+    }
+}


### PR DESCRIPTION
## Summary
- Add SimbaVoucherMetadata service that loads voucher metadata from SiDmCt via SQL Server Eloquent.
- Replace hardcoded Simba voucher metadata in Finance/IN/SO/PO voucher registries.
- Keep only Portal-specific overrides such as route names, model classes, cp/table exceptions, and sys_menuid aliases.

## Verification
- php -l changed voucher registry files and SimbaVoucherMetadata: pass
- grep for old simba-docs voucher metadata comments / return hardcoded arrays in voucher registries: clean

## Remaining hardcode after this PR
- SimbaReportRegistry still has a large hardcoded report seed array.
- SimbaDictionaryRegistry still has a hardcoded dictionary seed array.
- SimbaRouteRegistry still has a large Portal route map; should be split into Portal route bindings + SQL metadata enrichment.