### PR TITLE
refactor(simba): move process metadata to service

### DIFF
--- a/diepxuan/laravel-catalog/src/Config/SimbaProcessRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SimbaProcessRegistry.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-16 00:27:48
+ * @lastupdate 2026-06-07 21:44:00
  */
 
 namespace Diepxuan\Catalog\Config;
 
-use Diepxuan\Catalog\Services\SimbaMenuRepository;
+use Diepxuan\Catalog\Services\SimbaProcessMetadata;
 
 final class SimbaProcessRegistry
 {
@@ -22,38 +22,7 @@ final class SimbaProcessRegistry
      */
     public static function processes(): array
     {
-        $existingMenuIds = [];
-        foreach (SimbaRouteRegistry::routesWithoutProcesses() as $metadata) {
-            $existingMenuIds[$metadata['menuid']] = true;
-        }
-
-        $processes = [];
-        foreach ((new SimbaMenuRepository())->activeMenus() as $menu) {
-            if (isset($existingMenuIds[$menu->menuid])) {
-                continue;
-            }
-
-            if ('' === trim((string) $menu->dllName) && '' === trim((string) $menu->command) && '' === trim((string) $menu->code_name)) {
-                continue;
-            }
-
-            $route = self::generatedRouteName((string) $menu->moduleid, (string) ($menu->dllName ?: $menu->code_name ?: $menu->menuid));
-            while (isset($processes[$route])) {
-                $route .= '-' . str_replace('.', '-', $menu->menuid);
-            }
-
-            $processes[$route] = [
-                'module'    => (string) $menu->moduleid,
-                'menuid'    => (string) $menu->menuid,
-                'name'      => $menu->getDisplayName(),
-                'type'      => (string) $menu->type,
-                'dll_name'  => (string) $menu->dllName,
-                'command'   => (string) $menu->command,
-                'code_name' => (string) $menu->code_name,
-            ];
-        }
-
-        return $processes;
+        return SimbaProcessMetadata::processes(SimbaRouteRegistry::routesWithoutProcesses());
     }
 
     /**
@@ -61,14 +30,6 @@ final class SimbaProcessRegistry
      */
     public static function get(string $routeName): ?array
     {
-        return self::processes()[$routeName] ?? null;
-    }
-
-    private static function generatedRouteName(string $module, string $source): string
-    {
-        $slug = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $source));
-        $slug = trim($slug, '-');
-
-        return strtolower($module) . '.process.' . ($slug ?: 'menu');
+        return SimbaProcessMetadata::get($routeName, SimbaRouteRegistry::routesWithoutProcesses());
     }
 }

--- a/diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
+++ b/diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Config;
 
+use Diepxuan\Catalog\Services\SimbaProcessMetadata;
+
 final class SimbaRouteRegistry
 {
     public const TYPE_DICTIONARY = 'dictionary';
@@ -1066,7 +1068,7 @@ final class SimbaRouteRegistry
     private static function documentedProcessRoutes(): array
     {
         $routes = [];
-        foreach (SimbaProcessRegistry::processes() as $route => $metadata) {
+        foreach (SimbaProcessMetadata::processes(self::routesWithoutProcesses()) as $route => $metadata) {
             $routes[$route] = [
                 'module'      => $metadata['module'],
                 'menuid'      => $metadata['menuid'],

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaProcessIndex.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaProcessIndex.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\System;
 
-use Diepxuan\Catalog\Config\SimbaProcessRegistry;
+use Diepxuan\Catalog\Config\SimbaRouteRegistry;
+use Diepxuan\Catalog\Services\SimbaProcessMetadata;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -25,7 +26,7 @@ class SimbaProcessIndex extends Component
     public function mount(string $routeName): void
     {
         $this->routeName = $routeName;
-        $this->metadata  = SimbaProcessRegistry::get($routeName) ?? abort(404);
+        $this->metadata  = SimbaProcessMetadata::get($routeName, SimbaRouteRegistry::routesWithoutProcesses()) ?? abort(404);
     }
 
     public function render(): View

--- a/diepxuan/laravel-catalog/src/Services/SimbaProcessMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaProcessMetadata.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-07 21:44:00
+ */
+
+namespace Diepxuan\Catalog\Services;
+
+final class SimbaProcessMetadata
+{
+    /**
+     * @param array<string, array<string, mixed>> $existingRoutes
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function processes(array $existingRoutes = []): array
+    {
+        $existingMenuIds = [];
+        foreach ($existingRoutes as $metadata) {
+            $menuid = (string) ($metadata['menuid'] ?? '');
+            if ('' !== $menuid) {
+                $existingMenuIds[$menuid] = true;
+            }
+        }
+
+        $processes = [];
+        foreach ((new SimbaMenuRepository())->activeMenus() as $menu) {
+            if (isset($existingMenuIds[$menu->menuid])) {
+                continue;
+            }
+
+            if ('' === trim((string) $menu->dllName) && '' === trim((string) $menu->command) && '' === trim((string) $menu->code_name)) {
+                continue;
+            }
+
+            $route = self::generatedRouteName((string) $menu->moduleid, (string) ($menu->dllName ?: $menu->code_name ?: $menu->menuid));
+            while (isset($processes[$route])) {
+                $route .= '-' . str_replace('.', '-', (string) $menu->menuid);
+            }
+
+            $processes[$route] = [
+                'module'    => (string) $menu->moduleid,
+                'menuid'    => (string) $menu->menuid,
+                'name'      => $menu->getDisplayName(),
+                'type'      => (string) $menu->type,
+                'dll_name'  => (string) $menu->dllName,
+                'command'   => (string) $menu->command,
+                'code_name' => (string) $menu->code_name,
+            ];
+        }
+
+        return $processes;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $existingRoutes
+     *
+     * @return null|array<string, string>
+     */
+    public static function get(string $routeName, array $existingRoutes = []): ?array
+    {
+        return self::processes($existingRoutes)[$routeName] ?? null;
+    }
+
+    public static function generatedRouteName(string $module, string $source): string
+    {
+        $slug = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $source));
+        $slug = trim($slug, '-');
+
+        return strtolower($module) . '.process.' . ($slug ?: 'menu');
+    }
+}


### PR DESCRIPTION
## Summary
- Add SimbaProcessMetadata service to own dynamic Simba process metadata generation from active SQL-backed menu metadata.
- Keep SimbaProcessRegistry as a thin compatibility wrapper while moving runtime callers to the service.
- Update SimbaRouteRegistry process route enrichment to use the service directly.

## Verification
- php -l diepxuan/laravel-catalog/src/Services/SimbaProcessMetadata.php
- php -l diepxuan/laravel-catalog/src/Config/SimbaProcessRegistry.php
- php -l diepxuan/laravel-catalog/src/Config/SimbaRouteRegistry.php
- php -l diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaProcessIndex.php
- git diff --check
- ./vendor/bin/phpunit diepxuan/laravel-catalog/tests/Unit/Config/TimerConfigTest.php

## Notes
- Local dev-only modified files are intentionally excluded from this PR: diepxuan/laravel-catalog/routes/web.php and diepxuan/laravel-support/src/SupportServiceProvider.php.
- A broader CatalogServiceTimerTest run still has pre-existing failures unrelated to this change: missing getTimer/setTimer and session binding in that unit test.