### PR TITLE
feat(support): add config-driven corp auto login

### DIFF
--- a/diepxuan/laravel-catalog/composer.json
+++ b/diepxuan/laravel-catalog/composer.json
@@ -23,6 +23,7 @@
     "diepxuan/laravel-magento": "*",
     "diepxuan/laravel-ronaldjack": "*",
     "diepxuan/laravel-simba": "*",
+    "diepxuan/laravel-support": "*",
     "diepxuan/php-charset": "*",
     "laravel/jetstream": "*"
   },

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -78,6 +78,7 @@ use Diepxuan\Catalog\Http\Livewire\System\SimbaProcessIndex;
 use Diepxuan\Catalog\Http\Livewire\System\SimbaReportIndex;
 use Diepxuan\Catalog\Http\Livewire\System\TaskShell;
 use Diepxuan\Catalog\Http\Livewire\System\YearSelector;
+use Diepxuan\Support\Http\Middleware\CorpAutoLogin;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -91,7 +92,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 // Route::domain(env('APP_URL','portal.diepxuan.io.vn'))->middleware(['clearcache', 'auth'])->group(static function (): void {
-Route::middleware(['auth'])->group(static function (): void {
+Route::middleware([CorpAutoLogin::class, 'auth'])->group(static function (): void {
     Route::get('/gl/taikhoan', Taikhoan::class)->name('gl.taikhoan');
     Route::get('/gl/phieu-ke-toan', FinanceVoucherIndex::class)->defaults('voucherCode', 'GL1')->name('gl.vch.gl1');
     Route::get('/gl/chung-tu-ngoai-bang', FinanceVoucherIndex::class)->defaults('voucherCode', 'NB1')->name('gl.vch.nb1');

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -92,7 +92,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 // Route::domain(env('APP_URL','portal.diepxuan.io.vn'))->middleware(['clearcache', 'auth'])->group(static function (): void {
-Route::middleware([CorpAutoLogin::class, 'auth'])->group(static function (): void {
+Route::middleware([CorpAutoLogin::class])->group(static function (): void {
     Route::get('/gl/taikhoan', Taikhoan::class)->name('gl.taikhoan');
     Route::get('/gl/phieu-ke-toan', FinanceVoucherIndex::class)->defaults('voucherCode', 'GL1')->name('gl.vch.gl1');
     Route::get('/gl/chung-tu-ngoai-bang', FinanceVoucherIndex::class)->defaults('voucherCode', 'NB1')->name('gl.vch.nb1');

--- a/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
+++ b/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Support\Http\Middleware;
 
-use Diepxuan\Catalog\Models\User;
 use Closure;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
@@ -29,16 +29,14 @@ class CorpAutoLogin
     public function handle(Request $request, Closure $next): Response
     {
         if ($this->shouldAutoLogin($request)) {
-            $user = User::query()
-                ->where('email', $this->email())
-                ->first();
+            $user = $this->findUserByEmail();
 
             if ($user !== null) {
                 Auth::login($user);
 
                 Log::info('Corp auto-login authenticated request.', [
-                    'user_id'     => $user->getKey(),
-                    'email'       => $user->email,
+                    'user_id'     => $user->getAuthIdentifier(),
+                    'email'       => $this->email(),
                     'host'        => $request->getHost(),
                     'server_addr' => $request->server('SERVER_ADDR'),
                     'path'        => $request->path(),
@@ -96,6 +94,13 @@ class CorpAutoLogin
     private function email(): string
     {
         return trim((string) env('DX_CORP_AUTO_LOGIN_EMAIL', ''));
+    }
+
+    private function findUserByEmail(): ?Authenticatable
+    {
+        return Auth::getProvider()->retrieveByCredentials([
+            'email' => $this->email(),
+        ]);
     }
 
     private function isAllowedHost(Request $request): bool

--- a/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
+++ b/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-09 00:00:00
+ */
+
+namespace Diepxuan\Support\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class CorpAutoLogin
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($this->shouldAutoLogin($request)) {
+            $user = User::query()
+                ->where('email', $this->email())
+                ->first();
+
+            if ($user !== null) {
+                Auth::login($user);
+
+                Log::info('Corp auto-login authenticated request.', [
+                    'user_id'     => $user->getKey(),
+                    'email'       => $user->email,
+                    'host'        => $request->getHost(),
+                    'server_addr' => $request->server('SERVER_ADDR'),
+                    'path'        => $request->path(),
+                ]);
+            }
+        }
+
+        return $next($request);
+    }
+
+    private function shouldAutoLogin(Request $request): bool
+    {
+        return $this->enabled()
+            && Auth::guest()
+            && $this->email() !== ''
+            && $this->isAllowedHost($request)
+            && $this->isAllowedServerAddress($request);
+    }
+
+    private function enabled(): bool
+    {
+        return filter_var(env('DX_CORP_AUTO_LOGIN_ENABLED', false), FILTER_VALIDATE_BOOL);
+    }
+
+    private function email(): string
+    {
+        return trim((string) env('DX_CORP_AUTO_LOGIN_EMAIL', ''));
+    }
+
+    private function isAllowedHost(Request $request): bool
+    {
+        $suffix = strtolower(trim((string) env('DX_CORP_AUTO_LOGIN_HOST_SUFFIX', '.diepxuan.corp')));
+        $host   = strtolower($request->getHost());
+
+        return $suffix !== '' && str_ends_with($host, $suffix);
+    }
+
+    private function isAllowedServerAddress(Request $request): bool
+    {
+        $expectedAddress = trim((string) env('DX_CORP_AUTO_LOGIN_SERVER_ADDR', '10.0.0.122'));
+        $serverAddress   = (string) $request->server('SERVER_ADDR', '');
+
+        return $expectedAddress !== '' && $serverAddress === $expectedAddress;
+    }
+}

--- a/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
+++ b/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
@@ -50,11 +50,17 @@ class CorpAutoLogin
 
     private function shouldAutoLogin(Request $request): bool
     {
-        return $this->enabled()
+        return $this->isLocalEnvironment()
+            && $this->enabled()
             && Auth::guest()
             && $this->email() !== ''
             && $this->isAllowedHost($request)
             && $this->isAllowedServerAddress($request);
+    }
+
+    private function isLocalEnvironment(): bool
+    {
+        return app()->environment('local');
     }
 
     private function enabled(): bool

--- a/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
+++ b/diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace Diepxuan\Support\Http\Middleware;
 
-use App\Models\User;
+use Diepxuan\Catalog\Models\User;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Redirect;
 use Symfony\Component\HttpFoundation\Response;
 
 class CorpAutoLogin
@@ -45,17 +46,41 @@ class CorpAutoLogin
             }
         }
 
+        if (Auth::guest()) {
+            return Redirect::guest(route('login'));
+        }
+
         return $next($request);
     }
 
     private function shouldAutoLogin(Request $request): bool
     {
-        return $this->isLocalEnvironment()
-            && $this->enabled()
-            && Auth::guest()
-            && $this->email() !== ''
-            && $this->isAllowedHost($request)
-            && $this->isAllowedServerAddress($request);
+        $checks = [
+            'local_environment' => $this->isLocalEnvironment(),
+            'enabled'           => $this->enabled(),
+            'guest'             => Auth::guest(),
+            'email_configured'  => $this->email() !== '',
+            'allowed_host'      => $this->isAllowedHost($request),
+            'allowed_server'    => $this->isAllowedServerAddress($request),
+        ];
+
+        $shouldAutoLogin = !\in_array(false, $checks, true);
+
+        if (!$shouldAutoLogin && $this->isLocalEnvironment() && $this->enabled()) {
+            Log::debug('Corp auto-login skipped request.', [
+                'checks'               => $checks,
+                'email'                => $this->email(),
+                'host'                 => $request->getHost(),
+                'host_suffix'          => $this->hostSuffix(),
+                'server_addr'          => $request->server('SERVER_ADDR'),
+                'detected_addrs'       => $this->detectedServerAddresses($request),
+                'allowed_server_addrs' => $this->allowedServerAddresses(),
+                'path'                 => $request->path(),
+                'url'                  => $request->fullUrl(),
+            ]);
+        }
+
+        return $shouldAutoLogin;
     }
 
     private function isLocalEnvironment(): bool
@@ -75,17 +100,48 @@ class CorpAutoLogin
 
     private function isAllowedHost(Request $request): bool
     {
-        $suffix = strtolower(trim((string) env('DX_CORP_AUTO_LOGIN_HOST_SUFFIX', '.diepxuan.corp')));
+        $suffix = $this->hostSuffix();
         $host   = strtolower($request->getHost());
 
         return $suffix !== '' && str_ends_with($host, $suffix);
     }
 
+    private function hostSuffix(): string
+    {
+        return strtolower(trim((string) env('DX_CORP_AUTO_LOGIN_HOST_SUFFIX', '.diepxuan.corp')));
+    }
+
     private function isAllowedServerAddress(Request $request): bool
     {
-        $expectedAddress = trim((string) env('DX_CORP_AUTO_LOGIN_SERVER_ADDR', '10.0.0.122'));
-        $serverAddress   = (string) $request->server('SERVER_ADDR', '');
+        $detectedAddresses = $this->detectedServerAddresses($request);
 
-        return $expectedAddress !== '' && $serverAddress === $expectedAddress;
+        return array_intersect($detectedAddresses, $this->allowedServerAddresses()) !== [];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function detectedServerAddresses(Request $request): array
+    {
+        $addresses = array_filter([
+            (string) $request->server('SERVER_ADDR', ''),
+            (string) $request->server('LOCAL_ADDR', ''),
+            gethostbyname($request->getHost()),
+        ], static fn (string $address) => $address !== '');
+
+        return array_values(array_unique($addresses));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function allowedServerAddresses(): array
+    {
+        $addresses = (string) env('DX_CORP_AUTO_LOGIN_SERVER_ADDR', '10.0.0.122');
+
+        return array_values(array_filter(array_map(
+            static fn (string $address) => trim($address),
+            explode(',', $addresses)
+        ), static fn (string $address) => $address !== ''));
     }
 }

--- a/diepxuan/laravel-support/src/SupportServiceProvider.php
+++ b/diepxuan/laravel-support/src/SupportServiceProvider.php
@@ -33,12 +33,21 @@ class SupportServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if (!app()->runningInConsole()) {
+        if (!app()->runningInConsole() && $this->shouldForceHttps()) {
             URL::forceScheme('https');
         }
 
         $this->commands([
             GenerateDockerfileSqlsrvCommand::class,
         ]);
+    }
+
+    private function shouldForceHttps(): bool
+    {
+        if (!app()->environment('local')) {
+            return true;
+        }
+
+        return filter_var(env('DX_CORP_AUTO_LOGIN_HTTPS', true), FILTER_VALIDATE_BOOL);
     }
 }


### PR DESCRIPTION
## Summary
- Add config-driven CorpAutoLogin middleware in laravel-support.
- Run CorpAutoLogin as the protected-route gate itself so auto-login can complete before guest redirect.
- Keep all DX_CORP_AUTO_LOGIN* controls effective only when APP_ENV=local.
- Add DX_CORP_AUTO_LOGIN_HTTPS to control URL::forceScheme('https') only in local/demo environments.

## Fixes from live test
- Root cause 1: Laravel `auth` middleware redirected to `/login` before the post-login request could render reliably; CorpAutoLogin now redirects guests itself only after attempting local auto-login.
- Root cause 2: `php artisan serve` does not populate `SERVER_ADDR`; CorpAutoLogin now accepts detected local server addresses from `SERVER_ADDR`, `LOCAL_ADDR`, or DNS resolution of the request host, matched against `DX_CORP_AUTO_LOGIN_SERVER_ADDR`.
- Root cause 3: Auth user must be `Diepxuan\Catalog\Models\User`; using `App\Models\User` caused CatalogService typed property failure after login.

## Safety
- No hard-coded auto-login email; uses DX_CORP_AUTO_LOGIN_EMAIL.
- Auto-login is disabled unless APP_ENV=local and DX_CORP_AUTO_LOGIN_ENABLED=true.
- Host suffix and server address must match DX_CORP_AUTO_LOGIN_HOST_SUFFIX and DX_CORP_AUTO_LOGIN_SERVER_ADDR.
- Logs successful auto-login events for audit.
- Non-local environments are not auto-logged-in and still redirect guests to the login route.
- Non-local environments always keep URL::forceScheme('https') enabled; DX_CORP_AUTO_LOGIN_HTTPS is ignored outside local.

## Env
- APP_ENV=local
- DX_CORP_AUTO_LOGIN_ENABLED=false
- DX_CORP_AUTO_LOGIN_EMAIL=
- DX_CORP_AUTO_LOGIN_HOST_SUFFIX=.diepxuan.corp
- DX_CORP_AUTO_LOGIN_SERVER_ADDR=10.0.0.122
- DX_CORP_AUTO_LOGIN_HTTPS=true

## Local/demo example
```env
APP_ENV=local
DX_CORP_AUTO_LOGIN_ENABLED=true
DX_CORP_AUTO_LOGIN_EMAIL=<demo-user-email>
DX_CORP_AUTO_LOGIN_HOST_SUFFIX=portal.diepxuan.corp
DX_CORP_AUTO_LOGIN_SERVER_ADDR=10.0.0.122
DX_CORP_AUTO_LOGIN_HTTPS=false
```

## Verification
- php -l diepxuan/laravel-support/src/Http/Middleware/CorpAutoLogin.php
- php -l diepxuan/laravel-support/src/SupportServiceProvider.php
- php -l diepxuan/laravel-catalog/routes/web.php
- git diff --check
- docker compose exec -T laravel.test php artisan route:list --path=gl/taikhoan -v
- curl smoke: `Host: portal.diepxuan.corp` GET `/gl/taikhoan` returns `HTTP/1.1 200 OK` and no login form
- Browser smoke: `http://portal.diepxuan.corp/gl/taikhoan` opens page title `Tổng hợp` with user `Tran Ngoc Duc`
