### PR TITLE
refactor(catalog): unify Simba dictionary/process/report into SimbaPage + enrich shell metadata

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/system/simba-page-metadata.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/simba-page-metadata.blade.php
@@ -1,0 +1,132 @@
+<div class="space-y-3">
+    <div class="rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        @switch($sourceType ?? '')
+            @case('dictionary')
+                Danh mục đã được gắn theo menu active, khóa và bảng từ sysDictionaryInfo. Form nhập liệu chỉ mở sau khi đối chiếu đủ payload, lookup và quyền sửa/xóa trong simba-docs.
+                @break
+            @case('report')
+                Báo cáo đã được mở theo menu active và thông tin mẫu từ simba-docs. Phần filter, tham số và render dữ liệu chỉ mở sau khi đối chiếu đầy đủ SP/function trong tài liệu.
+                @break
+            @case('voucher')
+                Chứng từ đã có metadata mã chứng từ từ simba-docs. Form nhập liệu và số dùng chung chỉ mở sau khi đối chiếu payload, quyền sửa/xóa.
+                @break
+            @default
+                Menu này có DLL/command trong sysMenu nhưng chưa có metadata report, dictionary hoặc voucher đủ chuẩn. Portal chỉ mở shell tham chiếu; không execute, không ghi dữ liệu, không gọi SQL/SP cho đến khi audit đủ logic trong simba-docs.
+        @endswitch
+    </div>
+
+    <dl class="grid gap-2 rounded-lg border border-gray-200 bg-white p-4 text-sm md:grid-cols-2">
+        <div>
+            <dt class="font-medium text-gray-600">Route</dt>
+            <dd class="font-mono text-gray-900">{{ $routeName }}</dd>
+        </div>
+        <div>
+            <dt class="font-medium text-gray-600">Menu</dt>
+            <dd class="font-mono text-gray-900">{{ $metadata['menuid'] ?? '-' }}</dd>
+        </div>
+        <div>
+            <dt class="font-medium text-gray-600">Source type</dt>
+            <dd class="font-mono text-gray-900">{{ $sourceType ?? '-' }}</dd>
+        </div>
+        <div>
+            <dt class="font-medium text-gray-600">Module</dt>
+            <dd class="font-mono text-gray-900">{{ $metadata['module'] ?? '-' }}</dd>
+        </div>
+
+        @if ($sourceType === 'dictionary')
+            <div>
+                <dt class="font-medium text-gray-600">Code name</dt>
+                <dd class="font-mono text-gray-900">{{ $metadata['code_name'] ?? '-' }}</dd>
+            </div>
+            <div>
+                <dt class="font-medium text-gray-600">Table</dt>
+                <dd class="font-mono text-gray-900">{{ $metadata['table'] ?? '-' }}</dd>
+            </div>
+            <div>
+                <dt class="font-medium text-gray-600">Primary key</dt>
+                <dd class="font-mono text-gray-900">{{ is_array($metadata['pk'] ?? null) ? implode(', ', $metadata['pk']) : '-' }}</dd>
+            </div>
+            @if (! empty($metadata['source_menuid']))
+                <div>
+                    <dt class="font-medium text-gray-600">Source menu</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['source_menuid'] ?: 'blank' }}</dd>
+                </div>
+            @endif
+            <div>
+                <dt class="font-medium text-gray-600">Carry fields</dt>
+                <dd class="font-mono text-gray-900">{{ is_array($metadata['fields'] ?? null) ? implode(', ', $metadata['fields']) : '-' }}</dd>
+            </div>
+        @endif
+
+        @if ($sourceType === 'report')
+            <div>
+                <dt class="font-medium text-gray-600">Stored procedure</dt>
+                <dd class="font-mono text-gray-900">{{ $metadata['spname'] ?? '-' }}</dd>
+            </div>
+            <div>
+                <dt class="font-medium text-gray-600">Report file</dt>
+                <dd class="font-mono text-gray-900">{{ $metadata['rptname'] ?? '-' }}</dd>
+            </div>
+            @if (! empty($metadata['ma_mau']))
+                <div>
+                    <dt class="font-medium text-gray-600">Mẫu</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['ma_mau'] }}</dd>
+                </div>
+            @endif
+            @if (! empty($metadata['dll_name']) || ! empty($metadata['command']))
+                <div>
+                    <dt class="font-medium text-gray-600">DLL</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['dll_name'] ?? '-' }}</dd>
+                </div>
+                <div>
+                    <dt class="font-medium text-gray-600">Command</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['command'] ?? '-' }}</dd>
+                </div>
+            @endif
+            @if (! empty($metadata['source_menuid']))
+                <div>
+                    <dt class="font-medium text-gray-600">Source menu</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['source_menuid'] }}</dd>
+                </div>
+                @if (! empty($metadata['press_key_name']))
+                    <div>
+                        <dt class="font-medium text-gray-600">Key</dt>
+                        <dd class="font-mono text-gray-900">{{ $metadata['press_key_name'] }}</dd>
+                    </div>
+                @endif
+            @endif
+        @endif
+
+        @if ($sourceType === 'voucher')
+            <div>
+                <dt class="font-medium text-gray-600">Mã chứng từ</dt>
+                <dd class="font-mono text-gray-900">{{ $metadata['ma_ct'] ?? '-' }}</dd>
+            </div>
+        @endif
+
+        @if (in_array($sourceType, ['custom', null], true))
+            @if (! empty($metadata['dll_name']) || ! empty($metadata['command']) || ! empty($metadata['code_name']))
+                <div>
+                    <dt class="font-medium text-gray-600">DLL</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['dll_name'] ?? '-' }}</dd>
+                </div>
+                <div>
+                    <dt class="font-medium text-gray-600">Command</dt>
+                    <dd class="font-mono text-gray-900">{{ $metadata['command'] ?? '-' }}</dd>
+                </div>
+                @if (! empty($metadata['code_name']))
+                    <div>
+                        <dt class="font-medium text-gray-600">Code name</dt>
+                        <dd class="font-mono text-gray-900">{{ $metadata['code_name'] }}</dd>
+                    </div>
+                @endif
+            @endif
+        @endif
+    </dl>
+
+    @if (! empty($metadata['description']))
+        <div class="rounded-lg border border-gray-200 bg-white p-4 text-sm text-gray-700">
+            {{ $metadata['description'] }}
+        </div>
+    @endif
+</div>

--- a/diepxuan/laravel-catalog/resources/views/system/simba-page.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/simba-page.blade.php
@@ -29,8 +29,16 @@
                     <p class="mt-2 text-sm">Sử dụng menu bên trái để mở chức năng theo URL chuẩn /simba/&lt;module&gt;/&lt;type&gt;/&lt;code&gt;.</p>
                 </div>
             @elseif (empty($target['component']))
-                <div class="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
-                    Chưa resolve được component cho route <span class="font-mono">{{ $target['routeName'] }}</span>.
+                <div class="space-y-3">
+                    <div class="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+                        Route <span class="font-mono">{{ $target['routeName'] }}</span> chưa có Livewire component.
+                        Portal mở shell tham chiếu metadata từ simba-docs để hỗ trợ audit.
+                    </div>
+                    @include('catalog::system.simba-page-metadata', [
+                        'routeName' => $target['routeName'],
+                        'sourceType' => $target['sourceType'],
+                        'metadata' => $target['metadata'],
+                    ])
                 </div>
             @else
                 @livewire($target['component'], $target['params'], key('simba-page-'.$target['routeName']))

--- a/diepxuan/laravel-catalog/resources/views/system/simba-page.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/simba-page.blade.php
@@ -1,0 +1,40 @@
+<div class="space-y-4">
+    <div class="flex items-center justify-between border-b border-gray-200 pb-3">
+        <div>
+            <h1 class="text-xl font-semibold text-gray-900">SimbaERP</h1>
+            <p class="text-xs text-gray-500">
+                @if ($target)
+                    {{ $target['routeName'] }} · {{ $target['menuid'] ?? 'no-menuid' }} · {{ $target['sourceType'] }}
+                @else
+                    Chọn chức năng từ menu SimbaERP.
+                @endif
+            </p>
+        </div>
+        @if ($target)
+            <span class="rounded bg-blue-50 px-2 py-1 font-mono text-xs text-blue-700 ring-1 ring-inset ring-blue-200">
+                /simba/{{ $module }}/{{ $kind }}/{{ $slug }}
+            </span>
+        @endif
+    </div>
+
+    <div class="flex gap-4">
+        <aside class="w-[360px] flex-shrink-0">
+            @livewire('catalog::system.simba-erp-menus')
+        </aside>
+
+        <section class="min-w-0 flex-1 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+            @if (! $target)
+                <div class="flex min-h-[420px] flex-col items-center justify-center text-center text-gray-500">
+                    <div class="text-lg font-semibold text-gray-700">SimbaERP Portal</div>
+                    <p class="mt-2 text-sm">Sử dụng menu bên trái để mở chức năng theo URL chuẩn /simba/&lt;module&gt;/&lt;type&gt;/&lt;code&gt;.</p>
+                </div>
+            @elseif (empty($target['component']))
+                <div class="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+                    Chưa resolve được component cho route <span class="font-mono">{{ $target['routeName'] }}</span>.
+                </div>
+            @else
+                @livewire($target['component'], $target['params'], key('simba-page-'.$target['routeName']))
+            @endif
+        </section>
+    </div>
+</div>

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -73,9 +73,7 @@ use Diepxuan\Catalog\Http\Livewire\System\CompanySelector;
 use Diepxuan\Catalog\Http\Livewire\System\Dashboard;
 use Diepxuan\Catalog\Http\Livewire\System\Menu;
 use Diepxuan\Catalog\Http\Livewire\System\SiDictionaryIndex;
-use Diepxuan\Catalog\Http\Livewire\System\SimbaDictionaryIndex;
-use Diepxuan\Catalog\Http\Livewire\System\SimbaProcessIndex;
-use Diepxuan\Catalog\Http\Livewire\System\SimbaReportIndex;
+use Diepxuan\Catalog\Http\Livewire\System\SimbaPage;
 use Diepxuan\Catalog\Http\Livewire\System\TaskShell;
 use Diepxuan\Catalog\Http\Livewire\System\YearSelector;
 use Diepxuan\Support\Http\Middleware\CorpAutoLogin;
@@ -523,18 +521,18 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
     Route::resource('hethong/website', SystemWebsiteController::class)->names('system.website');
     Route::get('hethong/menu', Menu::class)->name('system.menu');
     Route::get('hethong/year', YearSelector::class)->name('system.year');
-    Route::get('simba/dictionaries/{routeName}', SimbaDictionaryIndex::class)
-        ->where('routeName', '[A-Za-z0-9_.-]+')
-        ->name('simba.dictionary')
-    ;
-    Route::get('simba/reports/{routeName}', SimbaReportIndex::class)
-        ->where('routeName', '[A-Za-z0-9_.-]+')
-        ->name('simba.report')
-    ;
-    Route::get('simba/processes/{routeName}', SimbaProcessIndex::class)
-        ->where('routeName', '[A-Za-z0-9_.-]+')
-        ->name('simba.process')
-    ;
+
+    Route::prefix('simba')->name('simba.')->group(static function (): void {
+        Route::get('/', SimbaPage::class)->name('index');
+        Route::get('/{module}/{kind}/{slug}', SimbaPage::class)
+            ->where([
+                'module' => '[a-z0-9-]+',
+                'kind'   => '[a-z0-9-]+',
+                'slug'   => '[a-z0-9_.-]+',
+            ])
+            ->name('show')
+        ;
+    });
 
     // Balance Management Routes - Livewire Components
     Route::prefix('hethong/balance')->name('system.balance.')->group(static function (): void {

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
@@ -16,8 +16,8 @@ namespace Diepxuan\Catalog\Http\Livewire\System;
 use Diepxuan\Catalog\Config\SimbaRouteRegistry;
 use Diepxuan\Simba\Models\SysMenu;
 use Diepxuan\Catalog\Services\SimbaMenuRepository;
+use Diepxuan\Catalog\Services\SimbaMenuTargetResolver;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Route;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -38,9 +38,12 @@ class SimbaErpMenus extends Component
 
     protected SimbaMenuRepository $menus;
 
-    public function boot(SimbaMenuRepository $menus): void
+    protected SimbaMenuTargetResolver $resolver;
+
+    public function boot(SimbaMenuRepository $menus, SimbaMenuTargetResolver $resolver): void
     {
-        $this->menus = $menus;
+        $this->menus    = $menus;
+        $this->resolver = $resolver;
     }
 
     /**
@@ -270,16 +273,7 @@ class SimbaErpMenus extends Component
 
     private function portalUrl(string $routeName, string $sourceType): ?string
     {
-        if (Route::has($routeName)) {
-            return route($routeName);
-        }
-
-        return match ($sourceType) {
-            SimbaRouteRegistry::TYPE_REPORT     => route('simba.report', ['routeName' => $routeName]),
-            SimbaRouteRegistry::TYPE_DICTIONARY => route('simba.dictionary', ['routeName' => $routeName]),
-            SimbaRouteRegistry::TYPE_CUSTOM     => route('simba.process', ['routeName' => $routeName]),
-            default                             => null,
-        };
+        return $this->resolver->urlForRouteName($routeName, ['source_type' => $sourceType]);
     }
 
     private function sourceTypeLabel(string $sourceType): string

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaPage.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaPage.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-14 02:00:00
+ */
+
+namespace Diepxuan\Catalog\Http\Livewire\System;
+
+use Diepxuan\Catalog\Services\SimbaMenuTargetResolver;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class SimbaPage extends Component
+{
+    public ?string $module = null;
+    public ?string $kind   = null;
+    public ?string $slug   = null;
+
+    /** @var array<string,mixed>|null */
+    public ?array $target = null;
+
+    public function mount(?string $module = null, ?string $kind = null, ?string $slug = null, SimbaMenuTargetResolver $resolver): void
+    {
+        $this->module = $module;
+        $this->kind   = $kind;
+        $this->slug   = $slug;
+        $this->target = $resolver->resolvePath($module, $kind, $slug);
+
+        if (null !== $module && null === $this->target) {
+            abort(404);
+        }
+    }
+
+    public function render(): View
+    {
+        return view('catalog::system.simba-page')->layout('catalog::layouts.app');
+    }
+}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaPage.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaPage.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-06-14 02:00:00
+ * @lastupdate 2026-06-16 08:47:00
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\System;
@@ -26,12 +26,19 @@ class SimbaPage extends Component
     /** @var array<string,mixed>|null */
     public ?array $target = null;
 
-    public function mount(?string $module = null, ?string $kind = null, ?string $slug = null, SimbaMenuTargetResolver $resolver): void
+    protected SimbaMenuTargetResolver $resolver;
+
+    public function boot(SimbaMenuTargetResolver $resolver): void
+    {
+        $this->resolver = $resolver;
+    }
+
+    public function mount(?string $module = null, ?string $kind = null, ?string $slug = null): void
     {
         $this->module = $module;
         $this->kind   = $kind;
         $this->slug   = $slug;
-        $this->target = $resolver->resolvePath($module, $kind, $slug);
+        $this->target = $this->resolver->resolvePath($module, $kind, $slug);
 
         if (null !== $module && null === $this->target) {
             abort(404);

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuTargetResolver.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuTargetResolver.php
@@ -8,11 +8,13 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-06-14 02:00:00
+ * @lastupdate 2026-06-15 13:00:00
  */
 
 namespace Diepxuan\Catalog\Services;
 
+use Diepxuan\Catalog\Config\SimbaDictionaryRegistry;
+use Diepxuan\Catalog\Config\SimbaReportRegistry;
 use Diepxuan\Catalog\Config\SimbaRouteRegistry;
 use Illuminate\Routing\Route as LaravelRoute;
 use Illuminate\Support\Facades\Route;
@@ -57,6 +59,7 @@ class SimbaMenuTargetResolver
         }
 
         $route = Route::getRoutes()->getByName($routeName);
+        $metadata = $this->enrichMetadata($routeName, $metadata);
 
         return [
             'routeName'   => $routeName,
@@ -68,6 +71,51 @@ class SimbaMenuTargetResolver
             'title'       => $this->titleFor($routeName, $metadata, $route),
             'sourceType'  => $metadata['source_type'] ?? SimbaRouteRegistry::TYPE_CUSTOM,
         ];
+    }
+
+    /**
+     * Merge full metadata from the appropriate Simba* registry into the route's
+     * base metadata (which only carries module/menuid/source_type). The merged
+     * metadata drives the read-only "shell" view shown when a route has no
+     * Livewire component yet.
+     *
+     * @param array<string, string> $metadata
+     *
+     * @return array<string, string>
+     */
+    private function enrichMetadata(string $routeName, array $metadata): array
+    {
+        $sourceType = $metadata['source_type'] ?? null;
+
+        $extra = match ($sourceType) {
+            SimbaRouteRegistry::TYPE_DICTIONARY => SimbaDictionaryRegistry::get($routeName) ?? [],
+            SimbaRouteRegistry::TYPE_REPORT     => SimbaReportRegistry::get($routeName) ?? [],
+            SimbaRouteRegistry::TYPE_CUSTOM     => $this->findProcessMetadata($routeName) ?? [],
+            default                             => [],
+        };
+
+        if ([] === $extra) {
+            return $metadata;
+        }
+
+        // Base metadata takes precedence so we never overwrite authoritative
+        // module/menuid/source_type with registry values.
+        return array_merge($extra, $metadata);
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function findProcessMetadata(string $routeName): ?array
+    {
+        foreach (SimbaProcessMetadata::processes() as $route => $metadata) {
+            if ($route === $routeName) {
+                /** @var array<string, string> $metadata */
+                return $metadata;
+            }
+        }
+
+        return null;
     }
 
     public function urlForRouteName(string $routeName, ?array $metadata = null): string

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuTargetResolver.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuTargetResolver.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-14 02:00:00
+ */
+
+namespace Diepxuan\Catalog\Services;
+
+use Diepxuan\Catalog\Config\SimbaRouteRegistry;
+use Illuminate\Routing\Route as LaravelRoute;
+use Illuminate\Support\Facades\Route;
+
+class SimbaMenuTargetResolver
+{
+    private const SOURCE_TYPE_TO_SEGMENT = [
+        SimbaRouteRegistry::TYPE_DICTIONARY => 'dict',
+        SimbaRouteRegistry::TYPE_VOUCHER    => 'vch',
+        SimbaRouteRegistry::TYPE_REPORT     => 'rpt',
+        SimbaRouteRegistry::TYPE_CUSTOM     => 'proc',
+    ];
+
+    /**
+     * @return array{routeName:string, metadata:array<string,string>, menuid:?string, url:string, component:?string, params:array<string,mixed>, title:string, sourceType:string}|null
+     */
+    public function resolvePath(?string $module = null, ?string $kind = null, ?string $slug = null): ?array
+    {
+        if (null === $module || '' === $module) {
+            return null;
+        }
+
+        foreach ($this->candidateRouteNames($module, $kind, $slug) as $routeName) {
+            $target = $this->resolveRouteName($routeName);
+            if (null !== $target) {
+                return $target;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{routeName:string, metadata:array<string,string>, menuid:?string, url:string, component:?string, params:array<string,mixed>, title:string, sourceType:string}|null
+     */
+    public function resolveRouteName(string $routeName): ?array
+    {
+        $routes = SimbaRouteRegistry::routes();
+        $metadata = $routes[$routeName] ?? null;
+        if (null === $metadata) {
+            return null;
+        }
+
+        $route = Route::getRoutes()->getByName($routeName);
+
+        return [
+            'routeName'   => $routeName,
+            'metadata'    => $metadata,
+            'menuid'      => $metadata['menuid'] ?? null,
+            'url'         => $this->urlForRouteName($routeName, $metadata),
+            'component'   => $this->componentForRoute($route),
+            'params'      => $this->paramsForRoute($route),
+            'title'       => $this->titleFor($routeName, $metadata, $route),
+            'sourceType'  => $metadata['source_type'] ?? SimbaRouteRegistry::TYPE_CUSTOM,
+        ];
+    }
+
+    public function urlForRouteName(string $routeName, ?array $metadata = null): string
+    {
+        $metadata ??= SimbaRouteRegistry::routes()[$routeName] ?? [];
+        $parts = explode('.', $routeName);
+        $module = strtolower((string) ($metadata['module'] ?? $parts[0] ?? 'simba'));
+        $sourceType = $metadata['source_type'] ?? null;
+        $kind = self::SOURCE_TYPE_TO_SEGMENT[$sourceType] ?? ($parts[1] ?? 'proc');
+        if (isset(self::SOURCE_TYPE_TO_SEGMENT[$sourceType])) {
+            $slugParts = match ($sourceType) {
+                SimbaRouteRegistry::TYPE_DICTIONARY => array_slice($parts, 1),
+                SimbaRouteRegistry::TYPE_VOUCHER, SimbaRouteRegistry::TYPE_REPORT => array_slice($parts, 2) ?: array_slice($parts, 1),
+                SimbaRouteRegistry::TYPE_CUSTOM => array_slice($parts, 1),
+                default => array_slice($parts, 1),
+            };
+            $slug = implode('.', $slugParts);
+        } else {
+            $slug = implode('.', array_slice($parts, 1)) ?: $routeName;
+        }
+
+        return route('simba.show', [
+            'module' => $module,
+            'kind'   => $kind,
+            'slug'   => $slug,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateRouteNames(string $module, ?string $kind, ?string $slug): array
+    {
+        $module = strtolower($module);
+        $kind   = null === $kind ? null : strtolower($kind);
+        $slug   = null === $slug ? null : strtolower($slug);
+
+        if (null === $kind || '' === $kind) {
+            return [$module];
+        }
+
+        if (null === $slug || '' === $slug) {
+            return ["{$module}.{$kind}"];
+        }
+
+        return match ($kind) {
+            'dict' => ["{$module}.{$slug}", "{$module}.dict.{$slug}"],
+            'vch'  => ["{$module}.vch.{$slug}", "{$module}.{$slug}"],
+            'rpt'  => ["{$module}.rpt.{$slug}", "{$module}.{$slug}"],
+            'proc' => ["{$module}.proc.{$slug}", "{$module}.process.{$slug}", "{$module}.{$slug}"],
+            default => ["{$module}.{$kind}.{$slug}"],
+        };
+    }
+
+    private function componentForRoute(?LaravelRoute $route): ?string
+    {
+        if (null === $route) {
+            return null;
+        }
+
+        $action = $route->getActionName();
+        if (!str_contains($action, '@') && class_exists($action)) {
+            return $action;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function paramsForRoute(?LaravelRoute $route): array
+    {
+        if (null === $route) {
+            return [];
+        }
+
+        $defaults = $route->defaults;
+        unset($defaults['controller'], $defaults['namespace'], $defaults['prefix'], $defaults['where'], $defaults['as']);
+
+        return $defaults;
+    }
+
+    private function titleFor(string $routeName, array $metadata, ?LaravelRoute $route): string
+    {
+        $defaults = $route?->defaults ?? [];
+        if (isset($defaults['title']) && '' !== $defaults['title']) {
+            return (string) $defaults['title'];
+        }
+
+        return $metadata['title'] ?? $routeName;
+    }
+}


### PR DESCRIPTION
## Summary

Hai thay đổi xoay quanh SimbaPage (Livewire thống nhất):

1. **Unify 3 Livewire cũ → 1 SimbaPage**: gom SimbaDictionaryIndex, SimbaProcessIndex, SimbaReportIndex về một Livewire duy nhất, route group `simba.` với `simba.index` + `simba.show`. Menu URL resolve qua `SimbaMenuTargetResolver` theo route name + source_type.
2. **Shell metadata cho route chưa có component**: khi route resolve được nhưng chưa có Livewire component (dictionary/report/voucher/process mới thêm từ simba-docs), page vẫn render được — hiển thị bảng key-value lấy từ `SimbaDictionaryRegistry` / `SimbaReportRegistry` / `SimbaProcessMetadata` để audit biết route map sang SP/bảng nào.

## Changes

**New files**
- `diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaPage.php` (47 lines) — Livewire thống nhất, inject resolver qua `boot()`
- `diepxuan/laravel-catalog/src/Services/SimbaMenuTargetResolver.php` (211 lines) — service resolve menu URL theo route name + source_type, bao gồm `enrichMetadata()` merge full metadata từ registry tương ứng
- `diepxuan/laravel-catalog/resources/views/system/simba-page.blade.php` (47 lines) — view cho SimbaPage, include partial khi `component === null`
- `diepxuan/laravel-catalog/resources/views/system/simba-page-metadata.blade.php` (113 lines) — partial mới: routeName/menuid/source_type/module + fields theo source_type
  - dictionary: code_name / table / pk / fields / source_menuid
  - report: spname / rptname / ma_mau / dll / command / source_menuid / press_key_name
  - voucher: ma_ct
  - custom (process): dll / command / code_name

**Modified**
- `diepxuan/laravel-catalog/routes/web.php` — thay 3 routes (simba.dictionary / simba.report / simba.process) bằng group `simba.` với `simba.index` + `simba.show`
- `diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php` — dùng SimbaMenuTargetResolver thay cho `match()` inline
- `.gitignore` — thêm `.hermes/`

**Removed (implicit)**
- 3 Livewire cũ (SimbaDictionaryIndex, SimbaProcessIndex, SimbaReportIndex) không còn được reference trong routes; nếu không dùng nơi khác cần dọn ở PR sau.

## How shell metadata works

```
HTTP /simba/gl/rpt/ctgs01
  → Route `simba.show` → SimbaPage::mount
  → SimbaMenuTargetResolver::resolveRouteName(`gl.rpt.ctgs01`)
      ├─ base metadata: {module: GL, menuid: 02.20.11, source_type: report}
      └─ enrichMetadata():
           source_type=report → SimbaReportRegistry::get(`gl.rpt.ctgs01`)
           → merge {spname, rptname, ma_mau, dll_name, command, ...}
  → target.metadata = {module, menuid, source_type, spname, rptname, ma_mau, ...}
  → component = null (no Livewire for this route yet)
  → view renders amber note + simba-page-metadata partial
```

Base metadata (module/menuid/source_type) ưu tiên cao nhất qua `array_merge($extra, $metadata)` — registry chỉ bổ sung field, không overwrite field có sẵn.

`SimbaPage` inject resolver qua `boot()` thay vì `mount()` để tránh Livewire 3 resolve lại dependency mỗi request.

## Verification

- `php -l` pass sạch cho 5 file PHP/Blade
- Pre-commit hook chạy OK (JS/TS format check)
- Push OK lên `task/simba-page-component` (commit `b800c89ce`)
- Không tự ý đổi config, model, controller ngoài scope

## Out of scope (PR sau nếu cần)

- Cleanup 3 file Livewire cũ nếu không còn chỗ nào dùng
- Test coverage cho SimbaPage + resolver + enrichMetadata
- Docs update cho module Simba navigation