### PR TITLE
feat(catalog): add system dropdown navigation

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/navigation-menu.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/navigation-menu.blade.php
@@ -18,9 +18,40 @@
                     <x-nav-link :href="route('simba.index')" :active="$this->isActive('simba.index', 'simba.show')" class="w-full md:w-auto">
                         {{ __('Simba ERP') }}
                     </x-nav-link>
-                    <x-nav-link :href="route('system.system')" :active="$this->isActive('system.system')" class="w-full md:w-auto">
-                        {{ __('Hệ thống') }}
-                    </x-nav-link>
+                    <div class="group relative w-full md:w-auto" x-data="{ openSystem: false }">
+                        <x-nav-link href="#" :active="$this->isActive('system', 'system.*')" class="min-h-16 w-full md:w-auto"
+                            @click.prevent="openSystem = !openSystem">
+                            {{ __('Hệ thống') }}
+                        </x-nav-link>
+                        <div x-cloak x-show="openSystem" @click.outside="openSystem = false" x-transition
+                            class="z-40 mt-0 bg-white md:absolute md:left-0 md:top-full md:w-64 md:space-y-1 md:rounded-lg md:border md:py-2 md:shadow-lg md:group-hover:block">
+                            <x-nav-link :href="route('system.system')" :active="$this->isActive('system.system')"
+                                class="w-full border-transparent ps-4 hover:border-transparent focus:border-transparent md:px-3">
+                                {{ __('Khoá số liệu') }}
+                            </x-nav-link>
+                            <x-nav-link :href="route('system.company')" :active="$this->isActive('system.company')"
+                                class="w-full border-transparent ps-4 hover:border-transparent focus:border-transparent md:px-3">
+                                {{ __('Đơn vị') }}
+                            </x-nav-link>
+                            <x-nav-link :href="route('system.year')" :active="$this->isActive('system.year')"
+                                class="w-full border-transparent ps-4 hover:border-transparent focus:border-transparent md:px-3">
+                                {{ __('Năm làm việc') }}
+                            </x-nav-link>
+                            <x-nav-link :href="route('system.balance.index')" :active="$this->isActive('system.balance')"
+                                class="w-full border-transparent ps-4 hover:border-transparent focus:border-transparent md:px-3">
+                                {{ __('Nhập/Chuyển số dư') }}
+                            </x-nav-link>
+                            <div class="border-t border-gray-200"></div>
+                            <x-nav-link :href="route('system.user.index')" :active="$this->isActive('system.user')"
+                                class="w-full border-transparent ps-4 hover:border-transparent focus:border-transparent md:px-3">
+                                {{ __('Người dùng') }}
+                            </x-nav-link>
+                            <x-nav-link :href="route('system.website.index')" :active="$this->isActive('system.website')"
+                                class="w-full border-transparent ps-4 hover:border-transparent focus:border-transparent md:px-3">
+                                {{ __('Website') }}
+                            </x-nav-link>
+                        </div>
+                    </div>
                 </div>
 
                 <div class="hidden min-h-16 md:ms-6 md:flex" :class="{ 'block': open, 'hidden': !open }">

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -721,8 +721,6 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
         Route::get('/nhom-cong-trinh', CoDictionaryIndex::class)->defaults('routeName', 'co.dmnhspct')->name('dmnhspct');
     });
 
-    Route::get('hethong/system', Dashboard::class)->name('system.system');
-    Route::get('hethong/company', CompanySelector::class)->name('system.company');
     Route::get('/si/congcu/dong-bo-he-thong', TaskShell::class)->defaults('title', 'Đồng bộ hệ thống')->defaults('dll', 'SIUtilities.dll')->defaults('task', 'Task 081')->name('si.tool.sync');
     Route::get('/si/danhmuc/tuy-chon-10', TaskShell::class)->defaults('title', 'Danh mục tùy chọn 10')->defaults('dll', 'SIDM10.dll')->defaults('task', 'Task 082')->name('si.dict.option10');
     Route::get('/si/thongtin/chuong-trinh', TaskShell::class)->defaults('title', 'Thông tin chương trình')->defaults('dll', 'SIAbout.dll')->defaults('task', 'Task 083')->name('si.info.program');
@@ -740,22 +738,27 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
         Route::get('/khoan-muc-phi', SiDictionaryIndex::class)->defaults('routeName', 'si.dmphi')->name('dmphi');
         Route::get('/ngoai-te', SiDictionaryIndex::class)->defaults('routeName', 'si.dmnt')->name('dmnt');
     });
-    Route::resource('hethong/user', SystemUserController::class)->names('system.user');
-    Route::resource('hethong/website', SystemWebsiteController::class)->names('system.website');
-    Route::get('hethong/year', YearSelector::class)->name('system.year');
 
-    // Balance Management Routes - Livewire Components
-    Route::prefix('hethong/balance')->name('system.balance.')->group(static function (): void {
-        Route::get('/', BalanceIndex::class)->name('index');
-        Route::get('/account-opening', AccountOpening::class)->name('account-opening');
-        Route::get('/transfer', Transfer::class)->name('transfer');
-        Route::get('/accounts-receivable', AccountsReceivable::class)->name('accounts-receivable');
-        Route::get('/accounts-payable', AccountsPayable::class)->name('accounts-payable');
-        Route::get('/inventory-opening', InventoryOpening::class)->name('inventory-opening');
-        Route::get('/inventory-opening-ntxt', InventoryOpeningNtxt::class)->name('inventory-opening-ntxt');
-        Route::get('/inventory-transfer', InventoryTransfer::class)->name('inventory-transfer');
-        Route::get('/work-in-progress', WorkInProgress::class)->name('work-in-progress');
-        Route::get('/cumulative-transactions', CumulativeTransactions::class)->name('cumulative-transactions');
+    Route::prefix('hethong')->name('system.')->group(static function (): void {
+        Route::get('system', Dashboard::class)->name('system');
+        Route::get('company', CompanySelector::class)->name('company');
+        Route::resource('user', SystemUserController::class)->names('user');
+        Route::resource('website', SystemWebsiteController::class)->names('website');
+        Route::get('year', YearSelector::class)->name('year');
+
+        // Balance Management Routes - Livewire Components
+        Route::prefix('balance')->name('balance.')->group(static function (): void {
+            Route::get('/', BalanceIndex::class)->name('index');
+            Route::get('/account-opening', AccountOpening::class)->name('account-opening');
+            Route::get('/transfer', Transfer::class)->name('transfer');
+            Route::get('/accounts-receivable', AccountsReceivable::class)->name('accounts-receivable');
+            Route::get('/accounts-payable', AccountsPayable::class)->name('accounts-payable');
+            Route::get('/inventory-opening', InventoryOpening::class)->name('inventory-opening');
+            Route::get('/inventory-opening-ntxt', InventoryOpeningNtxt::class)->name('inventory-opening-ntxt');
+            Route::get('/inventory-transfer', InventoryTransfer::class)->name('inventory-transfer');
+            Route::get('/work-in-progress', WorkInProgress::class)->name('work-in-progress');
+            Route::get('/cumulative-transactions', CumulativeTransactions::class)->name('cumulative-transactions');
+        });
     });
 
     // Route::get('/', [SystemController::class, 'index']);


### PR DESCRIPTION
## Summary
- Convert the fixed `Hệ thống` top-nav item into a dropdown.
- Add system submenu links for lock date, company, work year, balance tools, users, and website management.
- Regroup existing `hethong/*` routes under a shared `system.` prefix without changing the public URLs or route names.

## Review notes
- No database-backed menu is restored; this remains fixed navigation.
- `system.menu` remains removed.
- The Simba ERP menu remains isolated under `/simba` and is not rendered in the global navigation.

## Verification
- `php artisan view:clear`
- `php artisan route:list --name=system --name=si.dm`
- Verified route URLs with `Route::has()`/`route(..., false)` for:
  - `system.system`
  - `system.company`
  - `system.year`
  - `system.balance.index`
  - `system.user.index`
  - `system.website.index`
  - `si.dmct`
  - `si.dmphi`
  - `si.dmnt`
- `php -l diepxuan/laravel-catalog/routes/web.php`
- `git diff --check`
