### PR TITLE
fix: align Simba routes with actual menu metadata

### DIFF
--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -164,7 +164,7 @@ final class SimbaMenuRouteMetadata
     private function sourceTypeFor(SysMenu $menu): ?string
     {
         $type = (string) $menu->type;
-        if (SysMenu::TYPE_MODULE_ROOT === $type || SysMenu::TYPE_GROUP === $type) {
+        if (SysMenu::TYPE_MODULE_ROOT === $type) {
             return null;
         }
 
@@ -177,7 +177,11 @@ final class SimbaMenuRouteMetadata
         }
 
         if (SysMenu::TYPE_REPORT === $type || (bool) $menu->report) {
-            return SimbaMenuRouteMetadata::TYPE_REPORT;
+            if ($this->hasCallableMetadata($menu) || null !== $this->reportRow($menu)) {
+                return SimbaMenuRouteMetadata::TYPE_REPORT;
+            }
+
+            return null;
         }
 
         if ($this->hasCallableMetadata($menu)) {

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
@@ -10,11 +10,29 @@ use PHPUnit\Framework\TestCase;
 
 final class SimbaMenuRouteMetadataTest extends TestCase
 {
-    public function testSkipsRootAndGroupMenus(): void
+    public function testSkipsRootAndEmptyGroupMenus(): void
     {
         $metadata = $this->metadata([
-            $this->menu('02.00.00', SysMenu::TYPE_MODULE_ROOT, 'GL', 'GL'),
-            $this->menu('02.10.00', SysMenu::TYPE_GROUP, 'GL', 'Data'),
+            $this->menu('02.00.00', SysMenu::TYPE_MODULE_ROOT, 'GL', ''),
+            $this->menu('02.10.00', SysMenu::TYPE_GROUP, 'GL', ''),
+        ]);
+
+        self::assertSame([], $metadata->routes());
+    }
+
+    public function testGroupMenuWithReportFlagAndCallableMetadataGetsReportRoute(): void
+    {
+        $metadata = $this->metadata([
+            $this->menu('02.80.02', SysMenu::TYPE_GROUP, 'GL', 'F5GLRptTH01', report: true),
+        ]);
+
+        self::assertSame(SimbaMenuRouteMetadata::TYPE_REPORT, $metadata->routes()['gl.rpt.f5glrptth01']['source_type']);
+    }
+
+    public function testReportHeaderWithoutCallableMetadataIsSkipped(): void
+    {
+        $metadata = $this->metadata([
+            $this->menu('02.25.00', SysMenu::TYPE_REPORT, 'GL', '', report: true),
         ]);
 
         self::assertSame([], $metadata->routes());

--- a/docs/project/simba-menu-route-review.md
+++ b/docs/project/simba-menu-route-review.md
@@ -1,0 +1,72 @@
+# SimbaERP Menu Route Review
+
+Ngày review: 2026-06-19
+
+## Nguồn dữ liệu
+
+Review dựa trên menu thực tế từ MSSQL SimbaERP trên server `web`, đọc qua `SimbaMenuRepository::activeMenus()`.
+
+Kết quả audit trước khi sửa classifier:
+
+```json
+{
+  "active_count": 357,
+  "type_counts": {"5": 9, "": 69, "1": 67, "6": 9, "4": 152, "2": 48, "3": 3},
+  "route_counts": {"voucher": 67, "custom": 10, "report": 152, "dictionary": 48},
+  "route_count": 277,
+  "unrouted_count": 42,
+  "missing_count": 57
+}
+```
+
+## Sai lệch phát hiện
+
+### 1. Menu F5 report bị bỏ route
+
+Nhiều menu thực tế có:
+
+- `type = ''`
+- `report = true`
+- có `dllName` / `command`
+
+Ví dụ:
+
+- `02.80.02` GL `F5GLRptTH01`
+- `06.80.02` SO `Framework` / `frmDrilldownReport`
+- `10.80.02` PO `Framework` / `frmDrilldownReport`
+- `14.80.02` IN `INRptF5CD02`
+
+Code cũ bỏ qua `TYPE_GROUP` trước khi xét `report`, nên các menu F5 này không có route dù là menu action thực tế.
+
+### 2. Header report bị tạo route thừa
+
+Một số menu header có:
+
+- `type = '4'` hoặc `report = true`
+- không có `dllName`, `command`, `code_name`
+- không có row report metadata
+
+Ví dụ:
+
+- `02.25.00` Báo cáo Nhật ký chung
+- `02.20.00` Báo cáo Chứng từ ghi sổ
+- `06.20.00` Báo cáo Bán hàng
+- `10.20.00` Báo cáo Mua hàng
+
+Các dòng này là container/header, không nên sinh route shell riêng.
+
+## Quy tắc route sau khi sửa
+
+- `TYPE_MODULE_ROOT` luôn là container, không sinh route.
+- `TYPE_MASTER` sinh dictionary route.
+- `TYPE_VOUCHER` sinh voucher route.
+- `TYPE_REPORT` hoặc `report = true` chỉ sinh report route khi:
+  - có callable metadata (`dllName` / `command` / `code_name`), hoặc
+  - có row report metadata trong `SysReportInfo` / `ZSysReportInfo`.
+- Menu còn lại có callable metadata sinh custom/process route.
+- Menu trống không callable metadata không sinh route.
+
+## Test bổ sung
+
+- Group menu có `report = true` + callable metadata phải sinh report route.
+- Header report không callable metadata phải bị skip.


### PR DESCRIPTION
## Summary
- Review Simba route generation against actual MSSQL SimbaERP menu data from server web.
- Fix classifier so F5 report menus with type='' but report=true and callable metadata get report routes.
- Skip report header/container rows that have no callable metadata and no report metadata row.
- Add unit coverage and route review doc.

## Evidence from actual SimbaERP menu audit
- Active menus: 357
- Menu type counts: type 5 = 9, type '' = 69, type 1 = 67, type 6 = 9, type 4 = 152, type 2 = 48, type 3 = 3
- Found 42 actionable-looking menus without routes before fix; these were mainly F5 reports with type='' and report=true.
- Found report header rows being routed despite no dllName/command/code_name/report metadata.

## Verification
- php -l diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
- php -l diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
- vendor/bin/phpunit diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php

## Notes
- Audit was performed via ssh root@web using live MSSQL-backed Laravel app because local runtime lacks Microsoft ODBC Driver for SQL Server.