### PR TITLE
fix: import dictionary metadata model

### DIFF
--- a/diepxuan/laravel-catalog/src/Models/SysDictionaryInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/SysDictionaryInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-06-21 07:31:00
+ */
+
+namespace Diepxuan\Catalog\Models;
+
+use Diepxuan\Simba\Models\SysDictionaryInfo as SimbaModel;
+
+/**
+ * Model SysDictionaryInfo - SimbaERP dictionary metadata (catalog layer).
+ *
+ * Mở rộng từ Simba SysDictionaryInfo để Catalog dùng model nội bộ thay vì import trực tiếp model Simba.
+ */
+class SysDictionaryInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Services;
 
 use Diepxuan\Catalog\Models\SysMenu;
+use Diepxuan\Simba\Models\SysDictionaryInfo;
 
 final class SimbaMenuRouteMetadata
 {

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -336,16 +336,9 @@ final class SimbaMenuRouteMetadata
         }
 
         $menuid = (string) $menu->menuid;
-        $row = app(SimbaMetadataService::class)
-            ->get(SimbaMetadataService::DATASET_SYS_REPORT_INFO)
-            ->first(static fn ($row): bool => $menuid === (string) $row->menuid)
-        ;
-        if (null !== $row) {
-            return $row;
-        }
 
         return app(SimbaMetadataService::class)
-            ->get(SimbaMetadataService::DATASET_ZSYS_REPORT_INFO)
+            ->get(SimbaMetadataService::DATASET_SYS_REPORT_INFO)
             ->first(static fn ($row): bool => $menuid === (string) $row->menuid)
         ;
     }

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
+use Diepxuan\Catalog\Models\SysDictionaryInfo;
 use Diepxuan\Catalog\Models\SysMenu;
-use Diepxuan\Simba\Models\SysDictionaryInfo;
 
 final class SimbaMenuRouteMetadata
 {

--- a/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
@@ -30,7 +30,6 @@ class SimbaMetadataService
     public const DATASET_SYS_DICTIONARY_INFO = 'sys_dictionary_info';
     public const DATASET_SYS_REPORT_DRILL_DOWN_INFO = 'sys_report_drill_down_info';
     public const DATASET_SYS_REPORT_INFO = 'sys_report_info';
-    public const DATASET_ZSYS_REPORT_INFO = 'zsys_report_info';
 
     /** @var array<string, Collection|EloquentCollection> */
     private array $loaded = [];
@@ -46,7 +45,6 @@ class SimbaMetadataService
             self::DATASET_SYS_DICTIONARY_INFO,
             self::DATASET_SYS_REPORT_DRILL_DOWN_INFO,
             self::DATASET_SYS_REPORT_INFO,
-            self::DATASET_ZSYS_REPORT_INFO,
         ];
     }
 
@@ -119,8 +117,7 @@ class SimbaMetadataService
             self::DATASET_SYS_MENU => $this->mergedMenus(),
             self::DATASET_SYS_DICTIONARY_INFO => SysDictionaryInfo::query()->get(),
             self::DATASET_SYS_REPORT_DRILL_DOWN_INFO => SysReportDrillDownInfo::query()->get(),
-            self::DATASET_SYS_REPORT_INFO => SysReportInfo::query()->get(),
-            self::DATASET_ZSYS_REPORT_INFO => ZSysReportInfo::query()->get(),
+            self::DATASET_SYS_REPORT_INFO => $this->mergedReportInfo(),
         };
     }
 
@@ -134,6 +131,19 @@ class SimbaMetadataService
             ->merge(Zsysmenu::query()->get())
             ->filter(static fn (SysMenu $menu): bool => '' !== trim((string) $menu->menuid))
             ->unique(static fn (SysMenu $menu): string => (string) $menu->menuid)
+            ->values()
+        ;
+    }
+
+    /**
+     * @return Collection<int, SysReportInfo>
+     */
+    protected function mergedReportInfo(): Collection
+    {
+        return SysReportInfo::query()
+            ->get()
+            ->merge(ZSysReportInfo::query()->get())
+            ->filter(static fn (SysReportInfo $report): bool => '' !== trim((string) $report->menuid))
             ->values()
         ;
     }

--- a/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
+use Diepxuan\Catalog\Models\SysDictionaryInfo;
 use Diepxuan\Catalog\Models\SysMenu;
 use Diepxuan\Catalog\Models\Zsysmenu;
 use Diepxuan\Simba\Models\SiDmCt;
-use Diepxuan\Simba\Models\SysDictionaryInfo;
 use Diepxuan\Simba\Models\SysReportDrillDownInfo;
 use Diepxuan\Simba\Models\SysReportInfo;
 use Diepxuan\Simba\Models\ZSysReportInfo;

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
@@ -19,7 +19,6 @@ final class SimbaMetadataServiceTest extends TestCase
             SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO,
             SimbaMetadataService::DATASET_SYS_REPORT_DRILL_DOWN_INFO,
             SimbaMetadataService::DATASET_SYS_REPORT_INFO,
-            SimbaMetadataService::DATASET_ZSYS_REPORT_INFO,
         ], $service->datasets());
     }
 


### PR DESCRIPTION
## Summary
- Add the missing SysDictionaryInfo import in SimbaMenuRouteMetadata so dictionaryRow() resolves to Diepxuan\Simba\Models\SysDictionaryInfo instead of the service namespace.

## Verification
- php -l diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
- php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php