### PR TITLE
refactor(simba): deduplicate schema in four metadata models

### DIFF
--- a/diepxuan/laravel-simba/src/Models/SiDmCt.php
+++ b/diepxuan/laravel-simba/src/Models/SiDmCt.php
@@ -8,85 +8,32 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-06-05 20:58:00
+ * @lastupdate 2026-06-21
  */
 
 namespace Diepxuan\Simba\Models;
 
-use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\Models\Concerns\HasSimbaCompositeKey;
+use Diepxuan\Simba\SModel\SiDmCtModel as SModel;
 
 /**
  * Model SiDmCt - Khai báo màn hình nhập chứng từ.
  *
  * Source: simba-docs/tables/SiDmCt.md.
+ *
+ * Schema nằm trọn ở `SiDmCtModel`. Model này chỉ giữ behavior Simba-level
+ * và `HasSimbaCompositeKey` để thao tác theo composite primary key
+ * (ma_cty, ma_ct) an toàn.
  */
 class SiDmCt extends SModel
 {
-    public $incrementing  = false;
-    public $timestamps    = false;
-    protected $table      = 'SiDmCt';
-    protected $primaryKey = 'ma_ct';
-    protected $keyType    = 'string';
-
-    protected $fillable = [
-        'ma_cty',
-        'ma_ct',
-        'phan_he',
-        'ma_ct_me',
-        'ten_ct',
-        'tk_no',
-        'tk_co',
-        'ma_nt',
-        'so_lien',
-        'stt_nkc',
-        'stt_ntxt',
-        'ct_dc',
-        'loc_nsd',
-        'vv',
-        'spct',
-        'phi',
-        'bp',
-        'lo',
-        'sp_post',
-        'sp_process',
-        'ph',
-        'ct',
-        'sd',
-        'nxt',
-        'menuid',
-        'vn_prefix',
-        'vn_postfix',
-        'vn_sequence',
-        'vn_pattern',
-        'vn_width',
-        'PhFieldlist2IN',
-        'CtFieldlist2IN',
-        'kieu_trung_so_ct',
-        'VoucherGetWhenOpenForm',
-    ];
-
-    protected $casts = [
-        'so_lien'         => 'integer',
-        'stt_nkc'         => 'integer',
-        'stt_ntxt'        => 'integer',
-        'ct_dc'           => 'boolean',
-        'loc_nsd'         => 'boolean',
-        'vv'              => 'boolean',
-        'spct'            => 'boolean',
-        'phi'             => 'boolean',
-        'bp'              => 'boolean',
-        'lo'              => 'boolean',
-        'sd'              => 'boolean',
-        'vn_sequence'            => 'integer',
-        'vn_width'               => 'integer',
-        'kieu_trung_so_ct'       => 'integer',
-        'VoucherGetWhenOpenForm' => 'boolean',
-    ];
+    use HasSimbaCompositeKey;
 
     /**
-     * Scope: find voucher metadata by company and voucher code.
+     * Scope: tìm voucher metadata theo mã công ty + mã chứng từ.
      *
-     * @param mixed $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeVoucher($query, string $maCt, string $maCty = SModel::CTY)
     {
@@ -94,9 +41,10 @@ class SiDmCt extends SModel
     }
 
     /**
-     * Scope: find voucher metadata by Simba menuid.
+     * Scope: tìm voucher metadata theo menuid.
      *
-     * @param mixed $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeMenuId($query, string $menuId)
     {
@@ -104,6 +52,8 @@ class SiDmCt extends SModel
     }
 
     /**
+     * Lấy danh sách cột header cho nhập kho từ cột PhFieldlist2IN.
+     *
      * @return list<string>
      */
     public function headerFieldsForInventory(): array
@@ -112,6 +62,8 @@ class SiDmCt extends SModel
     }
 
     /**
+     * Lấy danh sách cột detail cho nhập kho từ cột CtFieldlist2IN.
+     *
      * @return list<string>
      */
     public function detailFieldsForInventory(): array

--- a/diepxuan/laravel-simba/src/Models/SysDictionaryInfo.php
+++ b/diepxuan/laravel-simba/src/Models/SysDictionaryInfo.php
@@ -8,64 +8,26 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-06-05 20:58:00
+ * @lastupdate 2026-06-21
  */
 
 namespace Diepxuan\Simba\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use Diepxuan\Simba\SModel\sysDictionaryInfoModel as SModel;
 
 /**
- * SimbaERP sysDictionaryInfo table model.
+ * SimbaERP sysDictionaryInfo model.
  *
  * Source: simba-docs/tables/sysDictionaryInfo.md.
+ *
+ * Schema (table, primaryKey, keyType, fillable, casts, timestamps) is owned
+ * by `sysDictionaryInfoModel`; this class only adds Simba-level helpers.
  */
-class SysDictionaryInfo extends Model
+class SysDictionaryInfo extends SModel
 {
-    public $incrementing  = false;
-    public $timestamps    = false;
-    protected $connection = 'sqlsrv';
-    protected $table      = 'sysDictionaryInfo';
-    protected $primaryKey = 'code_name';
-    protected $keyType    = 'string';
-
-    protected $fillable = [
-        'code_name',
-        'PK',
-        'code_fname',
-        'code_length',
-        'name_fname',
-        'table_name',
-        'menuid',
-        'lookup_when_invalid',
-        'allow_merge_code',
-        'dllname',
-        'view_class_name',
-        'edit_class_name',
-        'carry_field_list',
-        'default_sort',
-        'copy_vaora',
-        'par0',
-        'par1',
-        'par2',
-        'par3',
-        'par4',
-        'par5',
-        'par6',
-        'par7',
-        'par8',
-        'par9',
-        'description',
-    ];
-
-    protected $casts = [
-        'code_length'         => 'integer',
-        'lookup_when_invalid' => 'boolean',
-        'allow_merge_code'    => 'boolean',
-        'copy_vaora'          => 'boolean',
-    ];
-
     /**
+     * Lấy danh sách cột khóa chính từ cột PK (chuỗi phân tách bằng dấu phẩy).
+     *
      * @return list<string>
      */
     public function primaryKeyFields(): array
@@ -74,6 +36,8 @@ class SysDictionaryInfo extends Model
     }
 
     /**
+     * Lấy danh sách cột carry từ cột carry_field_list.
+     *
      * @return list<string>
      */
     public function carryFields(): array
@@ -82,9 +46,10 @@ class SysDictionaryInfo extends Model
     }
 
     /**
-     * Scope: find dictionary metadata by Simba code_name.
+     * Scope: tìm dictionary metadata theo code_name.
      *
-     * @param mixed $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeCodeName($query, string $codeName)
     {
@@ -92,9 +57,10 @@ class SysDictionaryInfo extends Model
     }
 
     /**
-     * Scope: find dictionary metadata by Simba menuid.
+     * Scope: tìm dictionary metadata theo menuid.
      *
-     * @param mixed $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeMenuId($query, string $menuId)
     {

--- a/diepxuan/laravel-simba/src/Models/SysReportDrillDownInfo.php
+++ b/diepxuan/laravel-simba/src/Models/SysReportDrillDownInfo.php
@@ -2,17 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-21
+ */
+
 namespace Diepxuan\Simba\Models;
 
-use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\Models\Concerns\HasSimbaCompositeKey;
+use Diepxuan\Simba\SModel\sysReportDrillDownInfoModel as SModel;
 
+/**
+ * SimbaERP sysReportDrillDownInfo model.
+ *
+ * Source: simba-docs/tables/sysReportDrillDownInfo.md.
+ *
+ * Schema nằm trọn ở `sysReportDrillDownInfoModel`. Model này chỉ bổ sung
+ * `HasSimbaCompositeKey` để thao tác theo composite primary key
+ * (menuid, ma_mau, press_key_name) an toàn.
+ */
 class SysReportDrillDownInfo extends SModel
 {
-    public $incrementing = false;
-    public $timestamps = false;
-    protected $table = 'sysReportDrillDownInfo';
-    protected $primaryKey = 'menuid';
-    protected $keyType = 'string';
-
-    protected $fillable = ['menuid','ma_mau','press_key_name','drilldown_menuid','drilldown_menuid1','drilldown_menuid2','drilldown_menuid3','drilldown_menuid4','dllName','command','description','par0','par1','par2','par3','par4','par5','par6','par7','par8','par9'];
+    use HasSimbaCompositeKey;
 }

--- a/diepxuan/laravel-simba/src/Models/SysReportInfo.php
+++ b/diepxuan/laravel-simba/src/Models/SysReportInfo.php
@@ -2,24 +2,29 @@
 
 declare(strict_types=1);
 
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-21
+ */
+
 namespace Diepxuan\Simba\Models;
 
-use Diepxuan\Simba\SModel\SModel;
+use Diepxuan\Simba\Models\Concerns\HasSimbaCompositeKey;
+use Diepxuan\Simba\SModel\sysReportInfoModel as SModel;
 
+/**
+ * SimbaERP sysReportInfo model.
+ *
+ * Source: simba-docs/tables/sysReportInfo.md.
+ *
+ * Schema nằm trọn ở `sysReportInfoModel`. Model này chỉ bổ sung
+ * `HasSimbaCompositeKey` để thao tác theo composite primary key
+ * (menuid, ma_mau) an toàn.
+ */
 class SysReportInfo extends SModel
 {
-    public $incrementing = false;
-    public $timestamps = false;
-    protected $table = 'sysReportInfo';
-    protected $primaryKey = 'menuid';
-    protected $keyType = 'string';
-
-    protected $fillable = ['menuid','ma_mau','ctlclass','spname','rptname','isdefault','bang_chu','bang_chu0','hasNT','dynReportFields','par0','par1','par2','par3','par4','par5','par6','par7','par8','par9','description_colname'];
-
-    protected $casts = [
-        'isdefault' => 'boolean',
-        'bang_chu' => 'boolean',
-        'bang_chu0' => 'boolean',
-        'hasNT' => 'boolean',
-    ];
+    use HasSimbaCompositeKey;
 }

--- a/docs/project/simba-model-layer-refactor-plan.md
+++ b/docs/project/simba-model-layer-refactor-plan.md
@@ -29,6 +29,8 @@ Tách rõ trách nhiệm 3 lớp model:
 ## Trạng thái đã làm trong PR #217
 
 PR: https://github.com/diepxuan/portal/pull/217
+Merge commit: `ac8212c08` — `refactor: document simba model layers (#217)`
+Commit cuối trong PR: `48be82c74` — `feat(simba): add direct models for generated schema`
 
 Đã hoàn tất:
 
@@ -50,6 +52,34 @@ PR: https://github.com/diepxuan/portal/pull/217
   - `SysUserInfo` -> `sysUserInfoModel`
 - `SysMenu` giữ trỏ về `SysMenuModel` mới/chuẩn vì file này đã có metadata đầy đủ hơn generated cũ `sysMenuModel`.
 - Không đổi public model class để tránh phá caller hiện tại.
+- Quy tắc primary key đã chốt và áp dụng cho toàn bộ 441 SModel:
+  - Bỏ `ma_cty` làm `$primaryKey` generic.
+  - Composite PK > 3 cột dùng `null` + `PRIMARY_KEY_COLUMNS`.
+  - Composite PK 2-3 cột chọn key đại diện không phải `ma_cty` (ưu tiên `stt_rec`).
+  - Bảng setup chỉ có `ma_cty` thì `null` + `PRIMARY_KEY_COLUMNS`.
+- Xóa 13 file SModel legacy không hậu tố `Model` không còn tham chiếu.
+- Tạo `diepxuan/laravel-simba/src/Models/Concerns/HasSimbaCompositeKey.php` với:
+  - `getPrimaryKeyColumns()`
+  - `getRepresentativeKeyName()`
+  - `scopeForCompositeKey()` (bắt buộc đủ PRIMARY_KEY_COLUMNS)
+  - `scopeForCompany()`
+  - `findByCompositeKey()`
+  - `updateByCompositeKey()`
+  - `deleteByCompositeKey()`
+  - `compositeKeyAttributes()`
+  - `compositeKeyString()`
+  - `assertCompositeKey()`
+- Bổ sung đầy đủ Models trực tiếp cho từng SModel:
+  - SModel classes: 441
+  - Models files: 445 (441 direct table + 4 alias hiện hữu)
+  - Models có `HasSimbaCompositeKey`: 342
+- Cập nhật `diepxuan/laravel-simba/README.md` cho đúng chuẩn `<Table>Model` và ví dụ code.
+
+Số liệu cuối PR #217:
+- Lint pass: 446 file PHP trong Models + Concerns
+- `class_exists` check: 445/445 pass
+- `git diff --check` pass
+- CI PR #217: 14/14 pass, mergeable, mergeStateStatus CLEAN.
 
 ---
 
@@ -96,6 +126,49 @@ Cần kiểm tra SModel generated tương ứng rồi refactor để:
 - Schema nằm ở `SModel`.
 - Behavior/helper nằm ở `Models`.
 - Catalog cache/service nằm ở `laravel-catalog`.
+
+### Trạng thái Phase 3 (đang thực hiện)
+
+PR: `task/simba-model-layer-phase3-schema-refactor`
+
+Audit SModel generated đã có:
+
+| Model | SModel generated | PRIMARY_KEY_COLUMNS | Ghi chú |
+|-------|------------------|----------------------|---------|
+| `SysDictionaryInfo` | `sysDictionaryInfoModel` | (single PK `code_name`) | Có behavior: `primaryKeyFields`, `carryFields`, `scopeCodeName`, `scopeMenuId` |
+| `SysReportInfo` | `sysReportInfoModel` | `['menuid', 'ma_mau']` | Composite 2 cột, không có behavior, model cũ dùng `SModel` base |
+| `SysReportDrillDownInfo` | `sysReportDrillDownInfoModel` | `['menuid', 'ma_mau', 'press_key_name']` | Composite 3 cột, không có behavior, model cũ dùng `SModel` base |
+| `SiDmCt` | `SiDmCtModel` | `['ma_cty', 'ma_ct']` | Có behavior: `scopeVoucher`, `scopeMenuId`, `headerFieldsForInventory`, `detailFieldsForInventory` |
+
+Sai lệch schema cần đối chiếu giữa Model cũ và SModel generated:
+
+- `SysReportInfo`:
+  - Model cũ cast `bang_chu`, `bang_chu0`, `hasNT` là `boolean`.
+  - SModel generated chỉ cast `isdefault` là `boolean`.
+  - Cần đối chiếu `simba-docs/tables/sysReportInfo.md` để xác định đúng; mặc định lấy theo SModel generated vì là nguồn sinh từ docs.
+- `SiDmCt`:
+  - Model cũ cast `VoucherGetWhenOpenForm` là `boolean`.
+  - SModel generated cast là `integer`.
+  - Cần đối chiếu `simba-docs/tables/SiDmCt.md` để xác định đúng.
+
+Hướng xử lý:
+
+1. Refactor 4 Model để chỉ extend SModel generated, không khai báo lại schema (`$table`, `$primaryKey`, `$keyType`, `$fillable`, `$casts`, `$timestamps`, `$incrementing`, `$connection`).
+2. Sử dụng `HasSimbaCompositeKey` trait cho các Model có composite PK (`SysReportInfo`, `SysReportDrillDownInfo`, `SiDmCt`).
+3. Behavior hiện có giữ nguyên trong Model.
+4. Các sai lệch casts nếu được chứng minh đúng từ docs sẽ được ghi đè trong Model bằng cast override, có comment giải thích nguồn từ docs.
+
+Các bước còn lại:
+
+- [x] Audit SModel generated đã tồn tại.
+- [ ] Refactor `SysDictionaryInfo`.
+- [ ] Refactor `SysReportInfo`.
+- [ ] Refactor `SysReportDrillDownInfo`.
+- [ ] Refactor `SiDmCt`.
+- [ ] Lint + autoload + diff check.
+- [ ] Đối chiếu casts sai lệch với `simba-docs/tables`.
+- [ ] Cập nhật README nếu cần.
+- [ ] Tạo PR Phase 3.
 
 ---
 

--- a/docs/project/simba-model-layer-refactor-plan.md
+++ b/docs/project/simba-model-layer-refactor-plan.md
@@ -161,14 +161,36 @@ Hướng xử lý:
 Các bước còn lại:
 
 - [x] Audit SModel generated đã tồn tại.
-- [ ] Refactor `SysDictionaryInfo`.
-- [ ] Refactor `SysReportInfo`.
-- [ ] Refactor `SysReportDrillDownInfo`.
-- [ ] Refactor `SiDmCt`.
-- [ ] Lint + autoload + diff check.
-- [ ] Đối chiếu casts sai lệch với `simba-docs/tables`.
-- [ ] Cập nhật README nếu cần.
+- [x] Refactor `SysDictionaryInfo`.
+- [x] Refactor `SysReportInfo`.
+- [x] Refactor `SysReportDrillDownInfo`.
+- [x] Refactor `SiDmCt`.
+- [x] Lint + autoload + diff check.
+- [x] Đối chiếu casts sai lệch với `simba-docs/tables`.
+- [x] Cập nhật README nếu cần.
 - [ ] Tạo PR Phase 3.
+
+Kết quả sau khi refactor:
+
+- 4 Model chỉ extend SModel generated, không khai báo lại schema.
+- 3 Model có composite PK dùng `HasSimbaCompositeKey`:
+  - `SysReportInfo` -> PK `(menuid, ma_mau)`
+  - `SysReportDrillDownInfo` -> PK `(menuid, ma_mau, press_key_name)`
+  - `SiDmCt` -> PK `(ma_cty, ma_ct)`
+- Behavior Simba-level giữ nguyên:
+  - `SysDictionaryInfo`: `primaryKeyFields()`, `carryFields()`, `scopeCodeName`, `scopeMenuId`
+  - `SiDmCt`: `scopeVoucher`, `scopeMenuId`, `headerFieldsForInventory()`, `detailFieldsForInventory()`
+- Lint: 4/4 pass.
+- `class_exists` + parent class + trait check: pass.
+- `git diff --check` pass.
+- Caller `diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php`, `SimbaVoucherMetadata.php`, `Models/SysDictionaryInfo.php` chỉ dùng query/attribute thường; không phụ thuộc schema declaration trong Model nên không phá API.
+
+Đối chiếu casts:
+
+- `SysReportInfo`: SModel cast `isdefault` boolean. Cột `bang_chu`/`bang_chu0` (NVARCHAR 50) và `hasNT` (NVARCHAR 1) từ docs không phải boolean; Model cũ cast boolean là sai -> đã loại bỏ.
+- `SiDmCt`: SModel cast `VoucherGetWhenOpenForm` integer (theo DB thật). Docs không liệt kê cột này; Model cũ cast boolean không có nguồn docs -> đã loại bỏ.
+
+Branch: `task/simba-model-layer-phase3-schema-refactor`
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 3 của simba-model-layer-refactor-plan: chuẩn hóa 4 Model còn tự khai báo schema thay vì extend SModel generated.

## Changes

- diepxuan/laravel-simba/src/Models/SysDictionaryInfo.php
- diepxuan/laravel-simba/src/Models/SysReportInfo.php
- diepxuan/laravel-simba/src/Models/SysReportDrillDownInfo.php
- diepxuan/laravel-simba/src/Models/SiDmCt.php
- docs/project/simba-model-layer-refactor-plan.md

## Refactor

- 4 Model chỉ extend SModel generated; không khai báo lại $table/$primaryKey/$keyType/$fillable/$casts/$timestamps/$incrementing/$connection.
- 3 Model có composite PK dùng HasSimbaCompositeKey: SysReportInfo (menuid, ma_mau), SysReportDrillDownInfo (menuid, ma_mau, press_key_name), SiDmCt (ma_cty, ma_ct).
- Behavior Simba-level giữ nguyên: primaryKeyFields, carryFields, scopeCodeName, scopeMenuId, scopeVoucher, headerFieldsForInventory, detailFieldsForInventory.
- Sai lệch casts cũ đã loại bỏ:
  - SysReportInfo: bang_chu/bang_chu0/hasNT là NVARCHAR theo docs, không phải boolean.
  - SiDmCt: VoucherGetWhenOpenForm không có trong docs; theo DB thật là integer.

## Verification

- php -l: 4/4 pass.
- class_exists + parent + trait check: pass.
- git diff --check: pass.
- Caller trong diepxuan/laravel-catalog chỉ dùng query/attribute thường; không phá API.

## Plan ref

docs/project/simba-model-layer-refactor-plan.md