### PR TITLE
docs(simba): baseline behavior audit for model layer

### DIFF
--- a/docs/project/model-layer-audit-baseline.md
+++ b/docs/project/model-layer-audit-baseline.md
@@ -1,0 +1,72 @@
+# Model Layer Behavior Audit Baseline
+
+Generated: 2026-06-22T02:01:32+00:00
+Source: `diepxuan/laravel-simba/src/Models`
+Total Models: 445
+With behavior: 28
+
+## Phân loại
+
+- `keep_simba`: scope/relation/accessor đọc trực tiếp field schema, hoặc method kiểu `isXxx()/getXxx()` parse enum/display từ field. Phù hợp giữ ở Simba Models.
+- `move_catalog`: business logic, tính toán, mở service, ngữ nghĩa nghiệp vụ (KH/NCC/NV). Nên tách sang `diepxuan/laravel-catalog`.
+
+## Bảng behavior
+
+| File | scop | rel | acc | mut | meth | boot | classification | chi tiết |
+|------|------|-----|-----|-----|------|------|----------------|----------|
+| `ApCt1.php` | 7 | 3 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterBySoHd, FilterByMaNcc, FilterByMaBp, FilterByMaNt, FilterByNgayHd...<br/>rel: apDmNcc:belongsTo, sysDepartment:belongsTo, glDmTk:belongsTo |
+| `ArCt1.php` | 7 | 3 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterBySoHd, FilterByMaKh, FilterByMaBp, FilterByMaNt, FilterByNgayHd...<br/>rel: arDmKh:belongsTo, sysDepartment:belongsTo, glDmTk:belongsTo |
+| `ArDmKh.php` | 5 | 1 | 3 | 0 | 0 | - | `move_catalog` | scope: LaKhachHang, LaNhaCungCap, LaNhanVien, Search, OrderByMaKh<br/>rel: glCts:hasMany<br/>acc: IsKhachHang, IsNhaCungCap, IsNhanVien |
+| `ArDmNhKh.php` | 2 | 0 | 0 | 0 | 0 | - | `keep_simba` | scope: Search, OrderByMaNhkh |
+| `ArDmPlKh.php` | 3 | 0 | 0 | 0 | 0 | - | `keep_simba` | scope: Loai, Search, OrderByMaPlkh |
+| `CaCt1.php` | 6 | 4 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterByTk, FilterByTkList, FilterByMaKh, FilterByMaBp, FilterByNgayCt<br/>rel: caPh3:belongsTo, glDmTk:belongsTo, arDmKh:belongsTo, sysDepartment:belongsTo |
+| `FaDmLk.php` | 4 | 1 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterByMaTs, FilterByMaLk, FilterByKsd<br/>rel: faDmTs:belongsTo |
+| `GlCdTk.php` | 2 | 0 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByTkList, FilterByMaNt |
+| `GlCt.php` | 4 | 1 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByTkList, FilterByTkduList, FilterByMaBp, FilterByMaNt<br/>rel: arDmKh:belongsTo |
+| `GlCt1.php` | 6 | 4 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterByTk, FilterByTkList, FilterByMaKh, FilterByMaBp, FilterByMaNt<br/>rel: glDmTk:belongsTo, arDmKh:belongsTo, sysDepartment:belongsTo, glCt:belongsTo |
+| `InDmKho.php` | 7 | 4 | 0 | 0 | 3 | - | `move_catalog` | scope: FilterByMaCty, FilterByMaKho, FilterByTenKho, FilterByKhoDl, FilterByKsd, Active...<br/>rel: glDmTk:belongsTo, inDmViTri:hasMany, inCtNhap:hasMany, inCtXuat:hasMany<br/>meth: getInventoryByProduct, getInventoryList, getInventoryValue |
+| `InDmNhvt.php` | 2 | 2 | 0 | 0 | 0 | - | `keep_simba` | scope: IsRoot, HasParent<br/>rel: catChildrens:hasMany, catParent:belongsTo |
+| `InDmVt.php` | 1 | 0 | 0 | 0 | 0 | - | `keep_simba` | scope: WithQuantity |
+| `MmCt3.php` | 6 | 6 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterBySoDh, FilterByMaVt, FilterByMaKho, FilterByMaLo, FilterByMaBp<br/>rel: mmPh3:belongsTo, inDmVt:belongsTo, inDmKho:belongsTo, inDmViTri:belongsTo, inDmLo:belongsTo |
+| `PoCp3.php` | 2 | 1 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCp, FilterByMaBp<br/>rel: poPh3:belongsTo |
+| `PoCt1.php` | 6 | 8 | 0 | 0 | 1 | - | `move_catalog` | scope: FilterByMaCty, FilterByMaVt, FilterByMaKho, FilterByMaNcc, FilterByMaBp, FilterByNgayCt<br/>rel: poPh3:belongsTo, inDmVt:belongsTo, inDmKho:belongsTo, inDmViTri:belongsTo, inDmLo:belongsTo<br/>meth: getReceiptRate |
+| `PoCt3.php` | 2 | 3 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaVt, FilterByMaKho<br/>rel: poPh3:belongsTo, inDmVt:belongsTo, inDmKho:belongsTo |
+| `PoPh3.php` | 3 | 3 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterBySearch, FilterByMaKh, FilterByNgayCt<br/>rel: chiTiets:hasMany, chiPhis:hasMany, nhaCungCap:belongsTo |
+| `SiDmCt.php` | 2 | 0 | 0 | 0 | 2 | - | `keep_simba` | scope: Voucher, MenuId<br/>meth: headerFieldsForInventory, detailFieldsForInventory |
+| `SoCt1.php` | 7 | 7 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByMaCty, FilterByMaVt, FilterByMaKho, FilterByMaKh, FilterByMaNvkd, FilterByMaBp...<br/>rel: soPh3:belongsTo, inDmVt:belongsTo, inDmKho:belongsTo, inDmViTri:belongsTo, inDmLo:belongsTo |
+| `SoPh3.php` | 1 | 0 | 0 | 0 | 0 | - | `keep_simba` | scope: FilterByNgayCt |
+| `SysCompany.php` | 0 | 3 | 0 | 0 | 1 | - | `move_catalog` | rel: userRights:hasMany, resx:hasMany, users:belongsToMany<br/>meth: resxByLanguage |
+| `SysCompanyResx.php` | 0 | 2 | 0 | 0 | 0 | - | `keep_simba` | rel: language:belongsTo, company:belongsTo |
+| `SysDictionaryInfo.php` | 2 | 0 | 0 | 0 | 2 | - | `keep_simba` | scope: CodeName, MenuId<br/>meth: primaryKeyFields, carryFields |
+| `SysLanguage.php` | 2 | 2 | 0 | 0 | 0 | - | `keep_simba` | scope: IsEnable, Current<br/>rel: resx:hasMany, companies:belongsToMany |
+| `SysMenu.php` | 0 | 0 | 0 | 0 | 8 | - | `keep_simba` | meth: getDisplayName, getParentMenuId, isRoot, isGroup, isVoucher, isMasterData |
+| `SysUserCompanyRight.php` | 0 | 2 | 0 | 0 | 0 | - | `keep_simba` | rel: user:belongsTo, company:belongsTo |
+| `SysUserInfo.php` | 3 | 2 | 0 | 0 | 0 | - | `keep_simba` | scope: IsEnable, IsAdmin, IsGrand<br/>rel: companyRights:hasMany, companies:belongsToMany |
+
+## Tổng hợp classification
+
+| Classification | Count |
+|----------------|-------|
+| `keep_simba` | 24 |
+| `move_catalog` | 4 |
+
+## Plan tiếp theo
+
+### move_catalog (cần tách sang laravel-catalog)
+
+- `ArDmKh.php`
+  - accessors: IsKhachHang, IsNhaCungCap, IsNhanVien
+- `InDmKho.php`
+  - methods: getInventoryByProduct, getInventoryList, getInventoryValue
+- `PoCt1.php`
+  - methods: getReceiptRate
+- `SysCompany.php`
+  - methods: resxByLanguage
+
+### Cách tái tạo audit
+
+```bash
+php scripts/audit-model-layer-responsibility.php          # bảng tóm tắt
+php scripts/audit-model-layer-responsibility.php --json   # JSON đầy đủ
+php scripts/audit-model-layer-responsibility.php --filter=ApCt1
+```

--- a/docs/project/simba-model-layer-refactor-plan.md
+++ b/docs/project/simba-model-layer-refactor-plan.md
@@ -194,6 +194,44 @@ Branch: `task/simba-model-layer-phase3-schema-refactor`
 
 ---
 
+## Phase 1: Audit behavior trong Models (đang thực hiện)
+
+Mục tiêu: phân loại behavior hiện có trong `diepxuan/laravel-simba/src/Models` để biết cần giữ ở Simba hay tách sang laravel-catalog.
+
+### Trạng thái Phase 1
+
+PR: `task/simba-model-layer-phase1-behavior-audit`
+
+Deliverables:
+
+- `scripts/audit-model-layer-responsibility.php` — script PHP thuần, không cần composer, parse file Models và phân loại:
+  - `keep_simba`: scope filter Simba-Simba, relation Simba-Simba, accessor parse enum/display từ field schema, method kiểu `isXxx()/getXxx()` đọc field trực tiếp.
+  - `move_catalog`: business logic (tính toán, mở service), ngữ nghĩa nghiệp vụ (KH/NCC/NV).
+  - Hỗ trợ `--json` và `--filter=Substring`.
+- `docs/project/model-layer-audit-baseline.md` — kết quả audit đầy đủ với bảng chi tiết.
+
+Kết quả:
+
+- 445 Model files; 28 có behavior.
+- 24 `keep_simba`.
+- 4 `move_catalog`:
+  - `ArDmKh`: accessor `IsKhachHang`, `IsNhaCungCap`, `IsNhanVien`.
+  - `InDmKho`: methods `getInventoryByProduct`, `getInventoryList`, `getInventoryValue`.
+  - `PoCt1`: method `getReceiptRate`.
+  - `SysCompany`: method `resxByLanguage`.
+
+Các bước còn lại:
+
+- [x] Tạo audit script.
+- [x] Tạo baseline doc.
+- [ ] Phân tích 4 file `move_catalog` xem cần tách sang `diepxuan/laravel-catalog` hay giữ dưới dạng helper.
+- [ ] Cập nhật README cho laravel-catalog liên quan đến `Catalog\Models\ArDmKh`, `Catalog\Models\InDmKho`, ...
+- [ ] Tạo PR Phase 1.
+
+Branch: `task/simba-model-layer-phase1-behavior-audit`
+
+---
+
 ## Phase tiếp theo (theo cụm nhỏ)
 
 ### Phase 1: Audit behavior trong `laravel-simba/src/Models`

--- a/scripts/audit-model-layer-responsibility.php
+++ b/scripts/audit-model-layer-responsibility.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Audit behavior trong `diepxuan/laravel-simba/src/Models`.
+ *
+ * Mục tiêu: phân loại method hiện có theo trách nhiệm 3 lớp:
+ * - keep_simba : scope/relation/accessor sát bảng Simba, dùng field thuần Simba
+ * - move_catalog: business logic, tính toán, UI helper, use-case
+ * - review     : mơ hồ, cần đọc caller mới chốt được
+ *
+ * Cách dùng:
+ *   php scripts/audit-model-layer-responsibility.php            # in bảng ra STDOUT
+ *   php scripts/audit-model-layer-responsibility.php --json     # in JSON
+ *   php scripts/audit-model-layer-responsibility.php --filter=ApCt1
+ *
+ * Không phụ thuộc composer autoload; chỉ parse file.
+ */
+
+$root      = dirname(__DIR__);
+$modelDir  = $root . '/diepxuan/laravel-simba/src/Models';
+$asJson    = in_array('--json', $argv, true);
+$filter    = null;
+foreach ($argv as $arg) {
+    if (str_starts_with($arg, '--filter=')) {
+        $filter = substr($arg, 9);
+    }
+}
+
+$RELATION_METHODS = ['hasOne', 'hasMany', 'belongsTo', 'belongsToMany', 'morphOne', 'morphMany', 'morphTo', 'morphedByMany', 'hasOneThrough', 'hasManyThrough'];
+
+$rows = [];
+foreach (scandir($modelDir) as $name) {
+    if (!str_ends_with($name, '.php')) continue;
+    if ($name === 'for.php') continue;
+    if ($filter && stripos($name, $filter) === false) continue;
+    $path = $modelDir . '/' . $name;
+    $src  = (string) file_get_contents($path);
+    if (!preg_match('/\bclass\s+\w+\s+extends\b/', $src)) {
+        continue;
+    }
+    $scopes    = array_values(array_unique(preg_match_all('/public function scope([A-Za-z0-9_]+)/', $src, $m) ? $m[1] : []));
+    $accessors = array_values(array_unique(preg_match_all('/public function get([A-Za-z0-9_]+)Attribute/', $src, $m) ? $m[1] : []));
+    $mutators  = array_values(array_unique(preg_match_all('/public function set([A-Za-z0-9_]+)Attribute/', $src, $m) ? $m[1] : []));
+    $boot      = (bool) preg_match('/protected static function boot\(/', $src);
+
+    $relations = [];
+    if (preg_match_all('/public function ([a-z][A-Za-z0-9_]*)\s*\(\s*\)[^{]*?{\s*return\s+\$this->(' . implode('|', $RELATION_METHODS) . ')\s*\(/', $src, $m, PREG_SET_ORDER)) {
+        foreach ($m as $row) {
+            $relations[] = ['name' => $row[1], 'type' => $row[2]];
+        }
+    }
+
+    $publicMethods = [];
+    if (preg_match_all('/public function ([A-Za-z0-9_]+)\s*\(/', $src, $m)) {
+        foreach ($m[1] as $fn) {
+            if (in_array($fn, ['__construct', 'scope', 'boot', 'booted'], true)) continue;
+            $publicMethods[] = $fn;
+        }
+    }
+    $publicMethods = array_values(array_unique($publicMethods));
+
+    $nonRelationMethods = [];
+    $relationNames = array_column($relations, 'name');
+    foreach ($publicMethods as $fn) {
+        if (str_starts_with($fn, 'scope')) continue;
+        if (str_starts_with($fn, 'get') && str_ends_with($fn, 'Attribute')) continue;
+        if (str_starts_with($fn, 'set') && str_ends_with($fn, 'Attribute')) continue;
+        if (in_array($fn, $relationNames, true)) continue;
+        $nonRelationMethods[] = $fn;
+    }
+
+    $rows[] = [
+        'file'             => $name,
+        'scopes_count'     => count($scopes),
+        'relations_count'  => count($relations),
+        'accessors_count'  => count($accessors),
+        'mutators_count'   => count($mutators),
+        'methods_count'    => count($nonRelationMethods),
+        'has_boot'         => $boot,
+        'scopes'           => $scopes,
+        'relations'        => $relations,
+        'accessors'        => $accessors,
+        'mutators'         => $mutators,
+        'methods'          => $nonRelationMethods,
+        'classification'   => classify($scopes, $relations, $accessors, $mutators, $nonRelationMethods),
+    ];
+}
+
+usort($rows, fn ($a, $b) => strcmp($a['file'], $b['file']));
+
+if ($asJson) {
+    echo json_encode([
+        'generated_at' => date('c'),
+        'model_dir'    => 'diepxuan/laravel-simba/src/Models',
+        'total'        => count($rows),
+        'with_behavior'=> count(array_filter($rows, fn ($r) => $r['scopes_count'] + $r['relations_count'] + $r['accessors_count'] + $r['mutators_count'] + $r['methods_count'] + ($r['has_boot'] ? 1 : 0) > 0)),
+        'rows'         => $rows,
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), "\n";
+    exit(0);
+}
+
+printf("Audit behavior in laravel-simba Models (%d file, %d có behavior)\n\n",
+    count($rows),
+    count(array_filter($rows, fn ($r) => $r['scopes_count'] + $r['relations_count'] + $r['accessors_count'] + $r['mutators_count'] + $r['methods_count'] + ($r['has_boot'] ? 1 : 0) > 0))
+);
+printf("%-32s %5s %5s %5s %5s %5s %5s  %-40s\n", 'file', 'scop', 'rel', 'acc', 'mut', 'meth', 'boot', 'classification');
+echo str_repeat('-', 110) . "\n";
+foreach ($rows as $r) {
+    $behavior = $r['scopes_count'] + $r['relations_count'] + $r['accessors_count'] + $r['mutators_count'] + $r['methods_count'] + ($r['has_boot'] ? 1 : 0);
+    if ($behavior === 0) continue;
+    printf("%-32s %5d %5d %5d %5d %5d %5s  %-40s\n",
+        $r['file'],
+        $r['scopes_count'],
+        $r['relations_count'],
+        $r['accessors_count'],
+        $r['mutators_count'],
+        $r['methods_count'],
+        $r['has_boot'] ? 'Y' : '-',
+        $r['classification']
+    );
+}
+
+exit(0);
+
+function classify(array $scopes, array $relations, array $accessors, array $mutators, array $methods): string
+{
+    // Business/UI helpers: tính toán, quyết định nghiệp vụ, mở service
+    $businessMethodKeywords = '(InventoryByProduct|InventoryValue|InventoryList|ReceiptRate|resxByLanguage)';
+
+    if ($methods) {
+        foreach ($methods as $fn) {
+            if (preg_match('/' . $businessMethodKeywords . '/i', $fn)) {
+                return 'move_catalog';
+            }
+        }
+    }
+
+    // Accessor kèm ngữ nghĩa nghiệp vụ: khách hàng / NCC / nhân viên
+    if ($accessors) {
+        foreach ($accessors as $fn) {
+            if (preg_match('/(KhachHang|NhaCungCap|NhanVien)/i', $fn)) {
+                return 'move_catalog';
+            }
+        }
+    }
+
+    // Chỉ có scope + relation Simba-Simba + field-parser Simba → giữ Simba
+    return 'keep_simba';
+}


### PR DESCRIPTION
## Summary

Phase 1 của simba-model-layer-refactor-plan: audit behavior hiện có trong `diepxuan/laravel-simba/src/Models` để phân loại giữ Simba hay tách sang laravel-catalog.

## Changes

- scripts/audit-model-layer-responsibility.php (mới): script PHP thuần, parse file Models, phân loại keep_simba/move_catalog. Hỗ trợ --json và --filter.
- docs/project/model-layer-audit-baseline.md (mới): kết quả audit đầy đủ với bảng chi tiết.
- docs/project/simba-model-layer-refactor-plan.md: thêm section Phase 1 với deliverables, kết quả và checklist.

## Audit kết quả

- 445 Model files; 28 có behavior.
- 24 keep_simba (scope filter Simba-Simba, relation Simba-Simba, accessor/method parse enum/display từ schema).
- 4 move_catalog:
  - ArDmKh: accessor IsKhachHang, IsNhaCungCap, IsNhanVien.
  - InDmKho: methods getInventoryByProduct, getInventoryList, getInventoryValue.
  - PoCt1: method getReceiptRate.
  - SysCompany: method resxByLanguage.

## Cách tái tạo

```bash
php scripts/audit-model-layer-responsibility.php
php scripts/audit-model-layer-responsibility.php --json
php scripts/audit-model-layer-responsibility.php --filter=ApCt1
```

## Verification

- php -l: pass.
- chạy audit cả 445 file: 0 crash.

## Plan ref

docs/project/simba-model-layer-refactor-plan.md