### PR TITLE
refactor(simba): move ArDmKh KH/NCC/NV scopes to catalog concern

### DIFF
--- a/diepxuan/laravel-catalog/src/Models/ArDmKh.php
+++ b/diepxuan/laravel-catalog/src/Models/ArDmKh.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Models;
 
+use Diepxuan\Catalog\Models\Concerns\HasArDmKhCategories;
 use Diepxuan\Simba\Models\ArDmKh as SimbaModel;
 use Diepxuan\Simba\SModel\SModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,10 +22,14 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Model ArDmKh - Danh mục khách hàng (catalog layer).
  *
- * Mở rộng từ Simba ArDmKh với relationships và helper methods.
+ * Mở rộng từ Simba ArDmKh với:
+ * - Quan hệ Portal: nhomKhachHang, phanLoaiKhachHang1/2/3.
+ * - Phân loại KH/NCC/NV nghiệp vụ (HasArDmKhCategories).
+ * - Helper getSoduKh, hasTransactions.
  */
 class ArDmKh extends SimbaModel
 {
+    use HasArDmKhCategories;
     /**
      * Company constant.
      */

--- a/diepxuan/laravel-catalog/src/Models/Concerns/HasArDmKhCategories.php
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/HasArDmKhCategories.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Concern: phân loại đối tượng ArDmKh theo nghiệp vụ Portal.
+ *
+ * Tách từ `Diepxuan\Simba\Models\ArDmKh` (Phase 2 refactor) để giữ
+ * Simba Models chỉ chứa behavior sát schema.
+ *
+ * Ngữ nghĩa KH/NCC/NV là quyết định nghiệp vụ Portal, không thuộc
+ * bảng `ArDmKh` thô của Simba.
+ */
+trait HasArDmKhCategories
+{
+    /**
+     * Scope: chỉ lấy khách hàng (isKh = true).
+     */
+    public function scopeLaKhachHang(Builder $query): Builder
+    {
+        return $query->where('isKh', true);
+    }
+
+    /**
+     * Scope: chỉ lấy nhà cung cấp (isNcc = true).
+     */
+    public function scopeLaNhaCungCap(Builder $query): Builder
+    {
+        return $query->where('isNcc', true);
+    }
+
+    /**
+     * Scope: chỉ lấy nhân viên (isNv = true).
+     */
+    public function scopeLaNhanVien(Builder $query): Builder
+    {
+        return $query->where('isNv', true);
+    }
+
+    /**
+     * Accessor: kiểm tra có phải khách hàng không.
+     */
+    public function getIsKhachHangAttribute(): bool
+    {
+        return (bool) $this->isKh;
+    }
+
+    /**
+     * Accessor: kiểm tra có phải nhà cung cấp không.
+     */
+    public function getIsNhaCungCapAttribute(): bool
+    {
+        return (bool) $this->isNcc;
+    }
+
+    /**
+     * Accessor: kiểm tra có phải nhân viên không.
+     */
+    public function getIsNhanVienAttribute(): bool
+    {
+        return (bool) $this->isNv;
+    }
+}

--- a/diepxuan/laravel-simba/src/Models/ArDmKh.php
+++ b/diepxuan/laravel-simba/src/Models/ArDmKh.php
@@ -22,7 +22,13 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 /**
  * Model ArDmKh - Danh mục khách hàng.
  *
- * Mở rộng từ ArDmKhModel với các scope và helper methods.
+ * Mở rộng từ ArDmKhModel với:
+ * - Global scope ksd.
+ * - Scope search/order theo field Simba.
+ * - Quan hệ glCts, stored procedure AsGetSoDuKh.
+ *
+ * Phân loại KH/NCC/NV đã được tách sang
+ * `Diepxuan\Catalog\Models\ArDmKh` (dùng `HasArDmKhCategories`).
  */
 class ArDmKh extends Model
 {
@@ -39,30 +45,6 @@ class ArDmKh extends Model
         static::addGlobalScope('ksd', static function (Builder $query): void {
             $query->where('ksd', true);
         });
-    }
-
-    /**
-     * Scope: Chỉ lấy khách hàng (isKh = true).
-     */
-    public function scopeLaKhachHang(Builder $query): Builder
-    {
-        return $query->where('isKh', true);
-    }
-
-    /**
-     * Scope: Chỉ lấy nhà cung cấp (isNcc = true).
-     */
-    public function scopeLaNhaCungCap(Builder $query): Builder
-    {
-        return $query->where('isNcc', true);
-    }
-
-    /**
-     * Scope: Chỉ lấy nhân viên (isNv = true).
-     */
-    public function scopeLaNhanVien(Builder $query): Builder
-    {
-        return $query->where('isNv', true);
     }
 
     /**
@@ -107,29 +89,5 @@ class ArDmKh extends Model
             'pNgay'   => $params['pNgay'] ?? null,
             'pTk'     => $params['pTk'] ?? null,
         ]);
-    }
-
-    /**
-     * Accessor: Kiểm tra có phải khách hàng không.
-     */
-    public function getIsKhachHangAttribute(): bool
-    {
-        return (bool) $this->isKh;
-    }
-
-    /**
-     * Accessor: Kiểm tra có phải nhà cung cấp không.
-     */
-    public function getIsNhaCungCapAttribute(): bool
-    {
-        return (bool) $this->isNcc;
-    }
-
-    /**
-     * Accessor: Kiểm tra có phải nhân viên không.
-     */
-    public function getIsNhanVienAttribute(): bool
-    {
-        return (bool) $this->isNv;
     }
 }

--- a/docs/project/simba-model-layer-refactor-plan.md
+++ b/docs/project/simba-model-layer-refactor-plan.md
@@ -232,6 +232,55 @@ Branch: `task/simba-model-layer-phase1-behavior-audit`
 
 ---
 
+## Phase 2: Tách behavior theo cụm (đang thực hiện)
+
+Mục tiêu: tách các method `move_catalog` (từ Phase 1 audit) ra khỏi Simba Models sang laravel-catalog.
+
+### Trạng thái Phase 2 - cụm ArDmKh
+
+Branch: `task/simba-model-layer-phase2-ardmkh-catalog`
+
+Đã làm:
+
+- Tạo `Diepxuan\Catalog\Models\Concerns\HasArDmKhCategories` chứa:
+  - scope `laKhachHang`, `laNhaCungCap`, `laNhanVien`
+  - accessor `is_khach_hang`, `is_nha_cung_cap`, `is_nhan_vien`
+- Gắn trait vào `Diepxuan\Catalog\Models\ArDmKh`.
+- Gỡ các method/accessor tương ứng khỏi `Diepxuan\Simba\Models\ArDmKh`.
+- Giữ nguyên trong `Simba\Models\ArDmKh`:
+  - `booted()` với global scope `ksd`.
+  - `scopeSearch`, `scopeOrderByMaKh` (helper query thuần dữ liệu).
+  - relation `glCts()`.
+  - stored procedure wrapper `AsGetSoDuKh()`.
+- Caller `diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php` đã dùng `Catalog\ArDmKh` sẵn từ trước nên không cần sửa.
+
+Verify:
+
+- php -l: 3/3 pass.
+- `git diff --check`: pass.
+- Reflection (không boot app):
+  - `Simba\ArDmKh`: `scopeLaKhachHang`=0, `getIsKhachHangAttribute`=0, `scopeSearch`=1, `scopeOrderByMaKh`=1.
+  - `Catalog\ArDmKh`: `scopeLaKhachHang`=1, `getIsKhachHangAttribute`=1, `scopeSearch`=1 (inherited), parent=`Simba\ArDmKh`.
+
+Các bước còn lại:
+
+- [x] Tạo concern trong catalog.
+- [x] Gắn trait vào `Catalog\ArDmKh`.
+- [x] Gỡ method tương ứng khỏi `Simba\ArDmKh`.
+- [x] Verify reflection.
+- [ ] Lint + autoload Catalog composer dump.
+- [ ] Tạo PR Phase 2 - cụm ArDmKh.
+
+### Plan cho các cụm còn lại (Phase 1 audit đã chỉ ra)
+
+- `InDmKho` (cụm Inventory): method `getInventoryByProduct`, `getInventoryList`, `getInventoryValue`. Tạo `HasInDmKhInventoryOperations` ở catalog.
+- `PoCt1` (cụm PO voucher): method `getReceiptRate`. Tạo `HasPoCt1ReceiptRate` ở catalog hoặc giữ helper query nếu thuần tính toán trên row.
+- `SysCompany` (cụm Sys): method `resxByLanguage`. Helper nghiệp vụ, chuyển sang catalog.
+
+Mỗi cụm một PR nhỏ.
+
+---
+
 ## Phase tiếp theo (theo cụm nhỏ)
 
 ### Phase 1: Audit behavior trong `laravel-simba/src/Models`


### PR DESCRIPTION
## Summary

Phase 2 - cụm ArDmKh: tách scope laKhachHang/laNhaCungCap/laNhanVien và accessor is_khach_hang/is_nha_cung_cap/is_nhan_vien khỏi Simba\Models\ArDmKh sang Catalog\Models\ArDmKh thông qua concern mới HasArDmKhCategories.

## Why

Phase 1 audit (#219) đã phân loại ArDmKh là move_catalog. Ngữ nghĩa KH/NCC/NV là quyết định nghiệp vụ Portal (catalog), không thuộc schema Simba thuần.

## Changes

- diepxuan/laravel-catalog/src/Models/Concerns/HasArDmKhCategories.php (mới): trait chứa 3 scope + 3 accessor.
- diepxuan/laravel-catalog/src/Models/ArDmKh.php: dùng HasArDmKhCategories; cập nhật docblock.
- diepxuan/laravel-simba/src/Models/ArDmKh.php: gỡ 3 scope + 3 accessor; giữ nguyên booted/scopeSearch/scopeOrderByMaKh/glCts/AsGetSoDuKh.
- docs/project/simba-model-layer-refactor-plan.md: thêm section Phase 2 với trạng thái cụm ArDmKh.

## Verification

- php -l: 3/3 pass.
- git diff --check: pass.
- Reflection:
  - Simba\ArDmKh: scopeLaKhachHang=0, getIsKhachHangAttribute=0, scopeSearch=1.
  - Catalog\ArDmKh: scopeLaKhachHang=1, getIsKhachHangAttribute=1, scopeSearch=1 (inherited), parent=Simba\ArDmKh.
- Caller InputKhachhang.php đã dùng Catalog\ArDmKh từ trước; không cần sửa.

## Plan ref

docs/project/simba-model-layer-refactor-plan.md