### PR TITLE
refactor(simba): move catalog business methods to catalog concerns

### DIFF
--- a/diepxuan/laravel-catalog/src/Models/Concerns/HasInDmKhoInventoryOperations.php
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/HasInDmKhoInventoryOperations.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models\Concerns;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Concern: các thao tác nghiệp vụ tồn kho trên InDmKho.
+ *
+ * Tách từ `Diepxuan\Simba\Models\InDmKho` (Phase 2 refactor) vì:
+ * - Gọi stored procedure AsINRptCD02 để lấy tồn kho theo vật tư / theo nhóm.
+ * - Tính giá trị tồn kho từ kết quả báo cáo (tổng sl_ton * gia_nt2).
+ *
+ * Bản thân các method này dùng `$this->ma_cty` và `$this->ma_kho` từ Model,
+ * nhưng tổng hợp dữ liệu và quyết định nghiệp vụ báo cáo tồn kho thuộc
+ * Catalog, không thuộc schema Simba thuần.
+ */
+trait HasInDmKhoInventoryOperations
+{
+    /**
+     * Lấy tồn kho theo vật tư.
+     */
+    public function getInventoryByProduct(string $maVt, ?string $ngay = null): array
+    {
+        $result = \Diepxuan\Simba\StoredProcedures\AsINRptCD02::call([
+            'pMa_Cty'    => $this->ma_cty,
+            'pMa_vt'     => $maVt,
+            'pMa_kho'    => $this->ma_kho,
+            'pNgay'      => $ngay ?? date('Y-m-d'),
+            'pMa_vitri'  => null,
+            'pTk_vt'     => null,
+            'pMa_nhvt'   => null,
+            'pDVT'       => null,
+            'pNgoai_te'  => null,
+            'pDk_Ck'     => null,
+            'pMa_lo'     => null,
+            'pQuaToiThieu' => null,
+            'pQuaToiDa'    => null,
+            'pSysMsg1'   => null,
+        ]);
+
+        return $result->isNotEmpty() ? (array) $result->first() : [];
+    }
+
+    /**
+     * Lấy danh sách vật tư tồn kho theo kho.
+     */
+    public function getInventoryList(?string $maNhvt = null, ?string $ngay = null): Collection
+    {
+        return \Diepxuan\Simba\StoredProcedures\AsINRptCD02::call([
+            'pMa_Cty'   => $this->ma_cty,
+            'pMa_kho'   => $this->ma_kho,
+            'pMa_nhvt'  => $maNhvt ?? '',
+            'pNgay'     => $ngay ?? date('Y-m-d'),
+            'pMa_vt'    => null,
+            'pMa_vitri' => null,
+            'pTk_vt'    => null,
+            'pDVT'      => null,
+            'pNgoai_te' => null,
+            'pDk_Ck'    => null,
+            'pMa_lo'    => null,
+            'pQuaToiThieu' => null,
+            'pQuaToiDa'    => null,
+            'pSysMsg1'  => null,
+        ]);
+    }
+
+    /**
+     * Tính giá trị tồn kho theo kho.
+     */
+    public function getInventoryValue(?string $ngay = null): float
+    {
+        $inventoryList = $this->getInventoryList(null, $ngay);
+
+        $totalValue = 0;
+        foreach ($inventoryList as $item) {
+            $totalValue += ($item->sl_ton ?? 0) * ($item->gia_nt2 ?? 0);
+        }
+
+        return $totalValue;
+    }
+}

--- a/diepxuan/laravel-catalog/src/Models/Concerns/HasPoCt1PurchaseMetrics.php
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/HasPoCt1PurchaseMetrics.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Concern: chỉ tiêu và báo cáo mua hàng trên PoCt1.
+ *
+ * Tách từ `Diepxuan\Simba\Models\PoCt1` (Phase 2 refactor) vì:
+ * - Tổng hợp giá trị / số lượng theo vật tư, theo nhà cung cấp.
+ * - Tỷ lệ nhập hàng (sl_nhap / so_luong).
+ * - Báo cáo mua hàng (asPORptMH01, asPORptDH01, asPORptNH01).
+ *
+ * Tất cả là nghiệp vụ báo cáo, không thuộc schema Simba.
+ */
+trait HasPoCt1PurchaseMetrics
+{
+    /**
+     * Tổng giá trị mua hàng theo vật tư.
+     */
+    public static function getTotalPurchaseByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
+    {
+        $query = self::where('ma_cty', $maCty);
+
+        if ($fromDate || $toDate) {
+            $query->whereHas('poPh3', function ($q) use ($fromDate, $toDate): void {
+                if ($fromDate) {
+                    $q->whereDate('ngay_ct', '>=', $fromDate);
+                }
+                if ($toDate) {
+                    $q->whereDate('ngay_ct', '<=', $toDate);
+                }
+            });
+        }
+
+        return $query->select('ma_vt', DB::raw('SUM(tien0) as tong_gia_tri'), DB::raw('SUM(tien_nt0) as tong_gia_tri_nt'))
+            ->groupBy('ma_vt')
+            ->get();
+    }
+
+    /**
+     * Tổng số lượng mua theo vật tư.
+     */
+    public static function getTotalQuantityByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
+    {
+        $query = self::where('ma_cty', $maCty);
+
+        if ($fromDate || $toDate) {
+            $query->whereHas('poPh3', function ($q) use ($fromDate, $toDate): void {
+                if ($fromDate) {
+                    $q->whereDate('ngay_ct', '>=', $fromDate);
+                }
+                if ($toDate) {
+                    $q->whereDate('ngay_ct', '<=', $toDate);
+                }
+            });
+        }
+
+        return $query->select('ma_vt', DB::raw('SUM(so_luong) as tong_so_luong'), DB::raw('SUM(so_luong_qd) as tong_so_luong_qd'))
+            ->groupBy('ma_vt')
+            ->get();
+    }
+
+    /**
+     * Tổng giá trị mua hàng theo nhà cung cấp.
+     */
+    public static function getTotalPurchaseBySupplier(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
+    {
+        $query = self::where('ma_cty', $maCty);
+
+        if ($fromDate || $toDate) {
+            $query->whereHas('poPh3', function ($q) use ($fromDate, $toDate): void {
+                if ($fromDate) {
+                    $q->whereDate('ngay_ct', '>=', $fromDate);
+                }
+                if ($toDate) {
+                    $q->whereDate('ngay_ct', '<=', $toDate);
+                }
+            });
+        }
+
+        return $query->select('poPh3.ma_ncc', DB::raw('SUM(po_ct1.tien0) as tong_gia_tri'), DB::raw('SUM(po_ct1.tien_nt0) as tong_gia_tri_nt'))
+            ->join('po_ph3', 'po_ct1.stt_rec', '=', 'po_ph3.stt_rec')
+            ->groupBy('po_ph3.ma_ncc')
+            ->get();
+    }
+
+    /**
+     * Tỷ lệ nhập hàng (sl_nhap / so_luong * 100).
+     */
+    public function getReceiptRate(): float
+    {
+        if ($this->so_luong == 0) {
+            return 0;
+        }
+
+        return ($this->sl_nhap / $this->so_luong) * 100;
+    }
+
+    /**
+     * Báo cáo mua hàng asPORptMH01.
+     */
+    public static function getPORptMH01(array $params): Collection
+    {
+        return self::executeRptSp('asPORptMH01', $params);
+    }
+
+    /**
+     * Báo cáo đặt hàng asPORptDH01.
+     */
+    public static function getPORptDH01(array $params): Collection
+    {
+        return self::executeRptSp('asPORptDH01', $params);
+    }
+
+    /**
+     * Báo cáo nhập hàng asPORptNH01.
+     */
+    public static function getPORptNH01(array $params): Collection
+    {
+        return self::executeRptSp('asPORptNH01', $params);
+    }
+
+    /**
+     * Helper chung cho 3 báo cáo PO: cùng tập tham số.
+     */
+    protected static function executeRptSp(string $spName, array $params): Collection
+    {
+        return collect(DB::connection((new static())->getConnectionName())->select("EXEC {$spName}
+            @pMa_Cty = :pMa_Cty,
+            @pNgay_Ct1 = :pNgay_Ct1,
+            @pNgay_Ct2 = :pNgay_Ct2,
+            @pMa_Ncc = :pMa_Ncc,
+            @pMa_Vt = :pMa_Vt,
+            @pMa_Bp = :pMa_Bp,
+            @pMa_Nt = :pMa_Nt
+        ", [
+            'pMa_Cty'   => $params['pMa_Cty']   ?? '',
+            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
+            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
+            'pMa_Ncc'   => $params['pMa_Ncc']   ?? '',
+            'pMa_Vt'    => $params['pMa_Vt']    ?? '',
+            'pMa_Bp'    => $params['pMa_Bp']    ?? '',
+            'pMa_Nt'    => $params['pMa_Nt']    ?? 'VND',
+        ]));
+    }
+}

--- a/diepxuan/laravel-catalog/src/Models/Concerns/HasSysCompanyLocalizedResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/HasSysCompanyLocalizedResx.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models\Concerns;
+
+use Diepxuan\Simba\Models\SysLanguage;
+
+/**
+ * Concern: truy vấn resource theo ngôn ngữ trên SysCompany.
+ *
+ * Tách từ `Diepxuan\Simba\Models\SysCompany` (Phase 2 refactor) vì:
+ * - Lọc resource theo SysLanguage là helper nghiệp vụ Catalog.
+ * - Simba giữ quan hệ raw `resx()`; Catalog bổ sung `resxByLanguage()`.
+ *
+ * SysCompanyResx thuộc cùng namespace `Diepxuan\Catalog\Models` nên không
+ * cần import; khi trait được dùng trong một Model thuộc namespace đó,
+ * `SysCompanyResx` sẽ tự resolve.
+ */
+trait HasSysCompanyLocalizedResx
+{
+    /**
+     * Resource theo ngôn ngữ.
+     */
+    public function resxByLanguage(SysLanguage $language)
+    {
+        return $this->hasMany(\Diepxuan\Catalog\Models\SysCompanyResx::class, 'ma_cty', 'ma_cty')
+            ->where('language', $language->Name);
+    }
+}

--- a/diepxuan/laravel-catalog/src/Models/InDmKho.php
+++ b/diepxuan/laravel-catalog/src/Models/InDmKho.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Models;
 
+use Diepxuan\Catalog\Models\Concerns\HasInDmKhoInventoryOperations;
 use Diepxuan\Simba\Models\InDmKho as Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
@@ -20,6 +21,8 @@ use Illuminate\Support\Collection;
 
 class InDmKho extends Model
 {
+    use HasInDmKhoInventoryOperations;
+
     /**
      * Gọi stored procedure asINGetDMKHO để lấy dữ liệu Danh sách kho.
      *

--- a/diepxuan/laravel-catalog/src/Models/PoCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/PoCt1.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models;
+
+use Diepxuan\Catalog\Models\Concerns\HasPoCt1PurchaseMetrics;
+use Diepxuan\Simba\Models\PoCt1 as SimbaModel;
+
+/**
+ * Model PoCt1 - chi tiết đơn mua hàng (catalog layer).
+ *
+ * Mở rộng từ Simba\PoCt1 với chỉ tiêu / báo cáo mua hàng nghiệp vụ
+ * (HasPoCt1PurchaseMetrics).
+ */
+class PoCt1 extends SimbaModel
+{
+    use HasPoCt1PurchaseMetrics;
+}

--- a/diepxuan/laravel-catalog/src/Models/SysCompany.php
+++ b/diepxuan/laravel-catalog/src/Models/SysCompany.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Models;
 
+use Diepxuan\Catalog\Models\Concerns\HasSysCompanyLocalizedResx;
 use Diepxuan\Simba\Models\SysCompany as Model;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class SysCompany extends Model
 {
+    use HasSysCompanyLocalizedResx;
+
     public function siSetup(): HasOne
     {
         return $this->hasOne(SiSetup::class, 'ma_cty', 'ma_cty');

--- a/diepxuan/laravel-simba/src/Models/InDmKho.php
+++ b/diepxuan/laravel-simba/src/Models/InDmKho.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-06-20 13:08:16
+ * @lastupdate 2026-06-22
  */
 
 namespace Diepxuan\Simba\Models;
@@ -17,12 +17,22 @@ use Diepxuan\Simba\Models\Concerns\HasSimbaCompositeKey;
 use Diepxuan\Simba\SModel\InDmKhoModel as Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Class InDmKho.
  *
  * This class represents the model for warehouse master data.
+ *
+ * Behavior nghiệp vụ (tồn kho theo vật tư / giá trị tồn kho) đã được tách
+ * sang `Diepxuan\Catalog\Models\Concerns\HasInDmKhoInventoryOperations`
+ * và gắn vào `Diepxuan\Catalog\Models\InDmKho`.
+ *
+ * Còn giữ ở đây:
+ * - Global scope filter (ma_cty, ma_kho, ten_kho, kho_dl, ksd).
+ * - Scope `active`, `isAgency`.
+ * - Quan hệ Simba-Simba: glDmTk, inDmViTri, inCtNhap, inCtXuat.
+ * - Stored procedure wrapper: getAsINGetDMKHO, getAsINRptCD01
+ *   (Catalog\InDmKho::getAsINGetDMKHO gọi lại qua parent::).
  */
 class InDmKho extends Model
 {
@@ -115,121 +125,40 @@ class InDmKho extends Model
     }
 
     /**
-     * Tính tổng tồn kho theo vật tư
-     * Sử dụng class AsINRptCD02 thay vì gọi stored procedure trực tiếp
-     */
-    public function getInventoryByProduct(string $maVt, ?string $ngay = null): array
-    {
-        $params = [
-            'pMa_Cty' => $this->ma_cty,
-            'pMa_vt' => $maVt,
-            'pMa_kho' => $this->ma_kho,
-            'pNgay' => $ngay ?? date('Y-m-d'),
-        ];
-
-        $result = \Diepxuan\Simba\StoredProcedures\AsINRptCD02::call([
-            'pMa_Cty' => $this->ma_cty,
-            'pMa_vt' => $maVt,
-            'pMa_kho' => $this->ma_kho,
-            'pNgay' => $ngay ?? date('Y-m-d'),
-            // Các tham số khác để null
-            'pMa_vitri' => null,
-            'pTk_vt' => null,
-            'pMa_nhvt' => null,
-            'pDVT' => null,
-            'pNgoai_te' => null,
-            'pDk_Ck' => null,
-            'pMa_lo' => null,
-            'pQuaToiThieu' => null,
-            'pQuaToiDa' => null,
-            'pSysMsg1' => null,
-        ]);
-
-        return $result->isNotEmpty() ? (array) $result->first() : [];
-    }
-
-    /**
-     * Lấy danh sách vật tư tồn kho
-     * Sử dụng class AsINRptCD02 thay vì gọi stored procedure trực tiếp
-     */
-    public function getInventoryList(?string $maNhvt = null, ?string $ngay = null): Collection
-    {
-        return \Diepxuan\Simba\StoredProcedures\AsINRptCD02::call([
-            'pMa_Cty' => $this->ma_cty,
-            'pMa_kho' => $this->ma_kho,
-            'pMa_nhvt' => $maNhvt ?? '',
-            'pNgay' => $ngay ?? date('Y-m-d'),
-            // Các tham số khác để null
-            'pMa_vt' => null,
-            'pMa_vitri' => null,
-            'pTk_vt' => null,
-            'pDVT' => null,
-            'pNgoai_te' => null,
-            'pDk_Ck' => null,
-            'pMa_lo' => null,
-            'pQuaToiThieu' => null,
-            'pQuaToiDa' => null,
-            'pSysMsg1' => null,
-        ]);
-    }
-
-    /**
-     * Tính giá trị tồn kho
-     */
-    public function getInventoryValue(?string $ngay = null): float
-    {
-        $inventoryList = $this->getInventoryList(null, $ngay);
-        
-        $totalValue = 0;
-        foreach ($inventoryList as $item) {
-            $totalValue += ($item->sl_ton ?? 0) * ($item->gia_nt2 ?? 0);
-        }
-        
-        return $totalValue;
-    }
-
-    /**
-     * Gọi stored procedure asINGetDMKHO để lấy danh sách kho
-     * Sử dụng class AsINGetDMKHO thay vì gọi stored procedure trực tiếp
+     * Gọi stored procedure asINGetDMKHO để lấy danh sách kho.
      */
     public static function getAsINGetDMKHO(array $params): Collection
     {
-        // Sử dụng AsINGetDMKHO class để gọi stored procedure
-        // Class sẽ xử lý đúng số lượng tham số (3 tham số thực tế)
         return \Diepxuan\Simba\StoredProcedures\AsINGetDMKHO::call([
             'pMa_Cty'   => $params['pMa_Cty'] ?? '',
             'pMa_kho'   => $params['pMa_kho'] ?? null,
             'pStruct'   => $params['pStruct'] ?? null,
-            'pLanguage' => $params['pLanguage'] ?? null, // Tham số này sẽ bị bỏ qua trong class
+            'pLanguage' => $params['pLanguage'] ?? null,
         ]);
     }
 
     /**
-     * Gọi stored procedure asINRptCD01 để lấy báo cáo tồn kho chi tiết
-     * Sử dụng class AsINRptCD01 thay vì gọi stored procedure trực tiếp
+     * Gọi stored procedure asINRptCD01 để lấy báo cáo tồn kho chi tiết.
      */
     public static function getAsINRptCD01(array $params): Collection
     {
-        // Sử dụng AsINRptCD01 class để gọi stored procedure
-        // Map pMa_Nt to pNgoai_te (foreign currency)
         return \Diepxuan\Simba\StoredProcedures\AsINRptCD01::call([
-            'pMa_Cty' => $params['pMa_Cty'] ?? '',
-            'pMa_kho' => $params['pMa_kho'] ?? '',
-            'pMa_vt'  => $params['pMa_vt'] ?? '',
-            'pNgay1'  => $params['pNgay'] ?? date('Y-m-d'), // Map pNgay to pNgay1
-            'pNgoai_te' => $params['pMa_Nt'] ?? 'VND', // Map pMa_Nt to pNgoai_te
-            // Các tham số khác để null
-            'pNgay2' => null,
-            'pLoai_bc' => null,
-            'pTk_vt' => null,
-            'pMa_nhvt' => null,
-            'pMa_vitri' => null,
-            'pma_plvt1' => null,
-            'pma_plvt2' => null,
-            'pma_plvt3' => null,
-            'pDVT' => null,
-            'pPSDC' => null,
-            'pSysMsg1' => null,
+            'pMa_Cty'    => $params['pMa_Cty'] ?? '',
+            'pMa_kho'    => $params['pMa_kho'] ?? '',
+            'pMa_vt'     => $params['pMa_vt'] ?? '',
+            'pNgay1'     => $params['pNgay'] ?? date('Y-m-d'),
+            'pNgoai_te'  => $params['pMa_Nt'] ?? 'VND',
+            'pNgay2'     => null,
+            'pLoai_bc'   => null,
+            'pTk_vt'     => null,
+            'pMa_nhvt'   => null,
+            'pMa_vitri'  => null,
+            'pma_plvt1'  => null,
+            'pma_plvt2'  => null,
+            'pma_plvt3'  => null,
+            'pDVT'       => null,
+            'pPSDC'      => null,
+            'pSysMsg1'   => null,
         ]);
     }
 }

--- a/diepxuan/laravel-simba/src/Models/PoCt1.php
+++ b/diepxuan/laravel-simba/src/Models/PoCt1.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-06-20 13:08:16
+ * @lastupdate 2026-06-22
  */
 
 namespace Diepxuan\Simba\Models;
@@ -16,13 +16,20 @@ namespace Diepxuan\Simba\Models;
 use Diepxuan\Simba\Models\Concerns\HasSimbaCompositeKey;
 use Diepxuan\Simba\SModel\PoCt1Model as Model;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Class PoCt1.
  *
  * This class represents the model for purchase order details.
+ *
+ * Behavior nghiệp vụ (tổng giá trị / số lượng theo vật tư / nhà cung cấp,
+ * tỷ lệ nhập, các báo cáo mua hàng) đã được tách sang
+ * `Diepxuan\Catalog\Models\Concerns\HasPoCt1PurchaseMetrics`
+ * và gắn vào `Diepxuan\Catalog\Models\PoCt1` (nếu có).
+ *
+ * Còn giữ ở đây:
+ * - Scope filter theo field Simba.
+ * - Quan hệ Simba-Simba: poPh3, inDmVt, inDmKho, inDmViTri, inDmLo, sysDepartment, glDmTkVt, glDmTkThue.
  */
 class PoCt1 extends Model
 {
@@ -62,7 +69,7 @@ class PoCt1 extends Model
     public function scopeFilterByMaNcc(Builder $query, ?string $maNcc): Builder
     {
         if (!empty($maNcc)) {
-            return $query->whereHas('poPh3', function ($q) use ($maNcc) {
+            $query->whereHas('poPh3', function ($q) use ($maNcc): void {
                 $q->where('ma_ncc', $maNcc);
             });
         }
@@ -84,12 +91,12 @@ class PoCt1 extends Model
     public function scopeFilterByNgayCt(Builder $query, ?string $fromDate, ?string $toDate): Builder
     {
         if (!empty($fromDate)) {
-            $query->whereHas('poPh3', function ($q) use ($fromDate) {
+            $query->whereHas('poPh3', function ($q) use ($fromDate): void {
                 $q->whereDate('ngay_ct', '>=', $fromDate);
             });
         }
         if (!empty($toDate)) {
-            $query->whereHas('poPh3', function ($q) use ($toDate) {
+            $query->whereHas('poPh3', function ($q) use ($toDate): void {
                 $q->whereDate('ngay_ct', '<=', $toDate);
             });
         }
@@ -143,159 +150,5 @@ class PoCt1 extends Model
     public function glDmTkThue()
     {
         return $this->belongsTo(GlDmTk::class, 'tk_thue', 'tk');
-    }
-
-    /**
-     * Tính tổng giá trị mua hàng theo vật tư
-     */
-    public static function getTotalPurchaseByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
-    {
-        $query = self::where('ma_cty', $maCty);
-        
-        if ($fromDate || $toDate) {
-            $query->whereHas('poPh3', function ($q) use ($fromDate, $toDate) {
-                if ($fromDate) {
-                    $q->whereDate('ngay_ct', '>=', $fromDate);
-                }
-                if ($toDate) {
-                    $q->whereDate('ngay_ct', '<=', $toDate);
-                }
-            });
-        }
-        
-        return $query->select('ma_vt', DB::raw('SUM(tien0) as tong_gia_tri'), DB::raw('SUM(tien_nt0) as tong_gia_tri_nt'))
-            ->groupBy('ma_vt')
-            ->get();
-    }
-
-    /**
-     * Tính tổng số lượng mua theo vật tư
-     */
-    public static function getTotalQuantityByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
-    {
-        $query = self::where('ma_cty', $maCty);
-        
-        if ($fromDate || $toDate) {
-            $query->whereHas('poPh3', function ($q) use ($fromDate, $toDate) {
-                if ($fromDate) {
-                    $q->whereDate('ngay_ct', '>=', $fromDate);
-                }
-                if ($toDate) {
-                    $q->whereDate('ngay_ct', '<=', $toDate);
-                }
-            });
-        }
-        
-        return $query->select('ma_vt', DB::raw('SUM(so_luong) as tong_so_luong'), DB::raw('SUM(so_luong_qd) as tong_so_luong_qd'))
-            ->groupBy('ma_vt')
-            ->get();
-    }
-
-    /**
-     * Tính tổng giá trị mua hàng theo nhà cung cấp
-     */
-    public static function getTotalPurchaseBySupplier(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
-    {
-        $query = self::where('ma_cty', $maCty);
-        
-        if ($fromDate || $toDate) {
-            $query->whereHas('poPh3', function ($q) use ($fromDate, $toDate) {
-                if ($fromDate) {
-                    $q->whereDate('ngay_ct', '>=', $fromDate);
-                }
-                if ($toDate) {
-                    $q->whereDate('ngay_ct', '<=', $toDate);
-                }
-            });
-        }
-        
-        return $query->select('poPh3.ma_ncc', DB::raw('SUM(po_ct1.tien0) as tong_gia_tri'), DB::raw('SUM(po_ct1.tien_nt0) as tong_gia_tri_nt'))
-            ->join('po_ph3', 'po_ct1.stt_rec', '=', 'po_ph3.stt_rec')
-            ->groupBy('po_ph3.ma_ncc')
-            ->get();
-    }
-
-    /**
-     * Tính tỷ lệ nhập hàng (số lượng đã nhập / số lượng đặt hàng)
-     */
-    public function getReceiptRate(): float
-    {
-        if ($this->so_luong == 0) {
-            return 0;
-        }
-        
-        return ($this->sl_nhap / $this->so_luong) * 100;
-    }
-
-    /**
-     * Gọi stored procedure asPORptMH01 để lấy báo cáo mua hàng
-     */
-    public static function getPORptMH01(array $params): Collection
-    {
-        return collect(DB::connection((new static())->getConnectionName())->select('EXEC asPORptMH01
-            @pMa_Cty = :pMa_Cty,
-            @pNgay_Ct1 = :pNgay_Ct1,
-            @pNgay_Ct2 = :pNgay_Ct2,
-            @pMa_Ncc = :pMa_Ncc,
-            @pMa_Vt = :pMa_Vt,
-            @pMa_Bp = :pMa_Bp,
-            @pMa_Nt = :pMa_Nt
-        ', [
-            'pMa_Cty'   => $params['pMa_Cty'] ?? '',
-            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
-            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
-            'pMa_Ncc'   => $params['pMa_Ncc'] ?? '',
-            'pMa_Vt'    => $params['pMa_Vt'] ?? '',
-            'pMa_Bp'    => $params['pMa_Bp'] ?? '',
-            'pMa_Nt'    => $params['pMa_Nt'] ?? 'VND',
-        ]));
-    }
-
-    /**
-     * Gọi stored procedure asPORptDH01 để lấy báo cáo đặt hàng
-     */
-    public static function getPORptDH01(array $params): Collection
-    {
-        return collect(DB::connection((new static())->getConnectionName())->select('EXEC asPORptDH01
-            @pMa_Cty = :pMa_Cty,
-            @pNgay_Ct1 = :pNgay_Ct1,
-            @pNgay_Ct2 = :pNgay_Ct2,
-            @pMa_Ncc = :pMa_Ncc,
-            @pMa_Vt = :pMa_Vt,
-            @pMa_Bp = :pMa_Bp,
-            @pMa_Nt = :pMa_Nt
-        ', [
-            'pMa_Cty'   => $params['pMa_Cty'] ?? '',
-            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
-            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
-            'pMa_Ncc'   => $params['pMa_Ncc'] ?? '',
-            'pMa_Vt'    => $params['pMa_Vt'] ?? '',
-            'pMa_Bp'    => $params['pMa_Bp'] ?? '',
-            'pMa_Nt'    => $params['pMa_Nt'] ?? 'VND',
-        ]));
-    }
-
-    /**
-     * Gọi stored procedure asPORptNH01 để lấy báo cáo nhập hàng
-     */
-    public static function getPORptNH01(array $params): Collection
-    {
-        return collect(DB::connection((new static())->getConnectionName())->select('EXEC asPORptNH01
-            @pMa_Cty = :pMa_Cty,
-            @pNgay_Ct1 = :pNgay_Ct1,
-            @pNgay_Ct2 = :pNgay_Ct2,
-            @pMa_Ncc = :pMa_Ncc,
-            @pMa_Vt = :pMa_Vt,
-            @pMa_Bp = :pMa_Bp,
-            @pMa_Nt = :pMa_Nt
-        ', [
-            'pMa_Cty'   => $params['pMa_Cty'] ?? '',
-            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
-            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
-            'pMa_Ncc'   => $params['pMa_Ncc'] ?? '',
-            'pMa_Vt'    => $params['pMa_Vt'] ?? '',
-            'pMa_Bp'    => $params['pMa_Bp'] ?? '',
-            'pMa_Nt'    => $params['pMa_Nt'] ?? 'VND',
-        ]));
     }
 }

--- a/diepxuan/laravel-simba/src/Models/SysCompany.php
+++ b/diepxuan/laravel-simba/src/Models/SysCompany.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-05-24 21:25:54
+ * @lastupdate 2026-06-22
  */
 
 namespace Diepxuan\Simba\Models;
@@ -16,6 +16,16 @@ namespace Diepxuan\Simba\Models;
 use Diepxuan\Simba\SModel\sysCompanyModel as Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
+/**
+ * SysCompany - danh sách công ty.
+ *
+ * Helper nghiệp vụ `resxByLanguage()` đã được tách sang
+ * `Diepxuan\Catalog\Models\Concerns\HasSysCompanyLocalizedResx`
+ * và gắn vào `Diepxuan\Catalog\Models\SysCompany`.
+ *
+ * Còn giữ ở đây:
+ * - Quan hệ Simba-Simba: userRights, resx, users.
+ */
 class SysCompany extends Model
 {
     public function userRights()
@@ -28,19 +38,10 @@ class SysCompany extends Model
         return $this->hasMany(SysCompanyResx::class, 'ma_cty', 'ma_cty');
     }
 
-    public function resxByLanguage(SysLanguage $language)
-    {
-        return $this->hasMany(SysCompanyResx::class, 'ma_cty', 'ma_cty')
-            ->where('language', $language->Name)
-        ;
-    }
-
     /**
      * Get the users associated with the company.
-     *
-     * @return BelongsToMany
      */
-    public function users()
+    public function users(): BelongsToMany
     {
         return $this->belongsToMany(
             SysUserInfo::class,

--- a/docs/project/simba-model-layer-refactor-plan.md
+++ b/docs/project/simba-model-layer-refactor-plan.md
@@ -273,9 +273,9 @@ Các bước còn lại:
 
 ### Plan cho các cụm còn lại (Phase 1 audit đã chỉ ra)
 
-- `InDmKho` (cụm Inventory): method `getInventoryByProduct`, `getInventoryList`, `getInventoryValue`. Tạo `HasInDmKhInventoryOperations` ở catalog.
-- `PoCt1` (cụm PO voucher): method `getReceiptRate`. Tạo `HasPoCt1ReceiptRate` ở catalog hoặc giữ helper query nếu thuần tính toán trên row.
-- `SysCompany` (cụm Sys): method `resxByLanguage`. Helper nghiệp vụ, chuyển sang catalog.
+- [x] `InDmKho` (cụm Inventory): method `getInventoryByProduct`, `getInventoryList`, `getInventoryValue`. Tạo `HasInDmKhoInventoryOperations` ở catalog.
+- [x] `PoCt1` (cụm PO voucher): method `getTotalPurchaseByProduct`, `getTotalQuantityByProduct`, `getTotalPurchaseBySupplier`, `getReceiptRate`, `getPORptMH01`, `getPORptDH01`, `getPORptNH01`. Tạo `HasPoCt1PurchaseMetrics` ở catalog.
+- [x] `SysCompany` (cụm Sys): method `resxByLanguage`. Helper nghiệp vụ, chuyển sang catalog qua `HasSysCompanyLocalizedResx`.
 
 Mỗi cụm một PR nhỏ.
 


### PR DESCRIPTION
## Summary

Phase 2 batch: tách các method nghiệp vụ còn lại (move_catalog) ra khỏi Simba\Models sang Catalog\Models thông qua 3 concern mới.

## Concerns mới (catalog)

- HasInDmKhoInventoryOperations: getInventoryByProduct, getInventoryList, getInventoryValue.
- HasPoCt1PurchaseMetrics: getTotalPurchaseByProduct, getTotalQuantityByProduct, getTotalPurchaseBySupplier, getReceiptRate, getPORptMH01/DH01/NH01, helper executeRptSp.
- HasSysCompanyLocalizedResx: resxByLanguage.

## Simba gỡ

- InDmKho.php: -69 dòng (3 method inventory), giữ scope/relation/getAsIN* wrapper.
- PoCt1.php: -130 dòng (7 method report/metrics), giữ scope/relation Simba-Simba.
- SysCompany.php: -7 dòng (resxByLanguage), giữ userRights/resx/users.

## Catalog gắn

- InDmKho.php: use HasInDmKhoInventoryOperations.
- PoCt1.php: tạo mới, use HasPoCt1PurchaseMetrics.
- SysCompany.php: use HasSysCompanyLocalizedResx.

## Verify

- php -l: 9/9 pass.
- git diff --check: pass.
- Reflection:
  - Simba\InDmKho: getInventory*=0, getAsINGetDMKHO=1.
  - Simba\PoCt1: getReceiptRate=0, getPORpt*=0, getTotalPurchase*=0.
  - Simba\SysCompany: resxByLanguage=0, resx=1, users=1.
  - Catalog\InDmKho: getInventory*=1, getAsINGetDMKHO=1 (inherited).
  - Catalog\PoCt1: getReceiptRate=1, getPORpt*=1, getTotalPurchase*=1.
  - Catalog\SysCompany: resxByLanguage=1, resx=1 (inherited), users=1 (inherited).
- Caller ngoài (audit bằng grep): chỉ Catalog\InDmKho::getAsINGetDMKHO qua parent:: (vẫn còn trên Simba base). Không có caller ngoài cho getInventory*, getReceiptRate, getPORpt*, getTotal*, resxByLanguage.

## Plan ref

docs/project/simba-model-layer-refactor-plan.md (Phase 2 cụm còn lại đã done).