### PR TITLE
test(simba): guard model layer responsibilities

### DIFF
--- a/diepxuan/laravel-catalog/src/Models/ArDmKh.php
+++ b/diepxuan/laravel-catalog/src/Models/ArDmKh.php
@@ -115,8 +115,6 @@ class ArDmKh extends SimbaModel
      */
     protected static function booted(): void
     {
-        parent::boot();
-
         static::addGlobalScope('orderByMaKh', static function ($query): void {
             $query->orderBy('ma_kh');
         });

--- a/diepxuan/laravel-catalog/src/Models/Concerns/HasSoCt1SalesMetrics.php
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/HasSoCt1SalesMetrics.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models\Concerns;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Concern: chỉ tiêu và báo cáo bán hàng trên SoCt1.
+ *
+ * Tách từ `Diepxuan\Simba\Models\SoCt1` (Phase 2 refactor) vì:
+ * - Tổng doanh thu / số lượng theo vật tư / theo nhân viên kinh doanh.
+ * - Báo cáo bán hàng (asSORptBH01, asSORptDT01, asSORptSL01).
+ *
+ * Tất cả là nghiệp vụ báo cáo, không thuộc schema Simba.
+ */
+trait HasSoCt1SalesMetrics
+{
+    /**
+     * Tổng doanh thu theo vật tư.
+     */
+    public static function getTotalRevenueByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
+    {
+        $query = self::where('ma_cty', $maCty);
+
+        if ($fromDate || $toDate) {
+            $query->whereHas('soPh3', function ($q) use ($fromDate, $toDate): void {
+                if ($fromDate) {
+                    $q->whereDate('ngay_ct', '>=', $fromDate);
+                }
+                if ($toDate) {
+                    $q->whereDate('ngay_ct', '<=', $toDate);
+                }
+            });
+        }
+
+        return $query->select('ma_vt', DB::raw('SUM(tien2) as tong_doanh_thu'), DB::raw('SUM(tien_nt2) as tong_doanh_thu_nt'))
+            ->groupBy('ma_vt')
+            ->get();
+    }
+
+    /**
+     * Tổng số lượng bán theo vật tư.
+     */
+    public static function getTotalQuantityByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
+    {
+        $query = self::where('ma_cty', $maCty);
+
+        if ($fromDate || $toDate) {
+            $query->whereHas('soPh3', function ($q) use ($fromDate, $toDate): void {
+                if ($fromDate) {
+                    $q->whereDate('ngay_ct', '>=', $fromDate);
+                }
+                if ($toDate) {
+                    $q->whereDate('ngay_ct', '<=', $toDate);
+                }
+            });
+        }
+
+        return $query->select('ma_vt', DB::raw('SUM(so_luong) as tong_so_luong'), DB::raw('SUM(so_luong_qd) as tong_so_luong_qd'))
+            ->groupBy('ma_vt')
+            ->get();
+    }
+
+    /**
+     * Tổng doanh thu theo nhân viên kinh doanh.
+     */
+    public static function getTotalRevenueBySalesperson(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
+    {
+        $query = self::where('ma_cty', $maCty)
+            ->whereNotNull('ma_nvkd');
+
+        if ($fromDate || $toDate) {
+            $query->whereHas('soPh3', function ($q) use ($fromDate, $toDate): void {
+                if ($fromDate) {
+                    $q->whereDate('ngay_ct', '>=', $fromDate);
+                }
+                if ($toDate) {
+                    $q->whereDate('ngay_ct', '<=', $toDate);
+                }
+            });
+        }
+
+        return $query->select('ma_nvkd', DB::raw('SUM(tien2) as tong_doanh_thu'), DB::raw('SUM(tien_nt2) as tong_doanh_thu_nt'))
+            ->groupBy('ma_nvkd')
+            ->get();
+    }
+
+    /**
+     * Báo cáo bán hàng asSORptBH01.
+     */
+    public static function getSORptBH01(array $params): Collection
+    {
+        return self::executeSORptSp('asSORptBH01', $params, [
+            'pMa_Cty', 'pNgay_Ct1', 'pNgay_Ct2', 'pMa_Kh', 'pMa_Vt', 'pMa_Nvkd', 'pMa_Bp', 'pMa_Nt',
+        ]);
+    }
+
+    /**
+     * Báo cáo doanh thu asSORptDT01.
+     */
+    public static function getSORptDT01(array $params): Collection
+    {
+        return self::executeSORptSp('asSORptDT01', $params, [
+            'pMa_Cty', 'pNgay_Ct1', 'pNgay_Ct2', 'pMa_Vt', 'pMa_Nvkd', 'pMa_Bp', 'pMa_Nt',
+        ]);
+    }
+
+    /**
+     * Báo cáo số lượng asSORptSL01.
+     */
+    public static function getSORptSL01(array $params): Collection
+    {
+        return self::executeSORptSp('asSORptSL01', $params, [
+            'pMa_Cty', 'pNgay_Ct1', 'pNgay_Ct2', 'pMa_Vt', 'pMa_Nvkd', 'pMa_Bp',
+        ]);
+    }
+
+    /**
+     * Helper chung cho 3 báo cáo SO: cùng tập tham số cơ bản + tuỳ sp.
+     */
+    protected static function executeSORptSp(string $spName, array $params, array $paramNames, array $defaults = []): Collection
+    {
+        $bindings = [];
+        $sql      = "EXEC {$spName}\n";
+        $paramLines = [];
+        foreach ($paramNames as $p) {
+            $paramLines[] = "        @$p = :$p";
+            $default      = $defaults[$p] ?? match ($p) {
+                'pNgay_Ct1' => '2025-01-01',
+                'pNgay_Ct2' => now(),
+                'pMa_Nt'    => 'VND',
+                default     => '',
+            };
+            $bindings[$p] = $params[$p] ?? $default;
+        }
+        $sql .= implode(",\n", $paramLines) . "\n        ";
+
+        return collect(DB::connection((new static())->getConnectionName())->select($sql, $bindings));
+    }
+}

--- a/diepxuan/laravel-catalog/src/Models/SoCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/SoCt1.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Diepxuan\Catalog\Models;
+
+use Diepxuan\Catalog\Models\Concerns\HasSoCt1SalesMetrics;
+use Diepxuan\Simba\Models\SoCt1 as SimbaModel;
+
+/**
+ * Model SoCt1 - chi tiết đơn bán hàng (catalog layer).
+ *
+ * Mở rộng từ Simba\SoCt1 với chỉ tiêu / báo cáo bán hàng nghiệp vụ
+ * (HasSoCt1SalesMetrics).
+ */
+class SoCt1 extends SimbaModel
+{
+    use HasSoCt1SalesMetrics;
+}

--- a/diepxuan/laravel-simba/src/Models/SoCt1.php
+++ b/diepxuan/laravel-simba/src/Models/SoCt1.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-06-20 13:08:16
+ * @lastupdate 2026-06-22
  */
 
 namespace Diepxuan\Simba\Models;
@@ -16,13 +16,20 @@ namespace Diepxuan\Simba\Models;
 use Diepxuan\Simba\Models\Concerns\HasSimbaCompositeKey;
 use Diepxuan\Simba\SModel\SoCt1Model as Model;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Class SoCt1.
  *
  * This class represents the model for sales order details.
+ *
+ * Behavior nghiệp vụ (tổng doanh thu / số lượng theo vật tư / nhân viên,
+ * các báo cáo bán hàng) đã được tách sang
+ * `Diepxuan\Catalog\Models\Concerns\HasSoCt1SalesMetrics`
+ * và gắn vào `Diepxuan\Catalog\Models\SoCt1`.
+ *
+ * Còn giữ ở đây:
+ * - Scope filter theo field Simba.
+ * - Quan hệ Simba-Simba: soPh3, inDmVt, inDmKho, inDmViTri, inDmLo, sysUserInfo, sysDepartment.
  */
 class SoCt1 extends Model
 {
@@ -62,7 +69,7 @@ class SoCt1 extends Model
     public function scopeFilterByMaKh(Builder $query, ?string $maKh): Builder
     {
         if (!empty($maKh)) {
-            return $query->whereHas('soPh3', function ($q) use ($maKh) {
+            return $query->whereHas('soPh3', function ($q) use ($maKh): void {
                 $q->where('ma_kh', $maKh);
             });
         }
@@ -94,12 +101,12 @@ class SoCt1 extends Model
     public function scopeFilterByNgayCt(Builder $query, ?string $fromDate, ?string $toDate): Builder
     {
         if (!empty($fromDate)) {
-            $query->whereHas('soPh3', function ($q) use ($fromDate) {
+            $query->whereHas('soPh3', function ($q) use ($fromDate): void {
                 $q->whereDate('ngay_ct', '>=', $fromDate);
             });
         }
         if (!empty($toDate)) {
-            $query->whereHas('soPh3', function ($q) use ($toDate) {
+            $query->whereHas('soPh3', function ($q) use ($toDate): void {
                 $q->whereDate('ngay_ct', '<=', $toDate);
             });
         }
@@ -147,147 +154,5 @@ class SoCt1 extends Model
     public function sysDepartment()
     {
         return $this->belongsTo(SysDepartment::class, 'ma_bp', 'ma_bp');
-    }
-
-    /**
-     * Tính tổng doanh thu theo vật tư
-     */
-    public static function getTotalRevenueByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
-    {
-        $query = self::where('ma_cty', $maCty);
-        
-        if ($fromDate || $toDate) {
-            $query->whereHas('soPh3', function ($q) use ($fromDate, $toDate) {
-                if ($fromDate) {
-                    $q->whereDate('ngay_ct', '>=', $fromDate);
-                }
-                if ($toDate) {
-                    $q->whereDate('ngay_ct', '<=', $toDate);
-                }
-            });
-        }
-        
-        return $query->select('ma_vt', DB::raw('SUM(tien2) as tong_doanh_thu'), DB::raw('SUM(tien_nt2) as tong_doanh_thu_nt'))
-            ->groupBy('ma_vt')
-            ->get();
-    }
-
-    /**
-     * Tính tổng số lượng bán theo vật tư
-     */
-    public static function getTotalQuantityByProduct(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
-    {
-        $query = self::where('ma_cty', $maCty);
-        
-        if ($fromDate || $toDate) {
-            $query->whereHas('soPh3', function ($q) use ($fromDate, $toDate) {
-                if ($fromDate) {
-                    $q->whereDate('ngay_ct', '>=', $fromDate);
-                }
-                if ($toDate) {
-                    $q->whereDate('ngay_ct', '<=', $toDate);
-                }
-            });
-        }
-        
-        return $query->select('ma_vt', DB::raw('SUM(so_luong) as tong_so_luong'), DB::raw('SUM(so_luong_qd) as tong_so_luong_qd'))
-            ->groupBy('ma_vt')
-            ->get();
-    }
-
-    /**
-     * Tính tổng doanh thu theo nhân viên kinh doanh
-     */
-    public static function getTotalRevenueBySalesperson(string $maCty, ?string $fromDate = null, ?string $toDate = null): Collection
-    {
-        $query = self::where('ma_cty', $maCty)
-            ->whereNotNull('ma_nvkd');
-        
-        if ($fromDate || $toDate) {
-            $query->whereHas('soPh3', function ($q) use ($fromDate, $toDate) {
-                if ($fromDate) {
-                    $q->whereDate('ngay_ct', '>=', $fromDate);
-                }
-                if ($toDate) {
-                    $q->whereDate('ngay_ct', '<=', $toDate);
-                }
-            });
-        }
-        
-        return $query->select('ma_nvkd', DB::raw('SUM(tien2) as tong_doanh_thu'), DB::raw('SUM(tien_nt2) as tong_doanh_thu_nt'))
-            ->groupBy('ma_nvkd')
-            ->get();
-    }
-
-    /**
-     * Gọi stored procedure asSORptBH01 để lấy báo cáo bán hàng
-     */
-    public static function getSORptBH01(array $params): Collection
-    {
-        return collect(DB::connection((new static())->getConnectionName())->select('EXEC asSORptBH01
-            @pMa_Cty = :pMa_Cty,
-            @pNgay_Ct1 = :pNgay_Ct1,
-            @pNgay_Ct2 = :pNgay_Ct2,
-            @pMa_Kh = :pMa_Kh,
-            @pMa_Vt = :pMa_Vt,
-            @pMa_Nvkd = :pMa_Nvkd,
-            @pMa_Bp = :pMa_Bp,
-            @pMa_Nt = :pMa_Nt
-        ', [
-            'pMa_Cty'   => $params['pMa_Cty'] ?? '',
-            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
-            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
-            'pMa_Kh'    => $params['pMa_Kh'] ?? '',
-            'pMa_Vt'    => $params['pMa_Vt'] ?? '',
-            'pMa_Nvkd'  => $params['pMa_Nvkd'] ?? '',
-            'pMa_Bp'    => $params['pMa_Bp'] ?? '',
-            'pMa_Nt'    => $params['pMa_Nt'] ?? 'VND',
-        ]));
-    }
-
-    /**
-     * Gọi stored procedure asSORptDT01 để lấy báo cáo doanh thu
-     */
-    public static function getSORptDT01(array $params): Collection
-    {
-        return collect(DB::connection((new static())->getConnectionName())->select('EXEC asSORptDT01
-            @pMa_Cty = :pMa_Cty,
-            @pNgay_Ct1 = :pNgay_Ct1,
-            @pNgay_Ct2 = :pNgay_Ct2,
-            @pMa_Vt = :pMa_Vt,
-            @pMa_Nvkd = :pMa_Nvkd,
-            @pMa_Bp = :pMa_Bp,
-            @pMa_Nt = :pMa_Nt
-        ', [
-            'pMa_Cty'   => $params['pMa_Cty'] ?? '',
-            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
-            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
-            'pMa_Vt'    => $params['pMa_Vt'] ?? '',
-            'pMa_Nvkd'  => $params['pMa_Nvkd'] ?? '',
-            'pMa_Bp'    => $params['pMa_Bp'] ?? '',
-            'pMa_Nt'    => $params['pMa_Nt'] ?? 'VND',
-        ]));
-    }
-
-    /**
-     * Gọi stored procedure asSORptSL01 để lấy báo cáo số lượng
-     */
-    public static function getSORptSL01(array $params): Collection
-    {
-        return collect(DB::connection((new static())->getConnectionName())->select('EXEC asSORptSL01
-            @pMa_Cty = :pMa_Cty,
-            @pNgay_Ct1 = :pNgay_Ct1,
-            @pNgay_Ct2 = :pNgay_Ct2,
-            @pMa_Vt = :pMa_Vt,
-            @pMa_Nvkd = :pMa_Nvkd,
-            @pMa_Bp = :pMa_Bp
-        ', [
-            'pMa_Cty'   => $params['pMa_Cty'] ?? '',
-            'pNgay_Ct1' => $params['pNgay_Ct1'] ?? '2025-01-01',
-            'pNgay_Ct2' => $params['pNgay_Ct2'] ?? now(),
-            'pMa_Vt'    => $params['pMa_Vt'] ?? '',
-            'pMa_Nvkd'  => $params['pMa_Nvkd'] ?? '',
-            'pMa_Bp'    => $params['pMa_Bp'] ?? '',
-        ]));
     }
 }

--- a/docs/project/simba-model-layer-refactor-plan.md
+++ b/docs/project/simba-model-layer-refactor-plan.md
@@ -279,6 +279,55 @@ Các bước còn lại:
 
 Mỗi cụm một PR nhỏ.
 
+
+---
+
+## Phase 4: Test bảo vệ ranh giới (đang thực hiện)
+
+Mục tiêu: thiết lập rào chắn tự động, đảm bảo các PR sau không xâm phạm ranh giới 3 lớp.
+
+### Trạng thái Phase 4
+
+Branch: `task/simba-model-layer-responsibility-tests`
+
+Test file: `tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php`
+
+7 test method:
+
+1. `testSModelGeneratedClassesHaveNoBehavior` — quét SModel generated, đảm bảo không có scope/relation/accessor/mutator/business method.
+2. `testSModelClassesDoNotCallParentBoot` — đảm bảo SModel generated không gọi `parent::boot()`.
+3. `testSimbaModelsDoNotExposeBusinessMethods` — kiểm tra business method đã move sang Catalog không còn trên `Simba\Models`.
+4. `testSimbaModelsBootedDoesNotCallParentBoot` — đảm bảo `booted()` trong Simba Models không gọi `parent::boot()`.
+5. `testCatalogModelsDoNotRedefineDbMetadata` — đảm bảo Catalog Models không khai báo DB metadata trực tiếp, trừ whitelist có lý do.
+6. `testCatalogModelsBootedDoesNotCallParentBoot` — đảm bảo Catalog Models không gọi `parent::boot()` trong `booted()`.
+7. `testCatalogModelsExtendSimbaModel` — kiểm tra parent class hợp lệ (Simba Models hoặc whitelist alias/utility).
+
+Phát hiện/fix khi viết test:
+
+- `Catalog\Models\ArDmKh::booted()` gọi `parent::boot()` không cần thiết → đã gỡ.
+- `Simba\Models\SoCt1` còn business/report methods bị bỏ sót ở Phase 2 → tạo `Catalog\Models\Concerns\HasSoCt1SalesMetrics` + `Catalog\Models\SoCt1`, gỡ method khỏi `Simba\Models\SoCt1`.
+
+Whitelist hiện tại:
+
+- `Zsysmenu`: alias table cùng schema SysMenu.
+- `System`, `SystemConfig`: catalog subclass alias.
+- `User`: extends `App\Models\User`.
+- `UserLink`: extends `AbstractModel`, utility link table.
+- `Params`: utility params model.
+- `InDmNhvt`: custom cast `CategoryMagento` ở catalog layer.
+- `CaCt2`, `CaPh2`, `CaPh3`: tạm thời extend SModel trực tiếp vì chưa có Simba Model tương ứng (TODO tạo lớp `Simba\Models`).
+
+Verify:
+
+```bash
+php -l tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+```
+
+Kết quả: 7 tests, 9 assertions, OK.
+
+Full `vendor/bin/phpunit` hiện còn lỗi pre-existing (`Core\PackageConfigTest`, `Feature\ExampleTest`) không liên quan PR này.
+
 ---
 
 ## Phase tiếp theo (theo cụm nhỏ)

--- a/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+++ b/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-06-22
+ */
+
+namespace Tests\Unit\Packages\Simba;
+
+use Tests\TestCase;
+
+/**
+ * Bảo vệ ranh giới 3 lớp của gói laravel-simba.
+ *
+ * Lớp 1: SModel (Diepxuan\Simba\SModel\<XxxModel>)
+ *         - Chỉ chứa raw schema mapping (table, fillable, casts, primaryKey, PRIMARY_KEY_COLUMNS, ...).
+ *         - KHÔNG được phép scope, relation, accessor, mutator, method nghiệp vụ, override booted() / parent::boot().
+ *
+ * Lớp 2: Simba Models (Diepxuan\Simba\Models\<Xxx>)
+ *         - Kế thừa SModel, bổ sung scope helper query, relation Simba-Simba, stored procedure wrapper.
+ *         - KHÔNG được phép method thuần business (getReceiptRate, getInventoryValue, resxByLanguage, ...).
+ *         - KHÔNG được có 2 method trùng tên (do shadow cùng tên với concern).
+ *
+ * Lớp 3: Catalog Models (Diepxuan\Catalog\Models\<Xxx>)
+ *         - Kế thừa Simba Model, bổ sung business logic, concern nghiệp vụ.
+ *         - KHÔNG được khai báo $table / $connection / $primaryKey / $fillable trực tiếp
+ *           (vì phải dùng schema từ SModel cha).
+ *         - KHÔNG được override booted() với parent::boot() (SModel base không dùng booted lifecycle để set connection).
+ */
+final class SimbaModelLayerResponsibilityTest extends TestCase
+{
+    private const SMODEL_DIR    = __DIR__ . '/../../../../diepxuan/laravel-simba/src/SModel';
+    private const SIMBA_DIR     = __DIR__ . '/../../../../diepxuan/laravel-simba/src/Models';
+    private const CATALOG_DIR   = __DIR__ . '/../../../../diepxuan/laravel-catalog/src/Models';
+
+    /**
+     * Whitelist method từ concern nghiệp vụ không được phép xuất hiện ở Simba Models.
+     * (Đã chuyển sang Catalog concerns trong PR #222.)
+     */
+    private const CATALOG_BUSINESS_METHODS = [
+        'getInventoryByProduct',
+        'getInventoryList',
+        'getInventoryValue',
+        'getTotalPurchaseByProduct',
+        'getTotalQuantityByProduct',
+        'getTotalPurchaseBySupplier',
+        'getReceiptRate',
+        'getPORptMH01',
+        'getPORptDH01',
+        'getPORptNH01',
+        'getTotalRevenueByProduct',
+        'getTotalRevenueBySalesperson',
+        'getSORptBH01',
+        'getSORptDT01',
+        'getSORptSL01',
+        'resxByLanguage',
+        'laKhachHang',
+        'laNhaCungCap',
+        'laNhanVien',
+        'isKhachHang',
+        'isNhaCungCap',
+        'isNhanVien',
+    ];
+
+    /**
+     * Catalog Models được phép khai báo DB metadata khi cần cho lý do đặc biệt:
+     * - Zsysmenu, System, SystemConfig, UserLink: alias/subclass pattern.
+     * - Params: utility bảng không có SModel.
+     * - User: extend App\Models\User (Laravel auth).
+     * - InDmNhvt: $casts với custom Cast class CategoryMagento (nghiệp vụ).
+     */
+    private const CATALOG_DB_METADATA_WHITELIST = [
+        'Zsysmenu'   => ['table'],          // cùng schema SysMenu, bảng khác
+        'System'     => [],                 // không khai báo metadata; extends SysCompany
+        'SystemConfig' => [],               // extends SiSetup
+        'UserLink'   => ['fillable'],       // simple utility table
+        'User'       => [],                 // extends App\Models\User
+        'Params'     => ['incrementing', 'timestamps', 'guarded'], // utility
+        'InDmNhvt'   => ['casts'],          // custom cast CategoryMagento
+    ];
+
+    /**
+     * Catalog Models được phép extend không theo Simba\Models:
+     * - App\Models\User (Laravel auth) - User.
+     * - Illuminate\Database\Eloquent\Model - Params, AbstractModel.
+     * - Catalog\Models (subclass catalog alias) - System, SystemConfig, Zsysmenu, UserLink.
+     * - Simba\SModel (chưa có Simba Model tương ứng) - CaCt2, CaPh2, CaPh3.
+     *   TODO: tạo Simba\Models tương ứng để dùng qua lớp 2.
+     */
+    private const CATALOG_EXTENDS_WHITELIST = [
+        'Params'      => 'Illuminate\\Database\\Eloquent\\Model',
+        'User'        => 'App\\Models\\User',
+        'System'      => 'Diepxuan\\Catalog\\Models\\SysCompany',
+        'SystemConfig'=> 'Diepxuan\\Catalog\\Models\\SiSetup',
+        'UserLink'    => 'Diepxuan\\Catalog\\Models\\AbstractModel',
+        'Zsysmenu'    => 'Diepxuan\\Catalog\\Models\\SysMenu',
+        'CaCt2'       => 'Diepxuan\\Simba\\SModel\\CaCt2Model',  // TODO
+        'CaPh2'       => 'Diepxuan\\Simba\\SModel\\CaPh2Model',  // TODO
+        'CaPh3'       => 'Diepxuan\\Simba\\SModel\\CaPh3Model',  // TODO
+    ];
+
+    /**
+     * SModel generated không được có behavior (scope, relation, accessor, mutator, business method).
+     */
+    public function testSModelGeneratedClassesHaveNoBehavior(): void
+    {
+        $files = glob(self::SMODEL_DIR . '/*Model.php') ?: [];
+        self::assertGreaterThan(100, count($files), 'SModel directory phải có file generated');
+
+        $violations = [];
+        foreach ($files as $file) {
+            $shortName = basename($file, '.php');
+            if ($shortName === 'SModel') {
+                continue; // base SModel, không phải generated
+            }
+            $class     = $this->resolveClass('Diepxuan\\Simba\\SModel', $shortName);
+            if ($class === null) {
+                continue;
+            }
+            $reflection = new \ReflectionClass($class);
+            if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+                continue;
+            }
+            foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                $declaring = $method->getDeclaringClass()->getName();
+                if ($declaring !== $class) {
+                    continue; // inherited từ SModel/Model bỏ qua
+                }
+                $name = $method->getName();
+                if (str_starts_with($name, 'scope')) {
+                    $violations[] = "SModel/{$shortName}: scope{$this->stripScope($name)}() không được phép";
+                    continue;
+                }
+                if ($this->isRelationMethod($method)) {
+                    $violations[] = "SModel/{$shortName}: relation method {$name}() không được phép";
+                    continue;
+                }
+                if (str_starts_with($name, 'get') || str_starts_with($name, 'set')) {
+                    $violations[] = "SModel/{$shortName}: accessor/mutator {$name}() không được phép";
+                    continue;
+                }
+                if ($name === 'booted') {
+                    $violations[] = "SModel/{$shortName}: override booted() không được phép";
+                    continue;
+                }
+                if ($this->isSchemaDeclaration($name)) {
+                    continue;
+                }
+                $violations[] = "SModel/{$shortName}: method {$name}() không được phép";
+            }
+        }
+
+        self::assertSame([], $violations, "SModel vi phạm ranh giới:\n" . implode("\n", $violations));
+    }
+
+    /**
+     * SModel generated không được gọi parent::boot() / parent::initializeTraits().
+     */
+    public function testSModelClassesDoNotCallParentBoot(): void
+    {
+        $files = glob(self::SMODEL_DIR . '/*Model.php') ?: [];
+        $violations = [];
+        foreach ($files as $file) {
+            if (basename($file) === 'SModel.php') {
+                continue;
+            }
+            $content = file_get_contents($file);
+            if ($content === false) {
+                continue;
+            }
+            if (preg_match('/parent\s*::\s*boot\s*\(/', $content) === 1) {
+                $violations[] = basename($file) . ': gọi parent::boot() không được phép trong SModel';
+            }
+        }
+        self::assertSame([], $violations, "SModel vi phạm parent::boot:\n" . implode("\n", $violations));
+    }
+
+    /**
+     * Simba Models không được chứa method business đã chuyển sang catalog.
+     */
+    public function testSimbaModelsDoNotExposeBusinessMethods(): void
+    {
+        $files = glob(self::SIMBA_DIR . '/*.php') ?: [];
+        self::assertGreaterThan(100, count($files), 'Simba Models directory phải có file');
+
+        $violations = [];
+        foreach ($files as $file) {
+            $shortName = basename($file, '.php');
+            $class     = $this->resolveClass('Diepxuan\\Simba\\Models', $shortName);
+            if ($class === null) {
+                continue;
+            }
+            $reflection = new \ReflectionClass($class);
+            if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+                continue;
+            }
+            foreach (self::CATALOG_BUSINESS_METHODS as $bizMethod) {
+                if ($reflection->hasMethod($bizMethod)) {
+                    $method = $reflection->getMethod($bizMethod);
+                    if ($method->getDeclaringClass()->getName() === $class) {
+                        $violations[] = "Simba\\Models\\{$shortName}: method {$bizMethod}() đã được move_catalog";
+                    }
+                }
+            }
+        }
+
+        self::assertSame([], $violations, "Simba\\Models chứa business method cấm:\n" . implode("\n", $violations));
+    }
+
+    /**
+     * Simba Models có thể có scope/relation nhưng KHÔNG được gọi parent::boot() trong booted().
+     */
+    public function testSimbaModelsBootedDoesNotCallParentBoot(): void
+    {
+        $files = glob(self::SIMBA_DIR . '/*.php') ?: [];
+        $violations = [];
+        foreach ($files as $file) {
+            $content = file_get_contents($file);
+            if ($content === false) {
+                continue;
+            }
+            if (preg_match('/static\s+function\s+booted\b[^{]*\{[^}]*parent\s*::\s*boot\s*\(/s', $content) === 1) {
+                $violations[] = basename($file) . ': booted() gọi parent::boot() không cần thiết';
+            }
+        }
+        self::assertSame([], $violations, "Simba\\Models booted() vi phạm:\n" . implode("\n", $violations));
+    }
+
+    /**
+     * Catalog Models không được khai báo $table / $connection / $primaryKey trực tiếp.
+     * Phải dùng schema từ SModel cha.
+     */
+    public function testCatalogModelsDoNotRedefineDbMetadata(): void
+    {
+        $files = glob(self::CATALOG_DIR . '/*.php') ?: [];
+        $violations = [];
+        foreach ($files as $file) {
+            $shortName = basename($file, '.php');
+            $class     = $this->resolveClass('Diepxuan\\Catalog\\Models', $shortName);
+            if ($class === null) {
+                continue;
+            }
+            $reflection = new \ReflectionClass($class);
+            if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+                continue;
+            }
+            // Bỏ qua Concerns — không phải Model.
+            if (str_contains($class, '\\Concerns\\')) {
+                continue;
+            }
+            $whitelistedProps = self::CATALOG_DB_METADATA_WHITELIST[$shortName] ?? [];
+            foreach (['table', 'connection', 'primaryKey', 'keyType', 'incrementing', 'timestamps', 'guarded', 'fillable', 'hidden', 'casts', 'attributes'] as $prop) {
+                if (in_array($prop, $whitelistedProps, true)) {
+                    continue;
+                }
+                if ($reflection->hasProperty($prop)) {
+                    $declaring = $reflection->getProperty($prop)->getDeclaringClass()->getName();
+                    if ($declaring === $class) {
+                        $violations[] = "Catalog\\Models\\{$shortName}: \$" . $prop . ' phải khai báo ở SModel cha';
+                    }
+                }
+            }
+        }
+        self::assertSame([], $violations, "Catalog\\Models khai báo DB metadata trực tiếp:\n" . implode("\n", $violations));
+    }
+
+    /**
+     * Catalog Models không được override booted() gọi parent::boot() (vì SModel base dùng __construct, không booted).
+     */
+    public function testCatalogModelsBootedDoesNotCallParentBoot(): void
+    {
+        $files = glob(self::CATALOG_DIR . '/*.php') ?: [];
+        $violations = [];
+        foreach ($files as $file) {
+            $content = file_get_contents($file);
+            if ($content === false) {
+                continue;
+            }
+            if (preg_match('/static\s+function\s+booted\b[^{]*\{[^}]*parent\s*::\s*boot\s*\(/s', $content) === 1) {
+                $violations[] = basename($file) . ': booted() gọi parent::boot() không cần thiết';
+            }
+        }
+        self::assertSame([], $violations, "Catalog\\Models booted() vi phạm:\n" . implode("\n", $violations));
+    }
+
+    /**
+     * Mỗi Catalog Model phải extends một Simba Model (tránh định nghĩa lại schema).
+     */
+    public function testCatalogModelsExtendSimbaModel(): void
+    {
+        $files = glob(self::CATALOG_DIR . '/*.php') ?: [];
+        $violations = [];
+        foreach ($files as $file) {
+            $shortName = basename($file, '.php');
+            $class     = $this->resolveClass('Diepxuan\\Catalog\\Models', $shortName);
+            if ($class === null) {
+                continue;
+            }
+            $reflection = new \ReflectionClass($class);
+            if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+                continue;
+            }
+            $parent = $reflection->getParentClass();
+            if ($parent === false) {
+                $violations[] = "Catalog\\Models\\{$shortName}: không có parent class";
+                continue;
+            }
+            $parentName = $parent->getName();
+            $expectedParent = self::CATALOG_EXTENDS_WHITELIST[$shortName] ?? null;
+            if ($expectedParent !== null) {
+                if ($parentName === $expectedParent) {
+                    continue;
+                }
+                $violations[] = "Catalog\\Models\\{$shortName}: parent {$parentName} phải là {$expectedParent}";
+                continue;
+            }
+            if (str_starts_with($parentName, 'Diepxuan\\Simba\\Models\\')) {
+                continue;
+            }
+            $violations[] = "Catalog\\Models\\{$shortName}: parent {$parentName} không thuộc Diepxuan\\Simba\\Models";
+        }
+        self::assertSame([], $violations, "Catalog\\Models extend sai:\n" . implode("\n", $violations));
+    }
+
+    private function resolveClass(string $namespace, string $shortName): ?string
+    {
+        $class = $namespace . '\\' . $shortName;
+        return class_exists($class) ? $class : null;
+    }
+
+    private function isRelationMethod(\ReflectionMethod $method): bool
+    {
+        $returnType = (string) $method->getReturnType();
+        if ($returnType === '') {
+            return false;
+        }
+        return str_contains($returnType, 'Relations\\');
+    }
+
+    private function stripScope(string $name): string
+    {
+        return substr($name, 5);
+    }
+
+    private function isSchemaDeclaration(string $name): bool
+    {
+        static $schemaMethods = [
+            'casts', 'getTable', 'getKeyName', 'getConnectionName',
+            'getKeyType', 'getIncrementing', 'getDates', 'getCasts',
+            'getPrimaryKey', 'getForeignKey',
+        ];
+        return in_array($name, $schemaMethods, true);
+    }
+}


### PR DESCRIPTION
## Summary

Thêm test bảo vệ ranh giới 3 lớp model sau Phase 1/2:

- SModel generated chỉ chứa schema mapping, không scope/relation/accessor/mutator/business method.
- Simba Models không expose business methods đã move sang Catalog.
- Catalog Models không khai báo DB metadata trực tiếp trừ whitelist có lý do.
- Không gọi parent::boot() trong booted() cho SModel/Simba/Catalog model layer.
- Catalog Models phải extends Simba Models hoặc thuộc whitelist alias/utility rõ ràng.

## Fix phát hiện khi viết test

- Gỡ parent::boot() không cần thiết khỏi Catalog\Models\ArDmKh::booted().
- SoCt1 còn business/report methods bị bỏ sót: tạo Catalog\Models\Concerns\HasSoCt1SalesMetrics + Catalog\Models\SoCt1, gỡ khỏi Simba\Models\SoCt1.

## Verify

- php -l changed PHP files: pass.
- vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php: 7 tests, 9 assertions, OK.
- git diff --check: pass.

## Note

Full vendor/bin/phpunit trên main hiện đã có lỗi pre-existing (Core\PackageConfigTest currency config, Feature\ExampleTest redirect). PR này không thêm lỗi mới; targeted test pass.