### PR TITLE
docs(catalog): add README for Catalog Models layer and Concerns

### DIFF
--- a/diepxuan/laravel-catalog/README.md
+++ b/diepxuan/laravel-catalog/README.md
@@ -4,8 +4,9 @@ Package catalog cho DXPanel.
 
 ## 📚 Documentation
 
-- **Project Docs:** [Model Architecture](../../docs/project/model-architecture.md) - 3-layer Model pattern
-- **Project Docs:** [Package Namespace Conventions](../../docs/project/package-namespace-conventions.md)
+- **Project Docs:** [Model layer responsibility & 3-layer pattern](../../docs/project/simba-model-layer-refactor-plan.md) - policy SModel / Simba\Models / Catalog\Models
+- **Package Docs:** [`src/Models/README.md`](src/Models/README.md) - Catalog Models layer
+- **Package Docs:** [`src/Models/Concerns/README.md`](src/Models/Concerns/README.md) - business concerns
 
 ## Mô tả
 
@@ -42,7 +43,8 @@ laravel-catalog/
 │   ├── Config/            # Configuration classes (TimerConfig)
 │   ├── Connectors/        # Connector SQL Server tùy chỉnh
 │   ├── Http/              # Controller, Livewire components và API
-│   ├── Models/            # Các model Eloquent
+│   ├── Models/            # Catalog Models layer (lớp 3 - xem src/Models/README.md)
+│   │   └── Concerns/      # Business concerns tách riêng (xem src/Models/Concerns/README.md)
 │   ├── Observers/         # Observer cho model
 │   ├── Providers/         # ServiceProvider
 │   ├── Services/          # Các service chính (CatalogService)

--- a/diepxuan/laravel-catalog/src/Models/Concerns/README.md
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/README.md
@@ -1,0 +1,77 @@
+# Catalog Models Concerns
+
+Thư mục này chứa các **business concern** (trait) dùng chung cho Catalog Model
+trong `diepxuan/laravel-catalog/src/Models`. Tài liệu policy tổng xem
+[`docs/project/simba-model-layer-refactor-plan.md`](../../../../../docs/project/simba-model-layer-refactor-plan.md).
+
+## Vai trò
+
+Concern là **trait đóng gói business logic** nghiệp vụ Portal/Catalog, tách
+khỏi model chính để:
+
+- Giữ `Catalog\Models\<TableName>` gọn, chỉ còn quan hệ và helper đặc thù.
+- Tái sử dụng logic giữa các model cùng nhóm nghiệp vụ
+  (vd: nhiều model cần phân loại KH/NCC/NV).
+- Tránh phình `Simba\Models` lớp 2 với logic đã thuộc về Portal/Catalog.
+
+Concern chỉ làm việc khi model `use` trait tương ứng. Trait không tự đăng ký
+toàn cục — phạm vi áp dụng do model quyết định.
+
+## Danh sách concern hiện tại
+
+| Trait | Mục đích | Model dùng |
+|---|---|---|
+| `HasArDmKhCategories` | Phân loại đối tượng KH/NCC/NV qua `isKh/isNcc/isNv` | `ArDmKh` |
+| `HasInDmKhoInventoryOperations` | Helper nghiệp vụ tồn kho (receipt rate, inventory value...) | `InDmKho` |
+| `HasPoCt1PurchaseMetrics` | Báo cáo/chỉ số mua hàng (`getPORpt`, `getTotalPurchase`...) | `PoCt1` |
+| `HasSoCt1SalesMetrics` | Báo cáo/chỉ số bán hàng (`getSORpt`, `getTotalRevenue`...) | `SoCt1` |
+| `HasSysCompanyLocalizedResx` | Đa ngôn ngữ resx cho SysCompany | `SysCompany` |
+
+## Được phép đặt tại đây
+
+- Scope nghiệp vụ Portal (`scopeLaKhachHang`, `scopeLaNhaCungCap`...).
+- Accessor/mutator có domain meaning nghiệp vụ Portal.
+- Helper tính toán business (inventory value, số dư, chỉ số báo cáo...).
+- Gọi stored procedure có tham số phục vụ nghiệp vụ, **kèm fallback rõ ràng**.
+- DocBlock mô tả rõ ngữ nghĩa nghiệp vụ và lý do tách concern.
+
+## Không đặt tại đây
+
+- Schema metadata (`$table`, `$primaryKey`, `$fillable`, `$casts`) — thuộc
+  `Simba\SModel\*` hoặc `Simba\Models\*`.
+- Logic raw query sát bảng Simba — thuộc `Simba\Models\*`.
+- Logic UI, route, request/session/auth, Livewire — thuộc `Http/`.
+- Logic không phụ thuộc model (service thuần) — thuộc `src/Services/`.
+- Trait phục vụ test/dev (factory, fake...) — đặt trong `tests/` hoặc
+  dùng package dev riêng.
+
+## Quy tắc đặt tên
+
+- Tên trait phải bắt đầu bằng `Has` (tiền tố chuẩn Laravel cho concern):
+  `HasArDmKhCategories`, `HasInDmKhoInventoryOperations`.
+- Một concern = một nhóm nghiệp vụ gắn với một model chính. Không gom
+  nhiều concern của các model khác nhau vào cùng một trait.
+- Đặt tên method rõ ràng, có comment PHPDoc giải thích ngữ nghĩa nghiệp vụ.
+
+## Quy tắc cập nhật
+
+- **Không tự đặt tên bảng/cột/SP.** Nguồn sự thật là `simba-docs/tables`.
+  Khi cần truy cập field mới, đọc docs trước, nếu không có dừng và hỏi Sếp.
+- Trước khi tạo concern mới, kiểm tra:
+  1. Logic đó có được dùng chung cho ≥2 model, hoặc làm model chính phình
+     quá nhiều? → Tách thành concern.
+  2. Logic đó thuộc về lớp nào trong 3-layer? (`SModel`/`Simba\Models`/`Catalog`)
+     → Đặt đúng lớp.
+- Khi thêm/sửa concern phải cập nhật audit classification
+  `scripts/audit-catalog-model-layer.php` cho các model `use` trait đó.
+- Mọi thay đổi phải đi qua:
+  ```bash
+  php scripts/audit-catalog-model-layer.php
+  vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+  ```
+
+## Tóm tắt
+
+`Concerns` = trait business nghiệp vụ Portal/Catalog, dùng chung cho Catalog
+Model. Phạm vi = một nhóm nghiệp vụ của một model. Không chứa schema,
+không chứa logic UI/service.

--- a/diepxuan/laravel-catalog/src/Models/README.md
+++ b/diepxuan/laravel-catalog/src/Models/README.md
@@ -1,0 +1,129 @@
+# Catalog Models layer
+
+Thư mục này chứa các model Eloquent ở lớp 3 (Catalog/Portal) trong pattern
+**3-layer Model**. Tài liệu policy tổng xem
+[`docs/project/simba-model-layer-refactor-plan.md`](../../../../docs/project/simba-model-layer-refactor-plan.md).
+
+## Vai trò
+
+`Catalog\Models` là lớp trên cùng, dùng cho **Portal/Catalog UI và business
+logic phục vụ use-case nghiệp vụ**. Model ở đây extend `Diepxuan\Simba\Models\*`
+(lớp 2), **không bao giờ extend trực tiếp `Diepxuan\Simba\SModel\*`** (lớp 1).
+
+```php
+use Diepxuan\Simba\Models\ArDmKh as SimbaModel;
+
+class ArDmKh extends SimbaModel
+{
+    use HasArDmKhCategories;   // business concern từ src/Models/Concerns
+    // relations / scopes / accessors phục vụ Portal/Catalog
+}
+```
+
+Catalog Models là nơi duy nhất được phép chứa:
+
+- Quan hệ (relation) phục vụ màn hình Portal (nhomKhachHang, phanLoaiKhachHang...).
+- Helper nghiệp vụ Portal (getSoduKh, hasTransactions...).
+- Scope/accessor/mutator mang ngữ nghĩa KH/NCC/NV hoặc workflow Catalog.
+- Global scope đặc thù Portal (`orderByMaKh`...).
+
+## Cấu trúc thư mục
+
+```
+src/Models/
+├── AbstractModel.php              # Base class cho model Catalog không map Simba
+├── Concerns/                      # Business concerns (xem README riêng)
+├── <TableName>.php                # Model extend Simba\Models\<TableName>
+└── ...
+```
+
+### `AbstractModel.php`
+
+Base class cho các model **không** map trực tiếp một bảng Simba
+(ví dụ: `System`, `SystemConfig`, `UserLink`, `Params`, `InventoryTicket`,
+`InventoryTicketItem`, `Product`).
+
+- Khai báo `$table`, `$primaryKey`, `$fillable`, `$hidden`, `$guarded`, `$connection`
+  trống — model con override theo schema thật của mình.
+- Bật `HasFactory` để hỗ trợ factory trong test/seed.
+- Constructor inject connection từ `config('database.default')`.
+- `boot()` đăng ký hook `creating/created/updating/updated/deleting/deleted`
+  làm placeholder cho các Catalog con cần override.
+
+Các Catalog Model **không** map bảng Simba đều extend `AbstractModel`.
+
+### `Concerns/`
+
+Các business concern tách riêng để giữ model chính gọn và reuse giữa các
+Catalog Model. Xem [`Concerns/README.md`](Concerns/README.md).
+
+## Được phép đặt tại đây
+
+- Extend `Diepxuan\Simba\Models\*` (lớp 2). **Không extend trực tiếp `SModel\*`.**
+- Quan hệ (relation) nghiệp vụ Portal giữa các model Simba/Catalog.
+- Scope query theo ngữ nghĩa KH/NCC/NV, workflow, hoặc policy Portal.
+- Accessor/mutator có domain meaning nghiệp vụ Portal.
+- Helper gọi stored procedure có tham số phục vụ màn hình/Livewire component.
+- Business method phục vụ use-case (tính số dư, kiểm tra ràng buộc trước khi xóa...).
+- Global scope đặc thù Portal.
+- Extend `AbstractModel` cho model không map bảng Simba.
+
+## Không đặt tại đây
+
+- Schema metadata trừ khi nằm trong whitelist có lý do
+  (`Params`, `System`, `SystemConfig`, `UserLink`, `InDmNhvt`).
+- Raw schema từ SQL Server — thuộc `diepxuan/laravel-simba/src/SModel`.
+- Query helper sát bảng Simba, không phụ thuộc use-case Catalog — thuộc
+  `diepxuan/laravel-simba/src/Models`.
+- Logic UI, route, request/session/auth, Livewire component — thuộc `Http/`.
+- Service orchestration — thuộc `src/Services/`.
+
+## Quy tắc cập nhật
+
+- **Không tự đặt tên bảng/cột/SP.** Nguồn sự thật là `simba-docs/tables`
+  và các tài liệu Simba readonly liên quan. Đối với bảng mới hoặc trường
+  không có trong docs, dừng và hỏi Sếp.
+- Trước khi thêm behavior vào Catalog Model, kiểm tra:
+  1. Nếu thuần Simba table/query → đặt trong `diepxuan/laravel-simba/src/Models`.
+  2. Nếu đã mang ngữ cảnh Portal/Catalog/UI/workflow → đặt ở đây.
+  3. Nếu là concern nghiệp vụ dùng chung → tách ra `Concerns/` và `use` trait.
+- Không override lại `$table`, `$primaryKey`, `$fillable`, `$casts` nếu Simba
+  Model gốc đã có đủ.
+- Khi thêm Catalog Model cần lệch rule (whitelist), **bắt buộc** thêm entry
+  kèm comment lý do trong:
+  - `SimbaModelLayerResponsibilityTest::$CATALOG_EXTENDS_WHITELIST`
+  - `SimbaModelLayerResponsibilityTest::$CATALOG_DB_METADATA_WHITELIST`
+- Mọi Model phải đi qua test gate trước khi merge:
+  `php scripts/audit-catalog-model-layer.php` và
+  `vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php`.
+
+## Phân loại Catalog Model
+
+Audit script `scripts/audit-catalog-model-layer.php` phân loại Catalog Model
+theo 4 nhóm:
+
+| Classification | Đặc điểm | Ví dụ |
+|---|---|---|
+| `concern_business` | Có dùng trait từ `Concerns/` | `ArDmKh`, `InDmKho`, `PoCt1`, `SoCt1`, `SysCompany` |
+| `inline_business` | Có business method inline (không qua concern) | model có `getInventory`, `getSoduKh`, `getTotalPurchase`... |
+| `catalog_utility` | Relation/scope/accessor nghiệp vụ, không có business method | `SoPh3`, `GlCt`, `ArDmNhKh`, `User`, `SysUserInfo` |
+| `passthrough` | Class rỗng, chỉ kế thừa | `CaCt2`, `CaPh2`, `CaPh3`, `Zsysmenu`, `ArDmPlKh` |
+
+Mục tiêu dài hạn: chuyển `inline_business` sang `concern_business` để reuse
+và giữ Catalog Model chính gọn.
+
+## Verify
+
+```bash
+# Audit Catalog layer
+php scripts/audit-catalog-model-layer.php
+
+# Test gate 3-layer
+vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+```
+
+## Tóm tắt
+
+`Catalog\Models` = lớp 3 trong pattern 3-layer, chứa business logic nghiệp vụ
+phục vụ Portal/Catalog UI. Extend `Diepxuan\Simba\Models\*`, không extend
+trực tiếp `SModel\*`. Business concern dùng chung tách vào `Concerns/`.


### PR DESCRIPTION
## Summary

Tạo 2 README mới và sửa root README của laravel-catalog để phân rõ vai trò
cho từng folder Model theo policy 3-layer
(xem [docs/project/simba-model-layer-refactor-plan.md](../../tree/main/docs/project/simba-model-layer-refactor-plan.md)):

### `diepxuan/laravel-catalog/src/Models/README.md` (mới, 128 dòng)
- Vai trò Catalog Models (lớp 3), extend `Simba\Models\*`, không extend `SModel\*`.
- Cấu trúc: `AbstractModel.php` base + `Concerns/` + `<TableName>.php`.
- Được phép / Không đặt, Quy tắc cập nhật (no self-named bảng/cột/SP).
- Phân loại 4 nhóm audit: `concern_business` / `inline_business` / `catalog_utility` / `passthrough`.

### `diepxuan/laravel-catalog/src/Models/Concerns/README.md` (mới, 76 dòng)
- Vai trò business concern (trait), tiền tố `Has*`.
- Bảng 5 concern hiện tại mapping sang model dùng:
  - `HasArDmKhCategories` → `ArDmKh`
  - `HasInDmKhoInventoryOperations` → `InDmKho`
  - `HasPoCt1PurchaseMetrics` → `PoCt1`
  - `HasSoCt1SalesMetrics` → `SoCt1`
  - `HasSysCompanyLocalizedResx` → `SysCompany`
- Được phép / Không đặt, Quy tắc đặt tên, Quy tắc cập nhật.

### `diepxuan/laravel-catalog/README.md` (sửa)
- Sửa 2 link broken (`docs/project/model-architecture.md` và `package-namespace-conventions.md` đều không tồn tại) → trỏ về `simba-model-layer-refactor-plan.md` và 2 README mới.
- Bổ sung `Concerns/` vào cấu trúc thư mục.

## Không sửa code PHP

Pure docs change, không ảnh hưởng build/test/runtime.

## Verify

Tất cả link tương đối trong README đều resolve OK (đã grep test trong quá trình viết).

## Note

Branch `docs/simba-model-layer-task-8-done` đang được session khác làm
việc riêng (PR #227), không động vào trong PR này.