### PR TITLE
refactor(catalog): move Simba-extending models to Models/Simba

### DIFF
--- a/diepxuan/laravel-catalog/README.md
+++ b/diepxuan/laravel-catalog/README.md
@@ -5,6 +5,7 @@ Package catalog cho DXPanel.
 ## 📚 Documentation
 
 - **Package Docs:** [`src/Models/README.md`](src/Models/README.md) - Catalog Models layer
+- **Package Docs:** [`src/Models/Simba/README.md`](src/Models/Simba/README.md) - 29 wrapper Simba
 - **Package Docs:** [`src/Models/Concerns/README.md`](src/Models/Concerns/README.md) - business concerns
 
 ## Mô tả
@@ -43,7 +44,8 @@ laravel-catalog/
 │   ├── Connectors/        # Connector SQL Server tùy chỉnh
 │   ├── Http/              # Controller, Livewire components và API
 │   ├── Models/            # Catalog Models layer (lớp 3 - xem src/Models/README.md)
-│   │   └── Concerns/      # Business concerns tách riêng (xem src/Models/Concerns/README.md)
+│   │   ├── Concerns/      # Business concerns tách riêng (xem src/Models/Concerns/README.md)
+│   │   └── Simba/         # 29 wrapper extend Simba\Models\* (xem src/Models/Simba/README.md)
 │   ├── Observers/         # Observer cho model
 │   ├── Providers/         # ServiceProvider
 │   ├── Services/          # Các service chính (CatalogService)

--- a/diepxuan/laravel-catalog/src/Commands/Products.php
+++ b/diepxuan/laravel-catalog/src/Commands/Products.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Commands;
 
-use Diepxuan\Catalog\Models\Product;
+use Diepxuan\Catalog\Models\Simba\Product;
 use Diepxuan\Catalog\Models\Simba\SProduct;
 use Diepxuan\Magento\Magento;
 use Diepxuan\Magento\Models\Product as MProduct;

--- a/diepxuan/laravel-catalog/src/Http/Controllers/InventoryController.php
+++ b/diepxuan/laravel-catalog/src/Http/Controllers/InventoryController.php
@@ -16,7 +16,7 @@ namespace Diepxuan\Catalog\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Diepxuan\Catalog\Http\Requests\SimbaRequest;
 use Diepxuan\Catalog\Models\Category;
-use Diepxuan\Catalog\Models\InventoryTicket;
+use Diepxuan\Catalog\Models\Simba\InventoryTicket;
 use Diepxuan\Simba\Models\KhoHang;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/diepxuan/laravel-catalog/src/Http/Controllers/SellController.php
+++ b/diepxuan/laravel-catalog/src/Http/Controllers/SellController.php
@@ -16,7 +16,7 @@ namespace Diepxuan\Catalog\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Diepxuan\Catalog\Http\Requests\SimbaRequest;
 use Diepxuan\Catalog\Models\Category;
-use Diepxuan\Catalog\Models\InventoryTicket;
+use Diepxuan\Catalog\Models\Simba\InventoryTicket;
 use Diepxuan\Simba\Models\KhoHang;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;

--- a/diepxuan/laravel-catalog/src/Http/Controllers/SystemUserController.php
+++ b/diepxuan/laravel-catalog/src/Http/Controllers/SystemUserController.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use Diepxuan\Catalog\Models\SysUserInfo;
+use Diepxuan\Catalog\Models\Simba\SysUserInfo;
 use Diepxuan\Catalog\Models\User;
 use Diepxuan\Simba\Models\System;
 use Illuminate\Contracts\View\View;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Hoadonbanhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Hoadonbanhang.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Banhang;
 
-use Diepxuan\Catalog\Models\SoPh3;
+use Diepxuan\Catalog\Models\Simba\SoPh3;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/Khachhang.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Banhang;
 
-use Diepxuan\Catalog\Models\ArDmKh;
+use Diepxuan\Catalog\Models\Simba\ArDmKh;
 use Diepxuan\Simba\SModel\SModel;
 use Diepxuan\Simba\StoredProcedures\AsARDelDMKH;
 use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Banhang;
 
-use Diepxuan\Catalog\Models\ArDmNhKh;
-use Diepxuan\Catalog\Models\ArDmPlKh;
+use Diepxuan\Catalog\Models\Simba\ArDmNhKh;
+use Diepxuan\Catalog\Models\Simba\ArDmPlKh;
 use Diepxuan\Simba\SModel\SModel;
 use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
 use Diepxuan\Simba\StoredProcedures\AsARInsDMKH;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Chi.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Chi.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Baocao;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Nganhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Nganhang.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Baocao;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Thu.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Thu.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Baocao;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Tienmat.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Baocao/Tienmat.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Baocao;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/Nhanvien.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Danhmuc/Nhanvien.php
@@ -22,7 +22,7 @@ class Nhanvien extends Ardmkh
 {
     public function deleteDoiTuong(string $maKh): void
     {
-        $nhanVien = \Diepxuan\Catalog\Models\ArDmKh::withoutGlobalScopes()
+        $nhanVien = \Diepxuan\Catalog\Models\Simba\ArDmKh::withoutGlobalScopes()
             ->where('ma_kh', $maKh)
             ->first()
         ;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baoco.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baoco.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Nganhang;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Nganhang;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Diepxuan\Simba\StoredProcedures\AsCADelPH2;
 use Diepxuan\Simba\StoredProcedures\AsProcessCT;
 use Illuminate\View\View;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono/Phieubaono.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono/Phieubaono.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Nganhang\Baono;
 
-use Diepxuan\Catalog\Models\ArDmKh;
-use Diepxuan\Catalog\Models\CaCt2;
+use Diepxuan\Catalog\Models\Simba\ArDmKh;
+use Diepxuan\Catalog\Models\Simba\CaCt2;
 use Diepxuan\Simba\Models\GlDmTk;
 use Diepxuan\Simba\StoredProcedures\AsCADelCT2;
 use Diepxuan\Simba\StoredProcedures\AsCAGetPH2;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Tienmat/Phieuchi.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Tienmat/Phieuchi.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Tienmat;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Tienmat/Phieuthu.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Tienmat/Phieuthu.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Cash\Tienmat;
 
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmkho.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmkho.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Catalog\Models\InDmKho;
+use Diepxuan\Catalog\Models\Simba\InDmKho;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmnhvt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmnhvt.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Catalog\Models\InDmNhvt;
+use Diepxuan\Catalog\Models\Simba\InDmNhvt;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Catalog\Models\InDmVt;
+use Diepxuan\Catalog\Models\Simba\InDmVt;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Catalog\Models\ArDmKh;
+use Diepxuan\Catalog\Models\Simba\ArDmKh;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\View\View;
 use Livewire\Attributes\Modelable;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Gl/Taikhoan.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Gl/Taikhoan.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Gl;
 
-use Diepxuan\Catalog\Models\GlDmTk;
+use Diepxuan\Catalog\Models\Simba\GlDmTk;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/In/Baocao/Tonkho.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/In/Baocao/Tonkho.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\In\Baocao;
 
-use Diepxuan\Catalog\Models\InDmVt;
+use Diepxuan\Catalog\Models\Simba\InDmVt;
 use Diepxuan\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/In/Dmkho.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/In/Dmkho.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\In;
 
-use Diepxuan\Catalog\Models\InDmKho;
+use Diepxuan\Catalog\Models\Simba\InDmKho;
 use Diepxuan\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/In/Dmnhvt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/In/Dmnhvt.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\In;
 
-use Diepxuan\Catalog\Models\InDmNhvt;
+use Diepxuan\Catalog\Models\Simba\InDmNhvt;
 use Diepxuan\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/In/Dmvt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/In/Dmvt.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\In;
 
-use Diepxuan\Catalog\Models\InDmVt;
+use Diepxuan\Catalog\Models\Simba\InDmVt;
 use Diepxuan\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Po/Dict/Ardmkh.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Po/Dict/Ardmkh.php
@@ -42,7 +42,7 @@ class Ardmkh extends Component
 
     public function deleteDoiTuong(string $maKh): void
     {
-        $nhaCungCap = \Diepxuan\Catalog\Models\ArDmKh::withoutGlobalScopes()
+        $nhaCungCap = \Diepxuan\Catalog\Models\Simba\ArDmKh::withoutGlobalScopes()
             ->where('ma_kh', $maKh)
             ->first()
         ;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Product/Products.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Product/Products.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Product;
 
-use Diepxuan\Catalog\Models\Product;
+use Diepxuan\Catalog\Models\Simba\Product;
 use Illuminate\View\View;
 use Livewire\Component;
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
@@ -16,7 +16,7 @@ namespace Diepxuan\Catalog\Http\Livewire\System;
 use Diepxuan\Catalog\Services\SimbaMenuRepository;
 use Diepxuan\Catalog\Services\SimbaMenuRouteMetadata;
 use Diepxuan\Catalog\Services\SimbaMenuTargetResolver;
-use Diepxuan\Catalog\Models\SysMenu;
+use Diepxuan\Catalog\Models\Simba\SysMenu;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
 use Livewire\Component;

--- a/diepxuan/laravel-catalog/src/Models/Concerns/HasSysCompanyLocalizedResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Concerns/HasSysCompanyLocalizedResx.php
@@ -32,7 +32,7 @@ trait HasSysCompanyLocalizedResx
      */
     public function resxByLanguage(SysLanguage $language)
     {
-        return $this->hasMany(\Diepxuan\Catalog\Models\SysCompanyResx::class, 'ma_cty', 'ma_cty')
+        return $this->hasMany(\Diepxuan\Catalog\Models\Simba\SysCompanyResx::class, 'ma_cty', 'ma_cty')
             ->where('language', $language->Name);
     }
 }

--- a/diepxuan/laravel-catalog/src/Models/README.md
+++ b/diepxuan/laravel-catalog/src/Models/README.md
@@ -1,120 +1,97 @@
 # Catalog Models layer
 
-Thư mục này chứa các model Eloquent ở lớp 3 (Catalog/Portal) trong pattern
-**3-layer Model** (`SModel` / `Simba\Models` / `Catalog\Models`).
+Thư mục `src/Models/` chứa các Catalog Model **không thuộc wrapper Simba**.
 
-## Vai trò
-
-`Catalog\Models` là lớp trên cùng, dùng cho **Portal/Catalog UI và business
-logic phục vụ use-case nghiệp vụ**. Model ở đây extend `Diepxuan\Simba\Models\*`
-(lớp 2), **không bao giờ extend trực tiếp `Diepxuan\Simba\SModel\*`** (lớp 1).
-
-```php
-use Diepxuan\Simba\Models\ArDmKh as SimbaModel;
-
-class ArDmKh extends SimbaModel
-{
-    use HasArDmKhCategories;   // business concern từ src/Models/Concerns
-    // relations / scopes / accessors phục vụ Portal/Catalog
-}
-```
-
-Catalog Models là nơi duy nhất được phép chứa:
-
-- Quan hệ (relation) phục vụ màn hình Portal (nhomKhachHang, phanLoaiKhachHang...).
-- Helper nghiệp vụ Portal (getSoduKh, hasTransactions...).
-- Scope/accessor/mutator mang ngữ nghĩa KH/NCC/NV hoặc workflow Catalog.
-- Global scope đặc thù Portal (`orderByMaKh`...).
+Sau khi tách cấu trúc (xem `Simba/README.md`), wrapper extend
+`Diepxuan\Simba\Models\*` được dời hết sang `src/Models/Simba/`. Thư mục này
+chỉ còn **7 file PHP top-level** + `Casts/` + `Concerns/`.
 
 ## Cấu trúc thư mục
 
 ```
 src/Models/
-├── AbstractModel.php              # Base class cho model Catalog không map Simba
-├── Concerns/                      # Business concerns (xem README riêng)
-├── <TableName>.php                # Model extend Simba\Models\<TableName>
-└── ...
+├── AbstractModel.php              # Base class cho Catalog Model không map Simba
+├── Params.php                     # Standalone Eloquent (không map Simba)
+├── User.php                       # Extend App\Models\User (Laravel auth)
+├── UserLink.php                   # Extend AbstractModel, dùng Simma\Models\SysUserInfo cho relation
+├── System.php                     # Extend Simba\SysCompany + thêm systemConfig relation
+├── SystemConfig.php               # Extend Simba\SiSetup + thêm system relation
+├── Zsysmenu.php                   # Extend Simba\SysMenu, override $table = 'zsysmenu'
+├── Casts/                         # Custom Eloquent cast
+│   └── CategoryMagento.php
+├── Concerns/                      # Business concern trait (xem Concerns/README.md)
+│   ├── HasArDmKhCategories.php
+│   ├── HasInDmKhoInventoryOperations.php
+│   ├── HasPoCt1PurchaseMetrics.php
+│   ├── HasSoCt1SalesMetrics.php
+│   ├── HasSysCompanyLocalizedResx.php
+│   └── README.md
+└── Simba/                         # 29 wrapper extend Simba\Models\* (xem Simba/README.md)
+    └── ...
 ```
 
-### `AbstractModel.php`
+## 7 file top-level
 
-Base class cho các model **không** map trực tiếp một bảng Simba
-(ví dụ: `System`, `SystemConfig`, `UserLink`, `Params`, `InventoryTicket`,
-`InventoryTicketItem`, `Product`).
+| File | Extend | Vai trò |
+|---|---|---|
+| `AbstractModel.php` | `Illuminate\Database\Eloquent\Model` | Base class cho Catalog Model không map bảng Simba |
+| `Params.php` | `Illuminate\Database\Eloquent\Model` | Bảng tiện ích không có SModel tương ứng |
+| `User.php` | `App\Models\User` | Extend user Laravel auth, thêm relation nghiệp vụ |
+| `UserLink.php` | `AbstractModel` | Bridge user ↔ SysUserInfo (qua relation) |
+| `System.php` | `Simba\SysCompany` | Thêm `systemConfig` relation + `khoaSo` accessor |
+| `SystemConfig.php` | `Simba\SiSetup` | Thêm `system` relation |
+| `Zsysmenu.php` | `Simba\SysMenu` | Override `$table = 'zsysmenu'` (cùng schema, khác bảng) |
 
-- Khai báo `$table`, `$primaryKey`, `$fillable`, `$hidden`, `$guarded`, `$connection`
-  trống — model con override theo schema thật của mình.
+## `AbstractModel.php`
+
+Base class cho các model **không** map trực tiếp một bảng Simba (hiện tại:
+`Params`, `UserLink` — và trước đây là `System`, `SystemConfig`,
+`InventoryTicket`, `InventoryTicketItem`, `Product` đã chuyển sang `Simba/`).
+
+- Khai báo `$fillable`, `$guarded`, `$incrementing`, `$timestamps`
+  mặc định — model con override theo schema thật.
 - Bật `HasFactory` để hỗ trợ factory trong test/seed.
-- Constructor inject connection từ `config('database.default')`.
 - `boot()` đăng ký hook `creating/created/updating/updated/deleting/deleted`
   làm placeholder cho các Catalog con cần override.
 
-Các Catalog Model **không** map bảng Simba đều extend `AbstractModel`.
+## `Casts/`
 
-### `Concerns/`
+Custom Eloquent cast phục vụ riêng cho Catalog:
 
-Các business concern tách riêng để giữ model chính gọn và reuse giữa các
-Catalog Model. Xem [`Concerns/README.md`](Concerns/README.md).
+- `CategoryMagento.php` — cast cho cột phân loại Magento trong `InDmNhvt`.
 
-## Được phép đặt tại đây
+## `Concerns/`
 
-- Extend `Diepxuan\Simba\Models\*` (lớp 2). **Không extend trực tiếp `SModel\*`.**
-- Quan hệ (relation) nghiệp vụ Portal giữa các model Simba/Catalog.
-- Scope query theo ngữ nghĩa KH/NCC/NV, workflow, hoặc policy Portal.
-- Accessor/mutator có domain meaning nghiệp vụ Portal.
-- Helper gọi stored procedure có tham số phục vụ màn hình/Livewire component.
-- Business method phục vụ use-case (tính số dư, kiểm tra ràng buộc trước khi xóa...).
-- Global scope đặc thù Portal.
-- Extend `AbstractModel` cho model không map bảng Simba.
+Các business concern trait tách riêng để giữ wrapper chính gọn và reuse:
 
-## Không đặt tại đây
+- `HasArDmKhCategories` — relation nhóm KH + phân loại KH.
+- `HasInDmKhoInventoryOperations` — tính tồn kho, nhập xuất tồn.
+- `HasPoCt1PurchaseMetrics` — chỉ số mua hàng (PO).
+- `HasSoCt1SalesMetrics` — chỉ số bán hàng (SO).
+- `HasSysCompanyLocalizedResx` — đa ngôn ngữ resx cho SysCompany.
 
-- Schema metadata trừ khi nằm trong whitelist có lý do
-  (`Params`, `System`, `SystemConfig`, `UserLink`, `InDmNhvt`).
-- Raw schema từ SQL Server — thuộc `diepxuan/laravel-simba/src/SModel`.
-- Query helper sát bảng Simba, không phụ thuộc use-case Catalog — thuộc
-  `diepxuan/laravel-simba/src/Models`.
-- Logic UI, route, request/session/auth, Livewire component — thuộc `Http/`.
-- Service orchestration — thuộc `src/Services/`.
+Xem chi tiết tại [`Concerns/README.md`](Concerns/README.md).
+
+## `Simba/`
+
+29 wrapper class extend `Diepxuan\Simba\Models\*` qua alias `SimbaModel`.
+Xem chi tiết tại [`Simba/README.md`](Simba/README.md).
 
 ## Quy tắc cập nhật
 
-- **Không tự đặt tên bảng/cột/SP.** Nguồn sự thật là `simba-docs/tables`
-  và các tài liệu Simba readonly liên quan. Đối với bảng mới hoặc trường
-  không có trong docs, dừng và hỏi Sếp.
-- Trước khi thêm behavior vào Catalog Model, kiểm tra:
-  1. Nếu thuần Simba table/query → đặt trong `diepxuan/laravel-simba/src/Models`.
-  2. Nếu đã mang ngữ cảnh Portal/Catalog/UI/workflow → đặt ở đây.
-  3. Nếu là concern nghiệp vụ dùng chung → tách ra `Concerns/` và `use` trait.
-- Không override lại `$table`, `$primaryKey`, `$fillable`, `$casts` nếu Simba
-  Model gốc đã có đủ.
-- Khi thêm Catalog Model cần lệch rule (whitelist), **bắt buộc** thêm entry
-  kèm comment lý do trong:
+- **Không tự đặt tên bảng/cột/SP.** Nguồn sự thật là `simba-docs/tables`.
+- Trước khi thêm Catalog Model mới, xác định rõ:
+  - Extend `Simba\Models\*` → đặt trong `Simba/`.
+  - Extend `Illuminate\Database\Eloquent\Model` / `AbstractModel` / `App\Models\User` →
+    đặt tại top-level `src/Models/`.
+- Khi thêm file lệch rule (whitelist), bắt buộc cập nhật:
   - `SimbaModelLayerResponsibilityTest::$CATALOG_EXTENDS_WHITELIST`
   - `SimbaModelLayerResponsibilityTest::$CATALOG_DB_METADATA_WHITELIST`
-- Mọi Model phải đi qua test gate trước khi merge:
-  `php scripts/audit-catalog-model-layer.php` và
-  `vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php`.
-
-## Phân loại Catalog Model
-
-Audit script `scripts/audit-catalog-model-layer.php` phân loại Catalog Model
-theo 4 nhóm:
-
-| Classification | Đặc điểm | Ví dụ |
-|---|---|---|
-| `concern_business` | Có dùng trait từ `Concerns/` | `ArDmKh`, `InDmKho`, `PoCt1`, `SoCt1`, `SysCompany` |
-| `inline_business` | Có business method inline (không qua concern) | model có `getInventory`, `getSoduKh`, `getTotalPurchase`... |
-| `catalog_utility` | Relation/scope/accessor nghiệp vụ, không có business method | `SoPh3`, `GlCt`, `ArDmNhKh`, `User`, `SysUserInfo` |
-| `passthrough` | Class rỗng, chỉ kế thừa | `CaCt2`, `CaPh2`, `CaPh3`, `Zsysmenu`, `ArDmPlKh` |
-
-Mục tiêu dài hạn: chuyển `inline_business` sang `concern_business` để reuse
-và giữ Catalog Model chính gọn.
 
 ## Verify
 
 ```bash
-# Audit Catalog layer
+# Audit toàn bộ Catalog layer (chỉ scan top-level *.php)
 php scripts/audit-catalog-model-layer.php
 
 # Test gate 3-layer
@@ -123,6 +100,7 @@ vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.p
 
 ## Tóm tắt
 
-`Catalog\Models` = lớp 3 trong pattern 3-layer, chứa business logic nghiệp vụ
-phục vụ Portal/Catalog UI. Extend `Diepxuan\Simba\Models\*`, không extend
-trực tiếp `SModel\*`. Business concern dùng chung tách vào `Concerns/`.
+`src/Models/` = 7 Catalog Model đặc biệt + `Casts/` + `Concerns/`. 29 wrapper
+extend `Simba\Models\*` đã chuyển sang `Simba/`. Pattern 3-layer
+(`SModel` / `Simba\Models` / `Catalog\Models`) vẫn giữ nguyên — chỉ tách
+vật lý cho dễ audit và phân quyền.

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArDmKh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArDmKh.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @lastupdate 2026-05-05 20:11:16
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Catalog\Models\Concerns\HasArDmKhCategories;
 use Diepxuan\Simba\Models\ArDmKh as SimbaModel;

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArDmNhKh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArDmNhKh.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-05 20:11:18
+ * @lastupdate 2026-05-05 20:11:17
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\ArDmPlKh as Model;
+use Diepxuan\Simba\Models\ArDmNhKh as SimbaModel;
 use Diepxuan\Simba\SModel\SModel;
 
 /**
- * Model ArDmPlKh - Danh mục phân loại khách hàng (catalog layer).
+ * Model ArDmNhKh - Danh mục nhóm khách hàng (catalog layer).
  */
-class ArDmPlKh extends Model
+class ArDmNhKh extends SimbaModel
 {
     /**
      * Company constant.

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArDmPlKh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArDmPlKh.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-05 20:11:17
+ * @lastupdate 2026-05-05 20:11:18
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\ArDmNhKh as Model;
+use Diepxuan\Simba\Models\ArDmPlKh as SimbaModel;
 use Diepxuan\Simba\SModel\SModel;
 
 /**
- * Model ArDmNhKh - Danh mục nhóm khách hàng (catalog layer).
+ * Model ArDmPlKh - Danh mục phân loại khách hàng (catalog layer).
  */
-class ArDmNhKh extends Model
+class ArDmPlKh extends SimbaModel
 {
     /**
      * Company constant.

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaCt2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaCt2.php
@@ -8,20 +8,18 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2024-05-22 10:20:30
+ * @lastupdate 2026-04-05 23:04:19
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\CaPh3 as SimbaModel;
+use Diepxuan\Simba\Models\CaCt2 as SimbaModel;
 
 /**
- * Model CaPh3 (Catalog layer).
+ * Model CaCt2 (Catalog layer).
  *
- * Extends `Diepxuan\Simba\Models\CaPh3` thay vì SModel trực tiếp để:
+ * Extends `Diepxuan\Simba\Models\CaCt2` thay vì SModel trực tiếp để:
  * - Đồng nhất pattern với các Catalog Model khác (đi qua lớp Simba).
  * - Tận dụng `HasSimbaCompositeKey` cho primary key composite.
  */
-class CaPh3 extends SimbaModel
-{
-}
+class CaCt2 extends SimbaModel {}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaCt3.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * @lastupdate 2024-05-22 10:20:30
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\CaCt3 as Model;
+use Diepxuan\Simba\Models\CaCt3 as SimbaModel;
 
-class CaCt3 extends Model
+class CaCt3 extends SimbaModel
 {
 }

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaPh2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaPh2.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
  * @lastupdate 2026-04-05 23:04:19
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\CaCt2 as SimbaModel;
+use Diepxuan\Simba\Models\CaPh2 as SimbaModel;
 
 /**
- * Model CaCt2 (Catalog layer).
+ * Model CaPh2 (Catalog layer).
  *
- * Extends `Diepxuan\Simba\Models\CaCt2` thay vì SModel trực tiếp để:
+ * Extends `Diepxuan\Simba\Models\CaPh2` thay vì SModel trực tiếp để:
  * - Đồng nhất pattern với các Catalog Model khác (đi qua lớp Simba).
  * - Tận dụng `HasSimbaCompositeKey` cho primary key composite.
  */
-class CaCt2 extends SimbaModel {}
+class CaPh2 extends SimbaModel {}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaPh3.php
@@ -8,18 +8,20 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-04-05 23:04:19
+ * @lastupdate 2024-05-22 10:20:30
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\CaPh2 as SimbaModel;
+use Diepxuan\Simba\Models\CaPh3 as SimbaModel;
 
 /**
- * Model CaPh2 (Catalog layer).
+ * Model CaPh3 (Catalog layer).
  *
- * Extends `Diepxuan\Simba\Models\CaPh2` thay vì SModel trực tiếp để:
+ * Extends `Diepxuan\Simba\Models\CaPh3` thay vì SModel trực tiếp để:
  * - Đồng nhất pattern với các Catalog Model khác (đi qua lớp Simba).
  * - Tận dụng `HasSimbaCompositeKey` cho primary key composite.
  */
-class CaPh2 extends SimbaModel {}
+class CaPh3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlCdTk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlCdTk.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @lastupdate 2025-06-07 13:26:48
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\GlCdTk as Model;
+use Diepxuan\Simba\Models\GlCdTk as SimbaModel;
 use Illuminate\Database\Eloquent\Builder;
 
-class GlCdTk extends Model
+class GlCdTk extends SimbaModel
 {
     /**
      * Gọi function afDuDauTk để lấy dữ liệu đầu kỳ.

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlCt.php
@@ -11,15 +11,15 @@ declare(strict_types=1);
  * @lastupdate 2026-05-16 00:28:09
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\GlCt as Model;
+use Diepxuan\Simba\Models\GlCt as SimbaModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
-class GlCt extends Model
+class GlCt extends SimbaModel
 {
     /**
      * Gọi function afDuDauTk để lấy dữ liệu đầu kỳ.

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlDmTk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlDmTk.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
  * @lastupdate 2025-05-30 11:51:26
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\GlDmTk as Model;
+use Diepxuan\Simba\Models\GlDmTk as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
 
-class GlDmTk extends Model
+class GlDmTk extends SimbaModel
 {
     protected function cdate(): Attribute
     {

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmKho.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmKho.php
@@ -8,36 +8,33 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-08-02 22:18:29
+ * @lastupdate 2025-08-02 23:49:27
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Catalog\Models\Casts\CategoryMagento;
-use Diepxuan\Simba\Models\InDmNhvt as Model;
+use Diepxuan\Catalog\Models\Concerns\HasInDmKhoInventoryOperations;
+use Diepxuan\Simba\Models\InDmKho as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
-class InDmNhvt extends Model
+class InDmKho extends SimbaModel
 {
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'magento' => CategoryMagento::class,
-    ];
+    use HasInDmKhoInventoryOperations;
 
     /**
-     * Gọi stored procedure asINGetDMNHVT để lấy dữ Danh sách nhóm vật tư - hàng hóa.
+     * Gọi stored procedure asINGetDMKHO để lấy dữ liệu Danh sách kho.
      *
      * @return array
      */
-    public static function getAsINGetDMNHVT(array $params): Collection
+    public static function getAsINGetDMKHO(array $params = []): Collection
     {
-        return self::hydrate(parent::getAsINGetDMNHVT($params)->toArray());
+        return self::hydrate(parent::getAsINGetDMKHO([
+            'pMa_Cty' => $params['pMa_Cty'] ??  \CatalogService::company()->id,
+            'pMa_kho' => $params['pMa_kho'] ?? null,
+            'pStruct' => $params['pStruct'] ?? null,
+        ])->toArray());
     }
 
     protected function cdate(): Attribute
@@ -68,27 +65,17 @@ class InDmNhvt extends Model
         );
     }
 
+    protected function khoDl(): Attribute
+    {
+        return Attribute::get(
+            static fn ($value, array $attributes) => ($value ?? $attributes['kho_dl'] ?? false) ? '✔' : ''
+        );
+    }
+
     protected function ksd(): Attribute
     {
         return Attribute::get(
             static fn ($value, array $attributes) => ($value ?? $attributes['ksd'] ?? $attributes['KSD'] ?? false) ? '✔' : ''
         );
-    }
-
-    protected function congSl(): Attribute
-    {
-        return Attribute::get(
-            static fn ($value, array $attributes) => ($value ?? $attributes['cong_sl'] ?? false) ? '✔' : ''
-        );
-    }
-
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
-    protected function casts(): array
-    {
-        return array_merge(parent::casts(), $this->casts);
     }
 }

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmNhvt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmNhvt.php
@@ -8,33 +8,36 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-08-02 23:49:27
+ * @lastupdate 2025-08-02 22:18:29
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Catalog\Models\Concerns\HasInDmKhoInventoryOperations;
-use Diepxuan\Simba\Models\InDmKho as Model;
+use Diepxuan\Catalog\Models\Casts\CategoryMagento;
+use Diepxuan\Simba\Models\InDmNhvt as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
-class InDmKho extends Model
+class InDmNhvt extends SimbaModel
 {
-    use HasInDmKhoInventoryOperations;
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'magento' => CategoryMagento::class,
+    ];
 
     /**
-     * Gọi stored procedure asINGetDMKHO để lấy dữ liệu Danh sách kho.
+     * Gọi stored procedure asINGetDMNHVT để lấy dữ Danh sách nhóm vật tư - hàng hóa.
      *
      * @return array
      */
-    public static function getAsINGetDMKHO(array $params = []): Collection
+    public static function getAsINGetDMNHVT(array $params): Collection
     {
-        return self::hydrate(parent::getAsINGetDMKHO([
-            'pMa_Cty' => $params['pMa_Cty'] ??  \CatalogService::company()->id,
-            'pMa_kho' => $params['pMa_kho'] ?? null,
-            'pStruct' => $params['pStruct'] ?? null,
-        ])->toArray());
+        return self::hydrate(parent::getAsINGetDMNHVT($params)->toArray());
     }
 
     protected function cdate(): Attribute
@@ -65,17 +68,27 @@ class InDmKho extends Model
         );
     }
 
-    protected function khoDl(): Attribute
-    {
-        return Attribute::get(
-            static fn ($value, array $attributes) => ($value ?? $attributes['kho_dl'] ?? false) ? '✔' : ''
-        );
-    }
-
     protected function ksd(): Attribute
     {
         return Attribute::get(
             static fn ($value, array $attributes) => ($value ?? $attributes['ksd'] ?? $attributes['KSD'] ?? false) ? '✔' : ''
         );
+    }
+
+    protected function congSl(): Attribute
+    {
+        return Attribute::get(
+            static fn ($value, array $attributes) => ($value ?? $attributes['cong_sl'] ?? false) ? '✔' : ''
+        );
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return array_merge(parent::casts(), $this->casts);
     }
 }

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmVt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmVt.php
@@ -8,20 +8,19 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-08-01 15:36:37
+ * @lastupdate 2026-06-22 21:07:55
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Currency\Formatter;
-use Diepxuan\Simba\Models\InDmVt as Model;
+use Diepxuan\Simba\Models\InDmVt as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-class InDmVt extends Model
+class InDmVt extends SimbaModel
 {
     /**
      * Scope a query to include the quantity of products.
@@ -65,26 +64,6 @@ class InDmVt extends Model
             ->select($selectColumns)
             ->groupBy($groupByColumns)
         ;
-    }
-
-    /**
-     * Gọi stored procedure asINGetDMVT để lấy dữ Danh sách vật tư - hàng hóa.
-     *
-     * @return array
-     */
-    public static function getAsINGetDMVT(array $params): Collection
-    {
-        return self::hydrate(parent::getAsINGetDMVT($params)->toArray());
-    }
-
-    /**
-     * Gọi stored procedure asINRptCD02 để lấy dữ Báo cáo tồn kho.
-     *
-     * @return array
-     */
-    public static function getAsINRptCD02(array $params): Collection
-    {
-        return self::hydrate(parent::getAsINRptCD02($params)->toArray());
     }
 
     protected function tenVt(): Attribute

--- a/diepxuan/laravel-catalog/src/Models/Simba/InventoryTicket.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InventoryTicket.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
  * @lastupdate 2024-05-30 09:34:20
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\PhieuChuyenKho;
+use Diepxuan\Simba\Models\PhieuChuyenKho as SimbaModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class InventoryTicket extends PhieuChuyenKho
+class InventoryTicket extends SimbaModel
 {
     public function scopeWhereNgayCt($query, $fromDate, $toDate)
     {

--- a/diepxuan/laravel-catalog/src/Models/Simba/InventoryTicketItem.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InventoryTicketItem.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @lastupdate 2024-05-30 08:59:11
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\PhieuChuyenKhoCT;
+use Diepxuan\Simba\Models\PhieuChuyenKhoCT as SimbaModel;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-class InventoryTicketItem extends PhieuChuyenKhoCT
+class InventoryTicketItem extends SimbaModel
 {
     public function product(): HasOne
     {

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt1.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @lastupdate 2026-06-22
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Catalog\Models\Concerns\HasPoCt1PurchaseMetrics;
 use Diepxuan\Simba\Models\PoCt1 as SimbaModel;

--- a/diepxuan/laravel-catalog/src/Models/Simba/Product.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/Product.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * @lastupdate 2025-05-31 09:09:15
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\Product as Model;
+use Diepxuan\Simba\Models\Product as SimbaModel;
 
-class Product extends Model
+class Product extends SimbaModel
 {
     /**
      * Scope a query to include the quantity of products.

--- a/diepxuan/laravel-catalog/src/Models/Simba/README.md
+++ b/diepxuan/laravel-catalog/src/Models/Simba/README.md
@@ -1,0 +1,126 @@
+# Catalog Models — `Simba/` wrappers
+
+Thư mục `src/Models/Simba/` chứa **29 wrapper class** ở lớp 3 (Catalog) trong
+pattern **3-layer Model** (`SModel` / `Simba\Models` / `Catalog\Models\Simba`).
+
+## Vai trò
+
+Mỗi file trong thư mục này là một Catalog Model **mỏng**, kế thừa trực tiếp
+một class ở `Diepxuan\Simba\Models\*` (lớp 2). Wrapper giữ:
+
+- Concern trait nghiệp vụ (`HasArDmKhCategories`, `HasInDmKhoInventoryOperations`,
+  `HasPoCt1PurchaseMetrics`, `HasSoCt1SalesMetrics`, `HasSysCompanyLocalizedResx`).
+- Quan hệ (relation) phục vụ màn hình Portal/Catalog
+  (`nhomKhachHang`, `phanLoaiKhachHang`, `systemConfig`, `khoMacDinh`...).
+- Scope query theo ngữ nghĩa KH/NCC/NV hoặc workflow Catalog
+  (`scopeWithQuantity`, `scopeWhereNgayCt`...).
+- Accessor/mutator mang ngữ nghĩa nghiệp vụ Portal.
+- Helper gọi stored procedure hoặc truy vấn phục vụ Livewire component.
+
+Wrapper **không** được phép khai báo `$table`, `$primaryKey`, `$fillable`,
+`$casts` trực tiếp — schema lấy từ SModel qua Simba Model cha.
+
+## Quy tắt alias `SimbaModel`
+
+Vì class trong `Catalog\Models\Simba\<X>` trùng tên với class cha
+`Simba\Models\<X>`, mọi wrapper đều **bắt buộc** alias `as SimbaModel`:
+
+```php
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Catalog\Models\Concerns\HasArDmKhCategories;
+use Diepxuan\Simba\Models\ArDmKh as SimbaModel;
+
+/**
+ * Model ArDmKh - Danh mục khách hàng (catalog layer).
+ */
+class ArDmKh extends SimbaModel
+{
+    use HasArDmKhCategories;
+
+    public function nhomKhachHang(): BelongsTo
+    {
+        return $this->belongsTo(Simba\Models\ArDmNhKh::class, ...);
+    }
+}
+```
+
+Không alias → PHP resolve `extends ArDmKh` về chính class đang khai báo
+(`Catalog\Models\Simba\ArDmKh`) → **fatal error**.
+
+Hai trường hợp đặc biệt (`InventoryTicket`, `InventoryTicketItem`) extend
+class cha tên khác (`PhieuChuyenKho`, `PhieuChuyenKhoCT`) nhưng vẫn dùng
+`as SimbaModel` để code đồng nhất trong cả thư mục.
+
+## Danh sách 29 wrapper
+
+| File | Class cha `Simba\Models\*` | Behavior |
+|---|---|---|
+| `ArDmKh.php` | `ArDmKh` | concern `HasArDmKhCategories`, nhiều relation |
+| `ArDmNhKh.php` | `ArDmNhKh` | wrapper const `CTY = SModel::CTY` |
+| `ArDmPlKh.php` | `ArDmPlKh` | wrapper const `CTY = SModel::CTY` |
+| `CaCt2.php` | `CaCt2` | rỗng (passthrough) |
+| `CaCt3.php` | `CaCt3` | rỗng (passthrough) |
+| `CaPh2.php` | `CaPh2` | rỗng (passthrough) |
+| `CaPh3.php` | `CaPh3` | rỗng (passthrough) |
+| `GlCdTk.php` | `GlCdTk` | 1 scope |
+| `GlCt.php` | `GlCt` | 4 scope/relation |
+| `GlDmTk.php` | `GlDmTk` | 2 accessor |
+| `InDmKho.php` | `InDmKho` | concern, 1 method, 6 accessor |
+| `InDmNhvt.php` | `InDmNhvt` | 1 method, 6 accessor, custom cast `CategoryMagento` |
+| `InDmVt.php` | `InDmVt` | nhiều scope |
+| `InventoryTicket.php` | `PhieuChuyenKho` | 2 scope, 1 relation |
+| `InventoryTicketItem.php` | `PhieuChuyenKhoCT` | 1 relation |
+| `PoCt1.php` | `PoCt1` | concern `HasPoCt1PurchaseMetrics` |
+| `Product.php` | `Product` | 1 scope phức tạp |
+| `SiDmBp.php` | `SiDmBp` | rỗng |
+| `SiDmNt.php` | `SiDmNt` | rỗng |
+| `SiSetup.php` | `SiSetup` | 1 relation, 1 accessor |
+| `SoCt1.php` | `SoCt1` | concern `HasSoCt1SalesMetrics` |
+| `SoPh3.php` | `SoPh3` | 1 method, 1 accessor |
+| `SysCompany.php` | `SysCompany` | concern `HasSysCompanyLocalizedResx` |
+| `SysCompanyResx.php` | `SysCompanyResx` | rỗng |
+| `SysDictionaryInfo.php` | `SysDictionaryInfo` | rỗng |
+| `SysLanguage.php` | `SysLanguage` | 1 accessor |
+| `SysMenu.php` | `SysMenu` | rỗng |
+| `SysUserInfo.php` | `SysUserInfo` | 1 relation |
+
+## Quan hệ với `src/Models/` (top-level)
+
+Một số class ở `src/Models/` (top-level) **extend** wrapper trong `Simba/`:
+
+| File top-level | Extend wrapper |
+|---|---|
+| `System.php` | `Simba\SysCompany` |
+| `SystemConfig.php` | `Simba\SiSetup` |
+| `Zsysmenu.php` | `Simba\SysMenu` |
+
+Cập nhật `SimbaModelLayerResponsibilityTest::$CATALOG_EXTENDS_WHITELIST`
+tương ứng khi thêm wrapper mới hoặc thay đổi mối quan hệ.
+
+## Quy tắc cập nhật
+
+- **Không tự đặt tên bảng/cột/SP.** Nguồn sự thật là `simba-docs/tables`
+  và các tài liệu Simba readonly liên quan.
+- Trước khi thêm behavior vào wrapper, kiểm tra:
+  1. Nếu thuần Simba table/query → đặt trong `diepxuan/laravel-simba/src/Models`.
+  2. Nếu đã mang ngữ cảnh Portal/Catalog/UI/workflow → giữ trong wrapper này.
+  3. Nếu là concern nghiệp vụ dùng chung → tách ra `../Concerns/` và `use` trait.
+- Không override lại `$table`, `$primaryKey`, `$fillable`, `$casts` —
+  schema lấy từ SModel qua Simba Model cha.
+
+## Verify
+
+```bash
+# php -l toàn bộ wrapper
+for f in diepxuan/laravel-catalog/src/Models/Simba/*.php; do php -l "$f"; done
+
+# Test gate 3-layer (assert whitelist System/SystemConfig/Zsysmenu trỏ đúng Simba\...)
+vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+```
+
+## Tóm tắt
+
+`Simba/` = 29 wrapper class ở lớp 3, extend `Diepxuan\Simba\Models\*` qua alias
+`SimbaModel`. Chứa business logic nghiệp vụ phục vụ Portal/Catalog UI.
+Concern nghiệp vụ dùng chung tách vào `../Concerns/`.

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmBp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmBp.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
  * @lastupdate 2026-03-11 22:25:00
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SiDmNt as Model;
+use Diepxuan\Simba\Models\SiDmBp as SimbaModel;
 
 /**
- * Model SiDmNt - Danh mục ngoại tệ.
+ * Model SiDmBp - Danh mục bộ phận.
  */
-class SiDmNt extends Model
+class SiDmBp extends SimbaModel
 {
 }

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmNt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmNt.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
  * @lastupdate 2026-03-11 22:25:00
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SiDmBp as Model;
+use Diepxuan\Simba\Models\SiDmNt as SimbaModel;
 
 /**
- * Model SiDmBp - Danh mục bộ phận.
+ * Model SiDmNt - Danh mục ngoại tệ.
  */
-class SiDmBp extends Model
+class SiDmNt extends SimbaModel
 {
 }

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiSetup.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * @lastupdate 2025-06-04 10:42:11
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SiSetup as Model;
+use Diepxuan\Simba\Models\SiSetup as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 
-class SiSetup extends Model
+class SiSetup extends SimbaModel
 {
     protected function system(): BelongsTo
     {

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt1.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
  * @lastupdate 2026-06-22
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Catalog\Models\Concerns\HasSoCt1SalesMetrics;
 use Diepxuan\Simba\Models\SoCt1 as SimbaModel;

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh3.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * @lastupdate 2026-03-11 23:30:00
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SoPh3 as Model;
+use Diepxuan\Simba\Models\SoPh3 as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
-class SoPh3 extends Model
+class SoPh3 extends SimbaModel
 {
     /**
      * Gọi stored procedure asSoFilt3 để lấy dữ liệu danh sách bán hàng.

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysCompany.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysCompany.php
@@ -11,14 +11,14 @@ declare(strict_types=1);
  * @lastupdate 2025-06-04 10:22:13
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Catalog\Models\Concerns\HasSysCompanyLocalizedResx;
-use Diepxuan\Simba\Models\SysCompany as Model;
+use Diepxuan\Simba\Models\SysCompany as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
-class SysCompany extends Model
+class SysCompany extends SimbaModel
 {
     use HasSysCompanyLocalizedResx;
 

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysCompanyResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysCompanyResx.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * @lastupdate 2025-05-24 21:38:53
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SysCompanyResx as Model;
+use Diepxuan\Simba\Models\SysCompanyResx as SimbaModel;
 
-class SysCompanyResx extends Model {}
+class SysCompanyResx extends SimbaModel {}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysDictionaryInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysDictionaryInfo.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @lastupdate 2026-06-21 07:31:00
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Simba\Models\SysDictionaryInfo as SimbaModel;
 

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysLanguage.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysLanguage.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * @lastupdate 2025-07-12 15:33:30
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SysLanguage as Model;
+use Diepxuan\Simba\Models\SysLanguage as SimbaModel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
-class SysLanguage extends Model
+class SysLanguage extends SimbaModel
 {
     protected function name(): Attribute
     {

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysMenu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysMenu.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @lastupdate 2026-06-20 12:54:00
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
 use Diepxuan\Simba\Models\SysMenu as SimbaModel;
 

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysUserInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysUserInfo.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  * @lastupdate 2025-05-31 09:32:17
  */
 
-namespace Diepxuan\Catalog\Models;
+namespace Diepxuan\Catalog\Models\Simba;
 
-use Diepxuan\Simba\Models\SysUserInfo as Model;
+use Diepxuan\Simba\Models\SysUserInfo as SimbaModel;
 
-class SysUserInfo extends Model
+class SysUserInfo extends SimbaModel
 {
     public function companies()
     {

--- a/diepxuan/laravel-catalog/src/Models/System.php
+++ b/diepxuan/laravel-catalog/src/Models/System.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Models;
 
 use Carbon\Carbon;
+use Diepxuan\Catalog\Models\Simba\SysCompany;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 

--- a/diepxuan/laravel-catalog/src/Models/SystemConfig.php
+++ b/diepxuan/laravel-catalog/src/Models/SystemConfig.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Models;
 
+use Diepxuan\Catalog\Models\Simba\SiSetup;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class SystemConfig extends SiSetup

--- a/diepxuan/laravel-catalog/src/Models/Zsysmenu.php
+++ b/diepxuan/laravel-catalog/src/Models/Zsysmenu.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Models;
 
+use Diepxuan\Catalog\Models\Simba\SysMenu;
+
 /**
  * Model Zsysmenu - SimbaERP z menu metadata (catalog layer).
  *

--- a/diepxuan/laravel-catalog/src/Services/CatalogFunctions.php
+++ b/diepxuan/laravel-catalog/src/Services/CatalogFunctions.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
-use Diepxuan\Catalog\Models\GlCdTk;
-use Diepxuan\Catalog\Models\GlCt;
+use Diepxuan\Catalog\Models\Simba\GlCdTk;
+use Diepxuan\Catalog\Models\Simba\GlCt;
 use Diepxuan\Catalog\Models\Params;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;

--- a/diepxuan/laravel-catalog/src/Services/CatalogService.php
+++ b/diepxuan/laravel-catalog/src/Services/CatalogService.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Services;
 
 use Diepxuan\Catalog\Config\TimerConfig;
-use Diepxuan\Catalog\Models\GlDmTk;
-use Diepxuan\Catalog\Models\SysCompany;
-use Diepxuan\Catalog\Models\SysLanguage;
-use Diepxuan\Catalog\Models\SysUserInfo;
+use Diepxuan\Catalog\Models\Simba\GlDmTk;
+use Diepxuan\Catalog\Models\Simba\SysCompany;
+use Diepxuan\Catalog\Models\Simba\SysLanguage;
+use Diepxuan\Catalog\Models\Simba\SysUserInfo;
 use Diepxuan\Catalog\Models\User;
 use Illuminate\Support\Facades\Auth;
 

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRepository.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRepository.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
-use Diepxuan\Catalog\Models\SysMenu;
+use Diepxuan\Catalog\Models\Simba\SysMenu;
 use Illuminate\Support\Collection;
 
 /**

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
-use Diepxuan\Catalog\Models\SysDictionaryInfo;
-use Diepxuan\Catalog\Models\SysMenu;
+use Diepxuan\Catalog\Models\Simba\SysDictionaryInfo;
+use Diepxuan\Catalog\Models\Simba\SysMenu;
 
 final class SimbaMenuRouteMetadata
 {

--- a/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
-use Diepxuan\Catalog\Models\SysDictionaryInfo;
-use Diepxuan\Catalog\Models\SysMenu;
+use Diepxuan\Catalog\Models\Simba\SysDictionaryInfo;
+use Diepxuan\Catalog\Models\Simba\SysMenu;
 use Diepxuan\Catalog\Models\Zsysmenu;
 use Diepxuan\Simba\Models\SiDmCt;
 use Diepxuan\Simba\Models\SysReportDrillDownInfo;

--- a/diepxuan/laravel-catalog/tests/Unit/Http/Livewire/Cash/Nganhang/Baono/PhieubaonoTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Http/Livewire/Cash/Nganhang/Baono/PhieubaonoTest.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Tests\Unit\Http\Livewire\Cash\Nganhang\Baono;
 
 use Diepxuan\Catalog\Http\Livewire\Cash\Nganhang\Baono\Phieubaono;
-use Diepxuan\Catalog\Models\ArDmKh;
-use Diepxuan\Catalog\Models\CaCt3;
-use Diepxuan\Catalog\Models\CaPh3;
+use Diepxuan\Catalog\Models\Simba\ArDmKh;
+use Diepxuan\Catalog\Models\Simba\CaCt3;
+use Diepxuan\Catalog\Models\Simba\CaPh3;
 use Diepxuan\Simba\Models\GlDmTk;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Tests\Unit\Services;
 
 use Diepxuan\Catalog\Services\SimbaMenuRouteMetadata;
-use Diepxuan\Catalog\Models\SysMenu;
+use Diepxuan\Catalog\Models\Simba\SysMenu;
 use PHPUnit\Framework\TestCase;
 
 final class SimbaMenuRouteMetadataTest extends TestCase

--- a/scripts/audit-catalog-model-layer.php
+++ b/scripts/audit-catalog-model-layer.php
@@ -48,6 +48,7 @@ foreach (scandir($modelDir) as $name) {
     if ($name === 'for.php') continue;
     if ($filter && stripos($name, $filter) === false) continue;
     $path = $modelDir . '/' . $name;
+    if (!is_file($path)) continue;   // bỏ qua thư mục Simba/, Concerns/, Casts/ (chỉ scan .php ở top-level)
     $src  = (string) file_get_contents($path);
     if (!preg_match('/\bclass\s+\w+\s+extends\b/', $src)) {
         continue;

--- a/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+++ b/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
@@ -96,10 +96,10 @@ final class SimbaModelLayerResponsibilityTest extends TestCase
     private const CATALOG_EXTENDS_WHITELIST = [
         'Params'      => 'Illuminate\\Database\\Eloquent\\Model',
         'User'        => 'App\\Models\\User',
-        'System'      => 'Diepxuan\\Catalog\\Models\\SysCompany',
-        'SystemConfig'=> 'Diepxuan\\Catalog\\Models\\SiSetup',
+        'System'      => 'Diepxuan\\Catalog\\Models\\Simba\\SysCompany',
+        'SystemConfig'=> 'Diepxuan\\Catalog\\Models\\Simba\\SiSetup',
         'UserLink'    => 'Diepxuan\\Catalog\\Models\\AbstractModel',
-        'Zsysmenu'    => 'Diepxuan\\Catalog\\Models\\SysMenu',
+        'Zsysmenu'    => 'Diepxuan\\Catalog\\Models\\Simba\\SysMenu',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- Move 28 Catalog models that extend \ into \.
- Keep \ aliases to avoid class-name collisions between \ and \.
- Update \, \, and \ to extend the moved Catalog Simba wrappers.
- Update audit/test gates and README docs for the new structure.
- Include the approved \ cleanup (remove duplicated stored-procedure wrapper methods so calls fall through to Simba model parent).

## Verification
- \Usage: php [options] [-f] <file> [--] [args...]
   php [options] -r <code> [--] [args...]
   php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
   php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
   php [options] -S <addr>:<port> [-t docroot] [router]
   php [options] -- [args...]
   php [options] -a

  -a               Run as interactive shell (requires readline extension)
  -c <path>|<file> Look for php.ini file in this directory
  -n               No configuration (ini) files will be used
  -d foo[=bar]     Define INI entry foo with value 'bar'
  -e               Generate extended information for debugger/profiler
  -f <file>        Parse and execute <file>.
  -h               This help
  -i               PHP information
  -l               Syntax check only (lint)
  -m               Show compiled in modules
  -r <code>        Run PHP <code> without using script tags <?..?>
  -B <begin_code>  Run PHP <begin_code> before processing input lines
  -R <code>        Run PHP <code> for every input line
  -F <file>        Parse and execute <file> for every input line
  -E <end_code>    Run PHP <end_code> after processing all input lines
  -H               Hide any passed arguments from external tools.
  -S <addr>:<port> Run with built-in web server.
  -t <docroot>     Specify document root <docroot> for built-in web server.
  -s               Output HTML syntax highlighted source.
  -v               Version number
  -w               Output source with stripped comments and whitespace.
  -z <file>        Load Zend extension <file>.

  args...          Arguments passed to script. Use -- args when first argument
                   starts with - or script is read from stdin

  --ini            Show configuration file names

  --rf <name>      Show information about function <name>.
  --rc <name>      Show information about class <name>.
  --re <name>      Show information about extension <name>.
  --rz <name>      Show information about Zend extension <name>.
  --ri <name>      Show configuration for extension <name>.: 32/32 files pass (28 Simba wrappers + 3 top-level Catalog files + InDmVt in batch).
- \PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Test file "tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php\" not found: 8/8 pass, 10 assertions.
- \: OK.
- Reflection smoke test: 11/11 classes autoload and parent classes resolve correctly.
- \Audit behavior in laravel-catalog Models (7 file, 3 có behavior)

file                             parent                                    scop   rel   acc   mut  meth   boot booted  classification          
-------------------------------------------------------------------------------------------------------------------------------------------------
System.php                       SysCompany                                   0     1     0     0     0      -      -  catalog_utility         
User.php                         Model                                        0     1     0     0     1      -      -  catalog_utility         
UserLink.php                     AbstractModel                                0     2     0     0     0      -      -  catalog_utility         : total=7 top-level Catalog model files, with_behavior=3.
- \: pass.

## Notes
- Untracked local plan files are intentionally not included in this PR.
