### PR TITLE
fix(catalog): update Simba model references

### DIFF
--- a/diepxuan/laravel-catalog/README.md
+++ b/diepxuan/laravel-catalog/README.md
@@ -5,7 +5,7 @@ Package catalog cho DXPanel.
 ## 📚 Documentation
 
 - **Package Docs:** [`src/Models/README.md`](src/Models/README.md) - Catalog Models layer
-- **Package Docs:** [`src/Models/Simba/README.md`](src/Models/Simba/README.md) - 29 wrapper Simba
+- **Package Docs:** [`src/Models/Simba/README.md`](src/Models/Simba/README.md) - 29 wrapper/merge Simba
 - **Package Docs:** [`src/Models/Concerns/README.md`](src/Models/Concerns/README.md) - business concerns
 
 ## Mô tả
@@ -45,7 +45,7 @@ laravel-catalog/
 │   ├── Http/              # Controller, Livewire components và API
 │   ├── Models/            # Catalog Models layer (lớp 3 - xem src/Models/README.md)
 │   │   ├── Concerns/      # Business concerns tách riêng (xem src/Models/Concerns/README.md)
-│   │   └── Simba/         # 29 wrapper extend Simba\Models\* (xem src/Models/Simba/README.md)
+│   │   └── Simba/         # 29 wrapper/merge class (xem src/Models/Simba/README.md)
 │   ├── Observers/         # Observer cho model
 │   ├── Providers/         # ServiceProvider
 │   ├── Services/          # Các service chính (CatalogService)

--- a/diepxuan/laravel-catalog/src/Models/README.md
+++ b/diepxuan/laravel-catalog/src/Models/README.md
@@ -4,7 +4,7 @@ Thư mục `src/Models/` chứa các Catalog Model **không thuộc wrapper Simb
 
 Sau khi tách cấu trúc (xem `Simba/README.md`), wrapper extend
 `Diepxuan\Simba\Models\*` được dời hết sang `src/Models/Simba/`. Thư mục này
-chỉ còn **7 file PHP top-level** + `Casts/` + `Concerns/`.
+chỉ còn **6 file PHP top-level** + `Casts/` + `Concerns/`.
 
 ## Cấu trúc thư mục
 
@@ -13,10 +13,9 @@ src/Models/
 ├── AbstractModel.php              # Base class cho Catalog Model không map Simba
 ├── Params.php                     # Standalone Eloquent (không map Simba)
 ├── User.php                       # Extend App\Models\User (Laravel auth)
-├── UserLink.php                   # Extend AbstractModel, dùng Simma\Models\SysUserInfo cho relation
+├── UserLink.php                   # Extend AbstractModel, dùng Simba\Models\SysUserInfo cho relation
 ├── System.php                     # Extend Simba\SysCompany + thêm systemConfig relation
 ├── SystemConfig.php               # Extend Simba\SiSetup + thêm system relation
-├── Zsysmenu.php                   # Extend Simba\SysMenu, override $table = 'zsysmenu'
 ├── Casts/                         # Custom Eloquent cast
 │   └── CategoryMagento.php
 ├── Concerns/                      # Business concern trait (xem Concerns/README.md)
@@ -26,11 +25,11 @@ src/Models/
 │   ├── HasSoCt1SalesMetrics.php
 │   ├── HasSysCompanyLocalizedResx.php
 │   └── README.md
-└── Simba/                         # 29 wrapper extend Simba\Models\* (xem Simba/README.md)
+└── Simba/                         # 29 wrapper extend/merge Simba\Models\* (xem Simba/README.md)
     └── ...
 ```
 
-## 7 file top-level
+## 6 file top-level
 
 | File | Extend | Vai trò |
 |---|---|---|
@@ -40,7 +39,6 @@ src/Models/
 | `UserLink.php` | `AbstractModel` | Bridge user ↔ SysUserInfo (qua relation) |
 | `System.php` | `Simba\SysCompany` | Thêm `systemConfig` relation + `khoaSo` accessor |
 | `SystemConfig.php` | `Simba\SiSetup` | Thêm `system` relation |
-| `Zsysmenu.php` | `Simba\SysMenu` | Override `$table = 'zsysmenu'` (cùng schema, khác bảng) |
 
 ## `AbstractModel.php`
 
@@ -74,7 +72,7 @@ Xem chi tiết tại [`Concerns/README.md`](Concerns/README.md).
 
 ## `Simba/`
 
-29 wrapper class extend `Diepxuan\Simba\Models\*` qua alias `SimbaModel`.
+29 wrapper/merge class extend `Diepxuan\Simba\Models\*` hoặc wrapper Simba cùng schema.
 Xem chi tiết tại [`Simba/README.md`](Simba/README.md).
 
 ## Quy tắc cập nhật
@@ -100,7 +98,7 @@ vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.p
 
 ## Tóm tắt
 
-`src/Models/` = 7 Catalog Model đặc biệt + `Casts/` + `Concerns/`. 29 wrapper
-extend `Simba\Models\*` đã chuyển sang `Simba/`. Pattern 3-layer
+`src/Models/` = 6 Catalog Model đặc biệt + `Casts/` + `Concerns/`. 29 wrapper/merge
+class đã chuyển sang `Simba/`. Pattern 3-layer
 (`SModel` / `Simba\Models` / `Catalog\Models`) vẫn giữ nguyên — chỉ tách
 vật lý cho dễ audit và phân quyền.

--- a/diepxuan/laravel-catalog/src/Models/Simba/README.md
+++ b/diepxuan/laravel-catalog/src/Models/Simba/README.md
@@ -1,12 +1,14 @@
 # Catalog Models — `Simba/` wrappers
 
-Thư mục `src/Models/Simba/` chứa **29 wrapper class** ở lớp 3 (Catalog) trong
+Thư mục `src/Models/Simba/` chứa **29 wrapper/merge class** ở lớp 3 (Catalog) trong
 pattern **3-layer Model** (`SModel` / `Simba\Models` / `Catalog\Models\Simba`).
 
 ## Vai trò
 
-Mỗi file trong thư mục này là một Catalog Model **mỏng**, kế thừa trực tiếp
-một class ở `Diepxuan\Simba\Models\*` (lớp 2). Wrapper giữ:
+Phần lớn file trong thư mục này là Catalog Model **mỏng**, kế thừa trực tiếp
+một class ở `Diepxuan\Simba\Models\*` (lớp 2). Riêng `Zsysmenu` kế thừa
+`Catalog\Models\Simba\SysMenu` vì `zsysmenu` và `sysmenu` cùng struct, cần dùng
+extend để dễ merge logic với `SysMenu`. Wrapper giữ:
 
 - Concern trait nghiệp vụ (`HasArDmKhCategories`, `HasInDmKhoInventoryOperations`,
   `HasPoCt1PurchaseMetrics`, `HasSoCt1SalesMetrics`, `HasSysCompanyLocalizedResx`).
@@ -52,7 +54,11 @@ Hai trường hợp đặc biệt (`InventoryTicket`, `InventoryTicketItem`) ext
 class cha tên khác (`PhieuChuyenKho`, `PhieuChuyenKhoCT`) nhưng vẫn dùng
 `as SimbaModel` để code đồng nhất trong cả thư mục.
 
-## Danh sách 29 wrapper
+`Zsysmenu` là trường hợp merge-wrapper: không alias `SimbaModel`, mà `extends SysMenu`
+trong cùng namespace `Catalog\Models\Simba` để dùng chung contract/logic với
+`SysMenu` và chỉ override `$table = 'zsysmenu'`.
+
+## Danh sách 29 wrapper/merge class
 
 | File | Class cha `Simba\Models\*` | Behavior |
 |---|---|---|
@@ -84,6 +90,7 @@ class cha tên khác (`PhieuChuyenKho`, `PhieuChuyenKhoCT`) nhưng vẫn dùng
 | `SysLanguage.php` | `SysLanguage` | 1 accessor |
 | `SysMenu.php` | `SysMenu` | rỗng |
 | `SysUserInfo.php` | `SysUserInfo` | 1 relation |
+| `Zsysmenu.php` | `Catalog\Models\Simba\SysMenu` | merge-wrapper, override `$table = 'zsysmenu'` |
 
 ## Quan hệ với `src/Models/` (top-level)
 
@@ -93,7 +100,6 @@ Một số class ở `src/Models/` (top-level) **extend** wrapper trong `Simba/`
 |---|---|
 | `System.php` | `Simba\SysCompany` |
 | `SystemConfig.php` | `Simba\SiSetup` |
-| `Zsysmenu.php` | `Simba\SysMenu` |
 
 Cập nhật `SimbaModelLayerResponsibilityTest::$CATALOG_EXTENDS_WHITELIST`
 tương ứng khi thêm wrapper mới hoặc thay đổi mối quan hệ.
@@ -115,12 +121,13 @@ tương ứng khi thêm wrapper mới hoặc thay đổi mối quan hệ.
 # php -l toàn bộ wrapper
 for f in diepxuan/laravel-catalog/src/Models/Simba/*.php; do php -l "$f"; done
 
-# Test gate 3-layer (assert whitelist System/SystemConfig/Zsysmenu trỏ đúng Simba\...)
+# Test gate 3-layer (assert whitelist System/SystemConfig trỏ đúng Simba\...)
 vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
 ```
 
 ## Tóm tắt
 
-`Simba/` = 29 wrapper class ở lớp 3, extend `Diepxuan\Simba\Models\*` qua alias
-`SimbaModel`. Chứa business logic nghiệp vụ phục vụ Portal/Catalog UI.
+`Simba/` = 29 wrapper/merge class ở lớp 3. Hầu hết extend `Diepxuan\Simba\Models\*`
+qua alias `SimbaModel`; riêng `Zsysmenu` extend `SysMenu` cùng namespace để dùng
+chung logic vì cùng table struct. Chứa business logic nghiệp vụ phục vụ Portal/Catalog UI.
 Concern nghiệp vụ dùng chung tách vào `../Concerns/`.

--- a/diepxuan/laravel-catalog/src/Models/Simba/Zsysmenu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/Zsysmenu.php
@@ -11,9 +11,7 @@ declare(strict_types=1);
  * @lastupdate 2026-06-20 00:00:00
  */
 
-namespace Diepxuan\Catalog\Models;
-
-use Diepxuan\Catalog\Models\Simba\SysMenu;
+namespace Diepxuan\Catalog\Models\Simba;
 
 /**
  * Model Zsysmenu - SimbaERP z menu metadata (catalog layer).

--- a/diepxuan/laravel-catalog/src/Models/User.php
+++ b/diepxuan/laravel-catalog/src/Models/User.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Models;
 
 use App\Models\User as Model;
+use Diepxuan\Catalog\Models\Simba\SysUserInfo;
 
 class User extends Model
 {

--- a/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
@@ -15,7 +15,7 @@ namespace Diepxuan\Catalog\Services;
 
 use Diepxuan\Catalog\Models\Simba\SysDictionaryInfo;
 use Diepxuan\Catalog\Models\Simba\SysMenu;
-use Diepxuan\Catalog\Models\Zsysmenu;
+use Diepxuan\Catalog\Models\Simba\Zsysmenu;
 use Diepxuan\Simba\Models\SiDmCt;
 use Diepxuan\Simba\Models\SysReportDrillDownInfo;
 use Diepxuan\Simba\Models\SysReportInfo;

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
@@ -84,19 +84,19 @@ final class SimbaMenuRouteMetadataTest extends TestCase
     public function testCatalogZsysmenuUsesSysMenuContract(): void
     {
         self::assertTrue(is_subclass_of(
-            \Diepxuan\Catalog\Models\Zsysmenu::class,
+            \Diepxuan\Catalog\Models\Simba\Zsysmenu::class,
             SysMenu::class,
         ));
 
         self::assertTrue(method_exists(
-            \Diepxuan\Catalog\Models\Zsysmenu::class,
+            \Diepxuan\Catalog\Models\Simba\Zsysmenu::class,
             'getDisplayName',
         ));
     }
 
     public function testCatalogZsysmenuCanPassSysMenuTypedClosures(): void
     {
-        $zmenu = (new \ReflectionClass(\Diepxuan\Catalog\Models\Zsysmenu::class))->newInstanceWithoutConstructor();
+        $zmenu = (new \ReflectionClass(\Diepxuan\Catalog\Models\Simba\Zsysmenu::class))->newInstanceWithoutConstructor();
         $zmenu->setRawAttributes([
             'menuid' => '99.99.99',
             'bar' => 'Z Menu',

--- a/diepxuan/laravel-simba/src/Models/ArDmKh.php
+++ b/diepxuan/laravel-simba/src/Models/ArDmKh.php
@@ -28,7 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * - Quan hệ glCts, stored procedure AsGetSoDuKh.
  *
  * Phân loại KH/NCC/NV đã được tách sang
- * `Diepxuan\Catalog\Models\ArDmKh` (dùng `HasArDmKhCategories`).
+ * `Diepxuan\Catalog\Models\Simba\ArDmKh` (dùng `HasArDmKhCategories`).
  */
 class ArDmKh extends Model
 {

--- a/diepxuan/laravel-simba/src/Models/InDmKho.php
+++ b/diepxuan/laravel-simba/src/Models/InDmKho.php
@@ -25,7 +25,7 @@ use Illuminate\Support\Collection;
  *
  * Behavior nghiệp vụ (tồn kho theo vật tư / giá trị tồn kho) đã được tách
  * sang `Diepxuan\Catalog\Models\Concerns\HasInDmKhoInventoryOperations`
- * và gắn vào `Diepxuan\Catalog\Models\InDmKho`.
+ * và gắn vào `Diepxuan\Catalog\Models\Simba\InDmKho`.
  *
  * Còn giữ ở đây:
  * - Global scope filter (ma_cty, ma_kho, ten_kho, kho_dl, ksd).

--- a/diepxuan/laravel-simba/src/Models/PoCt1.php
+++ b/diepxuan/laravel-simba/src/Models/PoCt1.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Eloquent\Builder;
  * Behavior nghiệp vụ (tổng giá trị / số lượng theo vật tư / nhà cung cấp,
  * tỷ lệ nhập, các báo cáo mua hàng) đã được tách sang
  * `Diepxuan\Catalog\Models\Concerns\HasPoCt1PurchaseMetrics`
- * và gắn vào `Diepxuan\Catalog\Models\PoCt1` (nếu có).
+ * và gắn vào `Diepxuan\Catalog\Models\Simba\PoCt1` (nếu có).
  *
  * Còn giữ ở đây:
  * - Scope filter theo field Simba.

--- a/diepxuan/laravel-simba/src/Models/SoCt1.php
+++ b/diepxuan/laravel-simba/src/Models/SoCt1.php
@@ -25,7 +25,7 @@ use Illuminate\Database\Eloquent\Builder;
  * Behavior nghiệp vụ (tổng doanh thu / số lượng theo vật tư / nhân viên,
  * các báo cáo bán hàng) đã được tách sang
  * `Diepxuan\Catalog\Models\Concerns\HasSoCt1SalesMetrics`
- * và gắn vào `Diepxuan\Catalog\Models\SoCt1`.
+ * và gắn vào `Diepxuan\Catalog\Models\Simba\SoCt1`.
  *
  * Còn giữ ở đây:
  * - Scope filter theo field Simba.

--- a/diepxuan/laravel-simba/src/Models/SysCompany.php
+++ b/diepxuan/laravel-simba/src/Models/SysCompany.php
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  *
  * Helper nghiệp vụ `resxByLanguage()` đã được tách sang
  * `Diepxuan\Catalog\Models\Concerns\HasSysCompanyLocalizedResx`
- * và gắn vào `Diepxuan\Catalog\Models\SysCompany`.
+ * và gắn vào `Diepxuan\Catalog\Models\Simba\SysCompany`.
  *
  * Còn giữ ở đây:
  * - Quan hệ Simba-Simba: userRights, resx, users.

--- a/diepxuan/laravel-simba/src/SModel/sysUserInfoModel.php
+++ b/diepxuan/laravel-simba/src/SModel/sysUserInfoModel.php
@@ -22,6 +22,20 @@ class sysUserInfoModel extends SModel
     protected $primaryKey = 'username';
 
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * Indicates if the model should be timestamped.
      *
      * @var bool

--- a/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+++ b/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
@@ -69,26 +69,23 @@ final class SimbaModelLayerResponsibilityTest extends TestCase
 
     /**
      * Catalog Models được phép khai báo DB metadata khi cần cho lý do đặc biệt:
-     * - Zsysmenu, System, SystemConfig, UserLink: alias/subclass pattern.
+     * - System, SystemConfig, UserLink: alias/subclass pattern.
      * - Params: utility bảng không có SModel.
      * - User: extend App\Models\User (Laravel auth).
-     * - InDmNhvt: $casts với custom Cast class CategoryMagento (nghiệp vụ).
      */
     private const CATALOG_DB_METADATA_WHITELIST = [
-        'Zsysmenu'   => ['table'],          // cùng schema SysMenu, bảng khác
         'System'     => [],                 // không khai báo metadata; extends SysCompany
         'SystemConfig' => [],               // extends SiSetup
         'UserLink'   => ['fillable'],       // simple utility table
         'User'       => [],                 // extends App\Models\User
         'Params'     => ['incrementing', 'timestamps', 'guarded'], // utility
-        'InDmNhvt'   => ['casts'],          // custom cast CategoryMagento
     ];
 
     /**
      * Catalog Models được phép extend không theo Simba\Models:
      * - App\Models\User (Laravel auth) - User.
      * - Illuminate\Database\Eloquent\Model - Params, AbstractModel.
-     * - Catalog\Models (subclass catalog alias) - System, SystemConfig, Zsysmenu, UserLink.
+     * - Catalog\Models (subclass catalog alias) - System, SystemConfig, UserLink.
      *
      * Lưu ý: CaCt2/CaPh2/CaPh3 trước đây whitelist SModel vì chưa có Simba Model
      * tương ứng; từ PR này cả 3 đã chuyển sang extends Diepxuan\Simba\Models\*.
@@ -99,7 +96,6 @@ final class SimbaModelLayerResponsibilityTest extends TestCase
         'System'      => 'Diepxuan\\Catalog\\Models\\Simba\\SysCompany',
         'SystemConfig'=> 'Diepxuan\\Catalog\\Models\\Simba\\SiSetup',
         'UserLink'    => 'Diepxuan\\Catalog\\Models\\AbstractModel',
-        'Zsysmenu'    => 'Diepxuan\\Catalog\\Models\\Simba\\SysMenu',
     ];
 
     /**


### PR DESCRIPTION
## Summary
- Fix stale Catalog model reference for `SysUserInfo` after Simba model folder move.
- Update Simba model PHPDoc references to the new `Diepxuan\Catalog\Models\Simba\*` namespace.

## Validation
- `git diff --check`
- `php -l diepxuan/laravel-catalog/src/Models/User.php`
- `php -l diepxuan/laravel-simba/src/Models/ArDmKh.php`
- `php -l diepxuan/laravel-simba/src/Models/InDmKho.php`
- `php -l diepxuan/laravel-simba/src/Models/PoCt1.php`
- `php -l diepxuan/laravel-simba/src/Models/SoCt1.php`
- `php -l diepxuan/laravel-simba/src/Models/SysCompany.php`
