### PR TITLE
[codex] refactor local tool notes

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,45 +1,72 @@
 # TOOLS.md - Local Notes
 
-Skills define _how_ tools work. This file is for _your_ specifics — the stuff that's unique to your setup.
+File này ghi chú các chi tiết riêng của môi trường Portal. Skill và protocol dùng chung nằm ở nơi khác; file này chỉ giữ thông tin cần thiết cho workspace này.
 
-## What Goes Here
+## Nguyên tắc
 
-Things like:
-
-- Camera names and locations
-- SSH hosts and aliases
-- Device nicknames
-- Anything environment-specific
-
-## Why Separate?
-
-Skills are shared. Your setup is yours. Keeping them apart means you can update skills without losing your notes, and share skills without leaking your infrastructure.
-
----
+- Không lưu bí mật, token, mật khẩu hoặc dữ liệu nhạy cảm.
+- Không ghi lại hướng dẫn chung có thể sống trong skill/plugin.
+- Khi thêm tool/client mới, ghi rõ phạm vi áp dụng và cách nhận diện.
 
 ## SSH Hosts
 
 ### Development Servers
 
-- **web** → `ssh root@web` (Portal development server)
-    - Primary database server for Portal application
-    - Contains production-like data for development
+- **web** -> `ssh root@web`
+  - Portal development server.
+  - Chứa dữ liệu gần production phục vụ development.
 
 ### Database Connections
 
-- **Portal Database**: SQL Server on web server
+- **Portal Database:** SQL Server trên `web`.
 
 ### Notes
 
-- SSH key: `~/.ssh/id_rsa` (existing key)
-- Default port: 22
-- Use `ssh root@web` for direct connection
-
----
+- SSH key: `~/.ssh/id_rsa`
+- Default port: `22`
+- Dùng `ssh root@web` khi cần truy cập trực tiếp.
 
 ## simba-docs
 
-- **Mount point:** `simba-docs/` (trong workspace)
-- **Mục đích:** Toàn bộ tài liệu SimbaSql .NET — domain knowledge
-- **Trạng thái:** Readonly
+- **Mount point:** `simba-docs/`
+- **Mục đích:** Toàn bộ tài liệu SimbaSql .NET, là nguồn sự thật domain.
+- **Trạng thái:** Readonly.
 - **Chi tiết:** `docs/SIMBA-DOCS.md`
+
+<!-- AIGHT-CLIENT-START v=8 -->
+## Aight Client Notes
+
+Các ghi chú dưới đây chỉ áp dụng khi message đến từ Aight iOS app hoặc hosted Aight control UI.
+
+### Nhận diện
+
+- Aight iOS: `clientId = "openclaw-ios"`
+- Hosted control UI: `clientId = "openclaw-control-ui"`
+- Connect frame có `displayName = "Aight"`
+
+Nếu message không đến từ client trên, bỏ qua toàn bộ section Aight.
+
+### Chat, Voice, Images
+
+- Inbound voice đã được app chuyển thành text trước khi gửi vào gateway.
+- Outbound luôn trả plain text; app tự text-to-speech khi user bật voice mode.
+- Không dùng TTS tool và không gửi audio file cho Aight client.
+- Khi gửi ảnh, ưu tiên tool trả image bytes inline.
+- Nếu tool chỉ ghi file, file phải nằm trong `~/.openclaw/media/` hoặc legacy `~/.clawdbot/media/`, rồi trả mỗi file bằng một dòng `MEDIA: <path>`.
+- Không inline base64 image data.
+
+### Task Follow-Up
+
+- Không fire-and-forget khi giao việc async.
+- Nếu chỉ cần kết quả sub-agent ở lượt kế tiếp, dùng `sessions_yield`.
+- Nếu cần theo dõi hoặc điều hướng sub-agent, dùng `subagents` với `list`, `steer`, hoặc `kill`.
+- Chỉ dùng cron watchdog cho external async work, group-chat coordination, hoặc việc cần kiểm tra theo thời gian.
+- Worker phải claim task ngay, báo blocker nhanh, và báo completion với commit/change/next step.
+
+### Group Chat
+
+- Message group chat có prefix dạng `[Group Chat: "Name" - Members: ...]`.
+- Muốn nói với agent khác thì `@mention` trực tiếp trong text; không dùng `sessions_send`.
+- Recent messages là context; `[Your turn]` đánh dấu message mới cần xử lý.
+- Trong group task: claim ngay, báo blocker dưới 2 phút, không để task im lặng quá 5 phút, và báo completion không cần chờ hỏi.
+<!-- AIGHT-CLIENT-END -->


### PR DESCRIPTION
## What changed

- Refactored `TOOLS.md` into a shorter Portal-specific local notes document.
- Preserved SSH, Simba docs, and Aight client guidance while removing duplicated examples and long protocol prose.
- Added clear boundaries for what belongs in local notes versus shared skills/plugins.

## Why

The file had accumulated a large Aight-specific block that made local environment notes hard to scan. This keeps the operational rules available but easier to review and maintain.

## Validation

- `git diff --check`
- pre-commit checks from `git commit`