### PR TITLE
[codex] add catalog Simba model wrappers

### DIFF
--- a/diepxuan/laravel-catalog/README.md
+++ b/diepxuan/laravel-catalog/README.md
@@ -5,7 +5,7 @@ Package catalog cho DXPanel.
 ## 📚 Documentation
 
 - **Package Docs:** [`src/Models/README.md`](src/Models/README.md) - Catalog Models layer
-- **Package Docs:** [`src/Models/Simba/README.md`](src/Models/Simba/README.md) - 29 wrapper/merge Simba
+- **Package Docs:** [`src/Models/Simba/README.md`](src/Models/Simba/README.md) - wrapper/merge Simba
 - **Package Docs:** [`src/Models/Concerns/README.md`](src/Models/Concerns/README.md) - business concerns
 
 ## Mô tả
@@ -45,7 +45,7 @@ laravel-catalog/
 │   ├── Http/              # Controller, Livewire components và API
 │   ├── Models/            # Catalog Models layer (lớp 3 - xem src/Models/README.md)
 │   │   ├── Concerns/      # Business concerns tách riêng (xem src/Models/Concerns/README.md)
-│   │   └── Simba/         # 29 wrapper/merge class (xem src/Models/Simba/README.md)
+│   │   └── Simba/         # wrapper/merge class cover Simba Models (xem src/Models/Simba/README.md)
 │   ├── Observers/         # Observer cho model
 │   ├── Providers/         # ServiceProvider
 │   ├── Services/          # Các service chính (CatalogService)

--- a/diepxuan/laravel-catalog/src/Models/README.md
+++ b/diepxuan/laravel-catalog/src/Models/README.md
@@ -25,7 +25,7 @@ src/Models/
 │   ├── HasSoCt1SalesMetrics.php
 │   ├── HasSysCompanyLocalizedResx.php
 │   └── README.md
-└── Simba/                         # 29 wrapper extend/merge Simba\Models\* (xem Simba/README.md)
+└── Simba/                         # wrapper extend/merge Simba\Models\* (xem Simba/README.md)
     └── ...
 ```
 
@@ -72,8 +72,9 @@ Xem chi tiết tại [`Concerns/README.md`](Concerns/README.md).
 
 ## `Simba/`
 
-29 wrapper/merge class extend `Diepxuan\Simba\Models\*` hoặc wrapper Simba cùng schema.
-Xem chi tiết tại [`Simba/README.md`](Simba/README.md).
+445 wrapper/merge class extend `Diepxuan\Simba\Models\*` hoặc wrapper Simba cùng schema.
+Phần lớn là passthrough mỏng; 29 file có behavior riêng được liệt kê tại
+[`Simba/README.md`](Simba/README.md).
 
 ## Quy tắc cập nhật
 
@@ -98,7 +99,7 @@ vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.p
 
 ## Tóm tắt
 
-`src/Models/` = 6 Catalog Model đặc biệt + `Casts/` + `Concerns/`. 29 wrapper/merge
-class đã chuyển sang `Simba/`. Pattern 3-layer
+`src/Models/` = 6 Catalog Model đặc biệt + `Casts/` + `Concerns/`. Wrapper/merge
+class Simba nằm trong `Simba/`. Pattern 3-layer
 (`SModel` / `Simba\Models` / `Catalog\Models`) vẫn giữ nguyên — chỉ tách
 vật lý cho dễ audit và phân quyền.

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApCt1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApCt1 as SimbaModel;
+
+class ApCt1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApCt3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApCt3 as SimbaModel;
+
+class ApCt3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApCt4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApCt4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApCt4 as SimbaModel;
+
+class ApCt4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApPh1 as SimbaModel;
+
+class ApPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApPh3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApPh3 as SimbaModel;
+
+class ApPh3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApPh4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApPh4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApPh4 as SimbaModel;
+
+class ApPh4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ApTt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ApTt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ApTt as SimbaModel;
+
+class ApTt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArCdKh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArCdKh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArCdKh as SimbaModel;
+
+class ArCdKh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArCdKh13.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArCdKh13.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArCdKh13 as SimbaModel;
+
+class ArCdKh13 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArCt1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArCt1 as SimbaModel;
+
+class ArCt1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArCt3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArCt3 as SimbaModel;
+
+class ArCt3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArCt4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArCt4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArCt4 as SimbaModel;
+
+class ArCt4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArDmDckh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArDmDckh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArDmDckh as SimbaModel;
+
+class ArDmDckh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArDmKhNgh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArDmKhNgh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArDmKhNgh as SimbaModel;
+
+class ArDmKhNgh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArPh1 as SimbaModel;
+
+class ArPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArPh3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArPh3 as SimbaModel;
+
+class ArPh3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArPh4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArPh4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArPh4 as SimbaModel;
+
+class ArPh4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ArTt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ArTt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ArTt as SimbaModel;
+
+class ArTt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaCdKu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaCdKu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CaCdKu as SimbaModel;
+
+class CaCdKu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaCt1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CaCt1 as SimbaModel;
+
+class CaCt1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaDmKu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaDmKu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CaDmKu as SimbaModel;
+
+class CaDmKu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaLaiKu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaLaiKu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CaLaiKu as SimbaModel;
+
+class CaLaiKu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CaPh1 as SimbaModel;
+
+class CaPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CaTtHu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CaTtHu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CaTtHu as SimbaModel;
+
+class CaTtHu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoBgt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoBgt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoBgt as SimbaModel;
+
+class CoBgt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDd as SimbaModel;
+
+class CoDd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmBomCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmBomCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmBomCt as SimbaModel;
+
+class CoDmBomCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmBomPh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmBomPh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmBomPh as SimbaModel;
+
+class CoDmBomPh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmCptt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmCptt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmCptt as SimbaModel;
+
+class CoDmCptt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmNhSpct.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmNhSpct.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmNhSpct as SimbaModel;
+
+class CoDmNhSpct extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmPb.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmPb.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmPb as SimbaModel;
+
+class CoDmPb extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmPb1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmPb1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmPb1 as SimbaModel;
+
+class CoDmPb1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmPb2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmPb2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmPb2 as SimbaModel;
+
+class CoDmPb2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmPbCachTinhHs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmPbCachTinhHs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmPbCachTinhHs as SimbaModel;
+
+class CoDmPbCachTinhHs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmPbCachTinhHsResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmPbCachTinhHsResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmPbCachTinhHsResx as SimbaModel;
+
+class CoDmPbCachTinhHsResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoDmSpct.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoDmSpct.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoDmSpct as SimbaModel;
+
+class CoDmSpct extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoKhCptt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoKhCptt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoKhCptt as SimbaModel;
+
+class CoKhCptt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoLk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoLk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoLk as SimbaModel;
+
+class CoLk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoSetup as SimbaModel;
+
+class CoSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CoTgtMau.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CoTgtMau.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CoTgtMau as SimbaModel;
+
+class CoTgtMau extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CrCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CrCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CrCt as SimbaModel;
+
+class CrCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CrCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CrCt1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CrCt1 as SimbaModel;
+
+class CrCt1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/CrPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/CrPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\CrPh1 as SimbaModel;
+
+class CrPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmBpsd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmBpsd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmBpsd as SimbaModel;
+
+class FaDmBpsd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmCc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmCc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmCc as SimbaModel;
+
+class FaDmCc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmLdtg.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmLdtg.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmLdtg as SimbaModel;
+
+class FaDmLdtg extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmLk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmLk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmLk as SimbaModel;
+
+class FaDmLk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmNhts.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmNhts.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmNhts as SimbaModel;
+
+class FaDmNhts extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmNv.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmNv.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmNv as SimbaModel;
+
+class FaDmNv extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmTs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmTs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmTs as SimbaModel;
+
+class FaDmTs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDmTs1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDmTs1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDmTs1 as SimbaModel;
+
+class FaDmTs1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDtsd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDtsd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDtsd as SimbaModel;
+
+class FaDtsd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaDungKh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaDungKh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaDungKh as SimbaModel;
+
+class FaDungKh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaKhCc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaKhCc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaKhCc as SimbaModel;
+
+class FaKhCc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaKhTs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaKhTs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaKhTs as SimbaModel;
+
+class FaKhTs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/FaSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/FaSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\FaSetup as SimbaModel;
+
+class FaSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTMIX.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTMIX.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTMIX as SimbaModel;
+
+class GlBctcTMIX extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTMVI212.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTMVI212.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTMVI212 as SimbaModel;
+
+class GlBctcTMVI212 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTMVI29b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTMVI29b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTMVI29b as SimbaModel;
+
+class GlBctcTMVI29b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmI.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmI.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmI as SimbaModel;
+
+class GlBctcTmI extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI01.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI01.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI01 as SimbaModel;
+
+class GlBctcTmVI01 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI02a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI02a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI02a as SimbaModel;
+
+class GlBctcTmVI02a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI02b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI02b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI02b as SimbaModel;
+
+class GlBctcTmVI02b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI02c.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI02c.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI02c as SimbaModel;
+
+class GlBctcTmVI02c extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI03.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI03.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI03 as SimbaModel;
+
+class GlBctcTmVI03 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI04.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI04.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI04 as SimbaModel;
+
+class GlBctcTmVI04 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI05.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI05.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI05 as SimbaModel;
+
+class GlBctcTmVI05 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI06.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI06.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI06 as SimbaModel;
+
+class GlBctcTmVI06 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI0708.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI0708.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI0708 as SimbaModel;
+
+class GlBctcTmVI0708 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI08b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI08b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI08b as SimbaModel;
+
+class GlBctcTmVI08b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI09.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI09.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI09 as SimbaModel;
+
+class GlBctcTmVI09 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI10.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI10.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI10 as SimbaModel;
+
+class GlBctcTmVI10 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI11.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI11.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI11 as SimbaModel;
+
+class GlBctcTmVI11 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI12.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI12.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI12 as SimbaModel;
+
+class GlBctcTmVI12 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI13.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI13.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI13 as SimbaModel;
+
+class GlBctcTmVI13 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI15a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI15a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI15a as SimbaModel;
+
+class GlBctcTmVI15a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI15c.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI15c.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI15c as SimbaModel;
+
+class GlBctcTmVI15c extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI15d.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI15d.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI15d as SimbaModel;
+
+class GlBctcTmVI15d extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI16.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI16.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI16 as SimbaModel;
+
+class GlBctcTmVI16 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI17.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI17.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI17 as SimbaModel;
+
+class GlBctcTmVI17 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI18.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI18.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI18 as SimbaModel;
+
+class GlBctcTmVI18 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI211.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI211.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI211 as SimbaModel;
+
+class GlBctcTmVI211 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI23.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI23.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI23 as SimbaModel;
+
+class GlBctcTmVI23 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI25a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI25a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI25a as SimbaModel;
+
+class GlBctcTmVI25a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI25b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVI25b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVI25b as SimbaModel;
+
+class GlBctcTmVI25b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVII.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVII.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVII as SimbaModel;
+
+class GlBctcTmVII extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVIII.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBctcTmVIII.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBctcTmVIII as SimbaModel;
+
+class GlBctcTmVIII extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlBudget.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlBudget.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlBudget as SimbaModel;
+
+class GlBudget extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlCt1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlCt1 as SimbaModel;
+
+class GlCt1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlCtGs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlCtGs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlCtGs as SimbaModel;
+
+class GlCtGs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlDmCtgs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlDmCtgs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlDmCtgs as SimbaModel;
+
+class GlDmCtgs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlDmCtgsResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlDmCtgsResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlDmCtgsResx as SimbaModel;
+
+class GlDmCtgsResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlDmDgtg.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlDmDgtg.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlDmDgtg as SimbaModel;
+
+class GlDmDgtg extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlDmKc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlDmKc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlDmKc as SimbaModel;
+
+class GlDmKc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlFinReportData.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlFinReportData.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlFinReportData as SimbaModel;
+
+class GlFinReportData extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlLoaiTk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlLoaiTk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlLoaiTk as SimbaModel;
+
+class GlLoaiTk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc02.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc02.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctc02 as SimbaModel;
+
+class GlMauBctc02 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc03.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc03.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctc03 as SimbaModel;
+
+class GlMauBctc03 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc04.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc04.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctc04 as SimbaModel;
+
+class GlMauBctc04 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc05.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc05.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctc05 as SimbaModel;
+
+class GlMauBctc05 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc06.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctc06.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctc06 as SimbaModel;
+
+class GlMauBctc06 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTMIX.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTMIX.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTMIX as SimbaModel;
+
+class GlMauBctcTMIX extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTMVI212.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTMVI212.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTMVI212 as SimbaModel;
+
+class GlMauBctcTMVI212 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTMVI29b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTMVI29b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTMVI29b as SimbaModel;
+
+class GlMauBctcTMVI29b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmI.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmI.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmI as SimbaModel;
+
+class GlMauBctcTmI extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI01.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI01.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI01 as SimbaModel;
+
+class GlMauBctcTmVI01 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI02a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI02a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI02a as SimbaModel;
+
+class GlMauBctcTmVI02a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI02b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI02b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI02b as SimbaModel;
+
+class GlMauBctcTmVI02b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI02c.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI02c.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI02c as SimbaModel;
+
+class GlMauBctcTmVI02c extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI03.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI03.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI03 as SimbaModel;
+
+class GlMauBctcTmVI03 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI04.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI04.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI04 as SimbaModel;
+
+class GlMauBctcTmVI04 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI05.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI05.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI05 as SimbaModel;
+
+class GlMauBctcTmVI05 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI06.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI06.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI06 as SimbaModel;
+
+class GlMauBctcTmVI06 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI0708.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI0708.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI0708 as SimbaModel;
+
+class GlMauBctcTmVI0708 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI08b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI08b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI08b as SimbaModel;
+
+class GlMauBctcTmVI08b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI09.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI09.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI09 as SimbaModel;
+
+class GlMauBctcTmVI09 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI10.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI10.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI10 as SimbaModel;
+
+class GlMauBctcTmVI10 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI11.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI11.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI11 as SimbaModel;
+
+class GlMauBctcTmVI11 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI12.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI12.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI12 as SimbaModel;
+
+class GlMauBctcTmVI12 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI13.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI13.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI13 as SimbaModel;
+
+class GlMauBctcTmVI13 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI15a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI15a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI15a as SimbaModel;
+
+class GlMauBctcTmVI15a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI15d.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI15d.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI15d as SimbaModel;
+
+class GlMauBctcTmVI15d extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI16.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI16.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI16 as SimbaModel;
+
+class GlMauBctcTmVI16 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI17.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI17.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI17 as SimbaModel;
+
+class GlMauBctcTmVI17 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI18.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI18.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI18 as SimbaModel;
+
+class GlMauBctcTmVI18 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI211.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI211.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI211 as SimbaModel;
+
+class GlMauBctcTmVI211 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI23.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI23.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI23 as SimbaModel;
+
+class GlMauBctcTmVI23 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI25a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI25a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI25a as SimbaModel;
+
+class GlMauBctcTmVI25a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI25b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVI25b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVI25b as SimbaModel;
+
+class GlMauBctcTmVI25b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVII.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVII.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVII as SimbaModel;
+
+class GlMauBctcTmVII extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVIII.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlMauBctcTmVIII.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlMauBctcTmVIII as SimbaModel;
+
+class GlMauBctcTmVIII extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlNb.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlNb.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlNb as SimbaModel;
+
+class GlNb extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlPh1 as SimbaModel;
+
+class GlPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/GlmauBctcTmVI15c.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/GlmauBctcTmVI15c.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\GlmauBctcTmVI15c as SimbaModel;
+
+class GlmauBctcTmVI15c extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrChamCong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrChamCong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrChamCong as SimbaModel;
+
+class HrChamCong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrChamCongKhac.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrChamCongKhac.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrChamCongKhac as SimbaModel;
+
+class HrChamCongKhac extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDTHocVien.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDTHocVien.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDTHocVien as SimbaModel;
+
+class HrDTHocVien extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDTKhoa.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDTKhoa.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDTKhoa as SimbaModel;
+
+class HrDTKhoa extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDTLop.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDTLop.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDTLop as SimbaModel;
+
+class HrDTLop extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmCCTC.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmCCTC.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmCCTC as SimbaModel;
+
+class HrDmCCTC extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmCheDoNghi.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmCheDoNghi.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmCheDoNghi as SimbaModel;
+
+class HrDmCheDoNghi extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmKQDanhGia.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmKQDanhGia.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmKQDanhGia as SimbaModel;
+
+class HrDmKQDanhGia extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmKhac.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmKhac.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmKhac as SimbaModel;
+
+class HrDmKhac extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmKhacDs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmKhacDs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmKhacDs as SimbaModel;
+
+class HrDmKhacDs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmKhacDsResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmKhacDsResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmKhacDsResx as SimbaModel;
+
+class HrDmKhacDsResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmLuongToiThieu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmLuongToiThieu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmLuongToiThieu as SimbaModel;
+
+class HrDmLuongToiThieu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmNgachBac.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmNgachBac.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmNgachBac as SimbaModel;
+
+class HrDmNgachBac extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmNhomDanhGiaCT.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmNhomDanhGiaCT.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmNhomDanhGiaCT as SimbaModel;
+
+class HrDmNhomDanhGiaCT extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmNhomDanhGiaPH.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmNhomDanhGiaPH.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmNhomDanhGiaPH as SimbaModel;
+
+class HrDmNhomDanhGiaPH extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmPhanCapHanhChinh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmPhanCapHanhChinh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmPhanCapHanhChinh as SimbaModel;
+
+class HrDmPhanCapHanhChinh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmTCDanhGiaCT.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmTCDanhGiaCT.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmTCDanhGiaCT as SimbaModel;
+
+class HrDmTCDanhGiaCT extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmTCDanhGiaPH.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmTCDanhGiaPH.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmTCDanhGiaPH as SimbaModel;
+
+class HrDmTCDanhGiaPH extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrDmThangBangLuong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrDmThangBangLuong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrDmThangBangLuong as SimbaModel;
+
+class HrDmThangBangLuong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrHSNS.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrHSNS.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrHSNS as SimbaModel;
+
+class HrHSNS extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrHSNSPhuCap.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrHSNSPhuCap.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrHSNSPhuCap as SimbaModel;
+
+class HrHSNSPhuCap extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrHsNsTab.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrHsNsTab.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrHsNsTab as SimbaModel;
+
+class HrHsNsTab extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrHsNsTabResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrHsNsTabResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrHsNsTabResx as SimbaModel;
+
+class HrHsNsTabResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTBHXH.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTBHXH.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTBHXH as SimbaModel;
+
+class HrQTBHXH extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTCapCongCu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTCapCongCu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTCapCongCu as SimbaModel;
+
+class HrQTCapCongCu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTCongTac.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTCongTac.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTCongTac as SimbaModel;
+
+class HrQTCongTac extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTCuTru.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTCuTru.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTCuTru as SimbaModel;
+
+class HrQTCuTru extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTDanhGiaCT.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTDanhGiaCT.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTDanhGiaCT as SimbaModel;
+
+class HrQTDanhGiaCT extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTDanhGiaPH.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTDanhGiaPH.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTDanhGiaPH as SimbaModel;
+
+class HrQTDanhGiaPH extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTGhiChu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTGhiChu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTGhiChu as SimbaModel;
+
+class HrQTGhiChu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTHocTap.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTHocTap.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTHocTap as SimbaModel;
+
+class HrQTHocTap extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTHopDongLD.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTHopDongLD.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTHopDongLD as SimbaModel;
+
+class HrQTHopDongLD extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTKNCongTac.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTKNCongTac.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTKNCongTac as SimbaModel;
+
+class HrQTKNCongTac extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTKhenThuong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTKhenThuong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTKhenThuong as SimbaModel;
+
+class HrQTKhenThuong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTKyNang.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTKyNang.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTKyNang as SimbaModel;
+
+class HrQTKyNang extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTLuong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTLuong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTLuong as SimbaModel;
+
+class HrQTLuong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTNghiCheDo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTNghiCheDo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTNghiCheDo as SimbaModel;
+
+class HrQTNghiCheDo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQTTheChe.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQTTheChe.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQTTheChe as SimbaModel;
+
+class HrQTTheChe extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrQuanHeNV.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrQuanHeNV.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrQuanHeNV as SimbaModel;
+
+class HrQuanHeNV extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrSetup as SimbaModel;
+
+class HrSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrTDDeThi.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrTDDeThi.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrTDDeThi as SimbaModel;
+
+class HrTDDeThi extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrTDHoiDong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrTDHoiDong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrTDHoiDong as SimbaModel;
+
+class HrTDHoiDong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrTDKetQua.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrTDKetQua.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrTDKetQua as SimbaModel;
+
+class HrTDKetQua extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrTDUngVien.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrTDUngVien.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrTDUngVien as SimbaModel;
+
+class HrTDUngVien extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrTDVongThi.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrTDVongThi.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrTDVongThi as SimbaModel;
+
+class HrTDVongThi extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/HrTDYeuCau.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/HrTDYeuCau.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\HrTDYeuCau as SimbaModel;
+
+class HrTDYeuCau extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCdFifo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCdFifo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCdFifo as SimbaModel;
+
+class InCdFifo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCdVt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCdVt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCdVt as SimbaModel;
+
+class InCdVt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCdVt13.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCdVt13.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCdVt13 as SimbaModel;
+
+class InCdVt13 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt as SimbaModel;
+
+class InCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt1 as SimbaModel;
+
+class InCt1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt2 as SimbaModel;
+
+class InCt2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt3 as SimbaModel;
+
+class InCt3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt5.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt5.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt5 as SimbaModel;
+
+class InCt5 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt6d.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt6d.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt6d as SimbaModel;
+
+class InCt6d extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt6m.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt6m.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt6m as SimbaModel;
+
+class InCt6m extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InCt9.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InCt9.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InCt9 as SimbaModel;
+
+class InCt9 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmBarcode.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmBarcode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmBarcode as SimbaModel;
+
+class InDmBarcode extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmBom.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmBom.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmBom as SimbaModel;
+
+class InDmBom extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmLo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmLo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmLo as SimbaModel;
+
+class InDmLo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmLoaiGiaTon.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmLoaiGiaTon.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmLoaiGiaTon as SimbaModel;
+
+class InDmLoaiGiaTon extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmLoaiVt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmLoaiVt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmLoaiVt as SimbaModel;
+
+class InDmLoaiVt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmLoaiVtResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmLoaiVtResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmLoaiVtResx as SimbaModel;
+
+class InDmLoaiVtResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmNhVat.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmNhVat.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmNhVat as SimbaModel;
+
+class InDmNhVat extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmNx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmNx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmNx as SimbaModel;
+
+class InDmNx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmPlVt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmPlVt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmPlVt as SimbaModel;
+
+class InDmPlVt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InDmViTri.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InDmViTri.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InDmViTri as SimbaModel;
+
+class InDmViTri extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InGiaBq.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InGiaBq.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InGiaBq as SimbaModel;
+
+class InGiaBq extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InPh1 as SimbaModel;
+
+class InPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InPh2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InPh2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InPh2 as SimbaModel;
+
+class InPh2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InPh3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InPh3 as SimbaModel;
+
+class InPh3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InPh5.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InPh5.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InPh5 as SimbaModel;
+
+class InPh5 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InPh6.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InPh6.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InPh6 as SimbaModel;
+
+class InPh6 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InPh9.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InPh9.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InPh9 as SimbaModel;
+
+class InPh9 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/InSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/InSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\InSetup as SimbaModel;
+
+class InSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/LogCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/LogCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\LogCt as SimbaModel;
+
+class LogCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/LogFifo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/LogFifo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\LogFifo as SimbaModel;
+
+class LogFifo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/LogPrint.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/LogPrint.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\LogPrint as SimbaModel;
+
+class LogPrint extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/LogUpdate.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/LogUpdate.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\LogUpdate as SimbaModel;
+
+class LogUpdate extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/MmCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/MmCt3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\MmCt3 as SimbaModel;
+
+class MmCt3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/MmDmLo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/MmDmLo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\MmDmLo as SimbaModel;
+
+class MmDmLo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/MmPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/MmPh3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\MmPh3 as SimbaModel;
+
+class MmPh3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PODmGiaMua.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PODmGiaMua.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PODmGiaMua as SimbaModel;
+
+class PODmGiaMua extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCp2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCp2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCp2 as SimbaModel;
+
+class PoCp2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCp3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCp3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCp3 as SimbaModel;
+
+class PoCp3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCp4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCp4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCp4 as SimbaModel;
+
+class PoCp4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCp8.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCp8.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCp8 as SimbaModel;
+
+class PoCp8 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt as SimbaModel;
+
+class PoCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt0.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt0.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt0 as SimbaModel;
+
+class PoCt0 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt2 as SimbaModel;
+
+class PoCt2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt3 as SimbaModel;
+
+class PoCt3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt4 as SimbaModel;
+
+class PoCt4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt5.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt5.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt5 as SimbaModel;
+
+class PoCt5 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt6.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt6.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt6 as SimbaModel;
+
+class PoCt6 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoCt8.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoCt8.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoCt8 as SimbaModel;
+
+class PoCt8 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoDmCp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoDmCp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoDmCp as SimbaModel;
+
+class PoDmCp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoDmTt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoDmTt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoDmTt as SimbaModel;
+
+class PoDmTt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh0.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh0.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh0 as SimbaModel;
+
+class PoPh0 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh1 as SimbaModel;
+
+class PoPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh2 as SimbaModel;
+
+class PoPh2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh3 as SimbaModel;
+
+class PoPh3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh4 as SimbaModel;
+
+class PoPh4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh5.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh5.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh5 as SimbaModel;
+
+class PoPh5 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh6.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh6.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh6 as SimbaModel;
+
+class PoPh6 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoPh8.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoPh8.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoPh8 as SimbaModel;
+
+class PoPh8 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/PoSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/PoSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\PoSetup as SimbaModel;
+
+class PoSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/README.md
+++ b/diepxuan/laravel-catalog/src/Models/Simba/README.md
@@ -1,7 +1,9 @@
-# Catalog Models — `Simba/` wrappers
+# Catalog Models - `Simba/` wrappers
 
-Thư mục `src/Models/Simba/` chứa **29 wrapper/merge class** ở lớp 3 (Catalog) trong
+Thư mục `src/Models/Simba/` chứa **445 wrapper/merge class** ở lớp 3 (Catalog) trong
 pattern **3-layer Model** (`SModel` / `Simba\Models` / `Catalog\Models\Simba`).
+Mỗi model ở `diepxuan/laravel-simba/src/Models` phải có một wrapper tương ứng ở
+Catalog, trừ các alias/merge-wrapper đặc biệt đã ghi rõ bên dưới.
 
 ## Vai trò
 
@@ -19,10 +21,12 @@ extend để dễ merge logic với `SysMenu`. Wrapper giữ:
 - Accessor/mutator mang ngữ nghĩa nghiệp vụ Portal.
 - Helper gọi stored procedure hoặc truy vấn phục vụ Livewire component.
 
-Wrapper **không** được phép khai báo `$table`, `$primaryKey`, `$fillable`,
-`$casts` trực tiếp — schema lấy từ SModel qua Simba Model cha.
+Wrapper passthrough **không** được phép khai báo `$table`, `$primaryKey`,
+`$fillable`, `$casts` trực tiếp — schema lấy từ SModel qua Simba Model cha.
+Wrapper có behavior riêng chỉ khai báo metadata khi đã có lý do Catalog rõ ràng
+như `Zsysmenu` merge table hoặc custom cast của `InDmNhvt`.
 
-## Quy tắt alias `SimbaModel`
+## Quy tắc alias `SimbaModel`
 
 Vì class trong `Catalog\Models\Simba\<X>` trùng tên với class cha
 `Simba\Models\<X>`, mọi wrapper đều **bắt buộc** alias `as SimbaModel`:
@@ -50,17 +54,31 @@ class ArDmKh extends SimbaModel
 Không alias → PHP resolve `extends ArDmKh` về chính class đang khai báo
 (`Catalog\Models\Simba\ArDmKh`) → **fatal error**.
 
-Hai trường hợp đặc biệt (`InventoryTicket`, `InventoryTicketItem`) extend
-class cha tên khác (`PhieuChuyenKho`, `PhieuChuyenKhoCT`) nhưng vẫn dùng
-`as SimbaModel` để code đồng nhất trong cả thư mục.
+Hai trường hợp đặc biệt (`InventoryTicket`, `InventoryTicketItem`) extend class
+cha tên khác (`PhieuChuyenKho`, `PhieuChuyenKhoCT`) nhưng vẫn dùng `as
+SimbaModel` để code đồng nhất trong cả thư mục.
 
 `Zsysmenu` là trường hợp merge-wrapper: không alias `SimbaModel`, mà `extends SysMenu`
 trong cùng namespace `Catalog\Models\Simba` để dùng chung contract/logic với
 `SysMenu` và chỉ override `$table = 'zsysmenu'`.
 
-## Danh sách 29 wrapper/merge class
+## Coverage
 
-| File | Class cha `Simba\Models\*` | Behavior |
+`Catalog\Models\Simba` phải cover toàn bộ model lớp 2 trong `Simba\Models`.
+Các wrapper passthrough chỉ chứa namespace, alias `SimbaModel`, và `extends
+SimbaModel`; không khai báo lại schema.
+
+Alias/merge-wrapper:
+
+| Simba model | Catalog wrapper | Ghi chú |
+|---|---|---|
+| `PhieuChuyenKho` | `InventoryTicket` | Tên Catalog theo domain phiếu kho |
+| `PhieuChuyenKhoCT` | `InventoryTicketItem` | Tên Catalog theo domain dòng phiếu kho |
+| `zsysmenu` | `Zsysmenu` | Merge-wrapper dùng logic chung với `SysMenu` |
+
+## Wrapper có behavior riêng
+
+| File | Class cha | Behavior |
 |---|---|---|
 | `ArDmKh.php` | `ArDmKh` | concern `HasArDmKhCategories`, nhiều relation |
 | `ArDmNhKh.php` | `ArDmNhKh` | wrapper const `CTY = SModel::CTY` |
@@ -127,7 +145,8 @@ vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.p
 
 ## Tóm tắt
 
-`Simba/` = 29 wrapper/merge class ở lớp 3. Hầu hết extend `Diepxuan\Simba\Models\*`
-qua alias `SimbaModel`; riêng `Zsysmenu` extend `SysMenu` cùng namespace để dùng
-chung logic vì cùng table struct. Chứa business logic nghiệp vụ phục vụ Portal/Catalog UI.
-Concern nghiệp vụ dùng chung tách vào `../Concerns/`.
+`Simba/` = wrapper/merge class lớp 3 cover đủ model lớp 2. Hầu hết extend
+`Diepxuan\Simba\Models\*` qua alias `SimbaModel`; riêng `Zsysmenu` extend
+`SysMenu` cùng namespace để dùng chung logic vì cùng table struct. Chỉ các file
+có behavior riêng mới chứa business logic phục vụ Portal/Catalog UI. Concern
+nghiệp vụ dùng chung tách vào `../Concerns/`.

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaBangLuong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaBangLuong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaBangLuong as SimbaModel;
+
+class SaBangLuong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaBangLuongFields.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaBangLuongFields.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaBangLuongFields as SimbaModel;
+
+class SaBangLuongFields extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaBangLuongFieldsResX.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaBangLuongFieldsResX.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaBangLuongFieldsResX as SimbaModel;
+
+class SaBangLuongFieldsResX extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaDmCongDoan.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaDmCongDoan.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaDmCongDoan as SimbaModel;
+
+class SaDmCongDoan extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaDmNguoiPhuThuoc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaDmNguoiPhuThuoc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaDmNguoiPhuThuoc as SimbaModel;
+
+class SaDmNguoiPhuThuoc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaDmSanPham.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaDmSanPham.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaDmSanPham as SimbaModel;
+
+class SaDmSanPham extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaDmThueTNCN.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaDmThueTNCN.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaDmThueTNCN as SimbaModel;
+
+class SaDmThueTNCN extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaDmXepLoai.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaDmXepLoai.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaDmXepLoai as SimbaModel;
+
+class SaDmXepLoai extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaDonGiaSp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaDonGiaSp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaDonGiaSp as SimbaModel;
+
+class SaDonGiaSp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaLoai.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaLoai.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaLoai as SimbaModel;
+
+class SaLoai extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaQuyLuong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaQuyLuong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaQuyLuong as SimbaModel;
+
+class SaQuyLuong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SaSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SaSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SaSetup as SimbaModel;
+
+class SaSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiCompany.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiCompany.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiCompany as SimbaModel;
+
+class SiCompany extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmCt as SimbaModel;
+
+class SiDmCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmCtResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmCtResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmCtResx as SimbaModel;
+
+class SiDmCtResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmExcProc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmExcProc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmExcProc as SimbaModel;
+
+class SiDmExcProc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmHd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmHd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmHd as SimbaModel;
+
+class SiDmHd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmHttt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmHttt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmHttt as SimbaModel;
+
+class SiDmHttt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmMa.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmMa.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmMa as SimbaModel;
+
+class SiDmMa extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmNgh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmNgh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmNgh as SimbaModel;
+
+class SiDmNgh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmNhHd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmNhHd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmNhHd as SimbaModel;
+
+class SiDmNhHd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmPhi.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmPhi.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmPhi as SimbaModel;
+
+class SiDmPhi extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmProduct.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmProduct.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmProduct as SimbaModel;
+
+class SiDmProduct extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiDmTgNt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiDmTgNt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiDmTgNt as SimbaModel;
+
+class SiDmTgNt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiSoCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiSoCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiSoCt as SimbaModel;
+
+class SiSoCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiStt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiStt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiStt as SimbaModel;
+
+class SiStt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiUpdateLogBk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiUpdateLogBk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiUpdateLogBk as SimbaModel;
+
+class SiUpdateLogBk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiUpdateLogCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiUpdateLogCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiUpdateLogCt as SimbaModel;
+
+class SiUpdateLogCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SiUpdateLogPh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SiUpdateLogPh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SiUpdateLogPh as SimbaModel;
+
+class SiUpdateLogPh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SmLangSysMessageResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SmLangSysMessageResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SmLangSysMessageResx as SimbaModel;
+
+class SmLangSysMessageResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SmSysTables.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SmSysTables.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SmSysTables as SimbaModel;
+
+class SmSysTables extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt as SimbaModel;
+
+class SoCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt0.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt0.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt0 as SimbaModel;
+
+class SoCt0 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt2 as SimbaModel;
+
+class SoCt2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt3.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt3.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt3 as SimbaModel;
+
+class SoCt3 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt4 as SimbaModel;
+
+class SoCt4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt5.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt5.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt5 as SimbaModel;
+
+class SoCt5 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoCt6.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoCt6.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoCt6 as SimbaModel;
+
+class SoCt6 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmCk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmCk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmCk as SimbaModel;
+
+class SoDmCk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmGiaBan.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmGiaBan.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmGiaBan as SimbaModel;
+
+class SoDmGiaBan extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmGiaVanTai.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmGiaVanTai.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmGiaVanTai as SimbaModel;
+
+class SoDmGiaVanTai extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmHhkm.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmHhkm.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmHhkm as SimbaModel;
+
+class SoDmHhkm extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmKm.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmKm.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmKm as SimbaModel;
+
+class SoDmKm extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmNvkd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmNvkd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmNvkd as SimbaModel;
+
+class SoDmNvkd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmPtvt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmPtvt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmPtvt as SimbaModel;
+
+class SoDmPtvt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmTd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmTd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmTd as SimbaModel;
+
+class SoDmTd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmTkm.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmTkm.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmTkm as SimbaModel;
+
+class SoDmTkm extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmTs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmTs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmTs as SimbaModel;
+
+class SoDmTs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoDmTt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoDmTt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoDmTt as SimbaModel;
+
+class SoDmTt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoKyCk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoKyCk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoKyCk as SimbaModel;
+
+class SoKyCk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51BkHd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51BkHd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51BkHd as SimbaModel;
+
+class SoNd51BkHd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51BkHdCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51BkHdCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51BkHdCt as SimbaModel;
+
+class SoNd51BkHdCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51DmMhdCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51DmMhdCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51DmMhdCt as SimbaModel;
+
+class SoNd51DmMhdCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51DmMhdPh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51DmMhdPh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51DmMhdPh as SimbaModel;
+
+class SoNd51DmMhdPh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51DmQdAdHd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51DmQdAdHd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51DmQdAdHd as SimbaModel;
+
+class SoNd51DmQdAdHd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51Opt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51Opt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51Opt as SimbaModel;
+
+class SoNd51Opt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51PhHdCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51PhHdCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51PhHdCt as SimbaModel;
+
+class SoNd51PhHdCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51PhHdPh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51PhHdPh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51PhHdPh as SimbaModel;
+
+class SoNd51PhHdPh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51XlHd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51XlHd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51XlHd as SimbaModel;
+
+class SoNd51XlHd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoNd51XlHdCt.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoNd51XlHdCt.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoNd51XlHdCt as SimbaModel;
+
+class SoNd51XlHdCt extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh0.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh0.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoPh0 as SimbaModel;
+
+class SoPh0 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoPh1 as SimbaModel;
+
+class SoPh1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoPh2 as SimbaModel;
+
+class SoPh2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh4.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh4.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoPh4 as SimbaModel;
+
+class SoPh4 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh5.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh5.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoPh5 as SimbaModel;
+
+class SoPh5 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoPh6.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoPh6.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoPh6 as SimbaModel;
+
+class SoPh6 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SoSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SoSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SoSetup as SimbaModel;
+
+class SoSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysReportDrillDownInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysReportDrillDownInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SysReportDrillDownInfo as SimbaModel;
+
+class SysReportDrillDownInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysReportInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysReportInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SysReportInfo as SimbaModel;
+
+class SysReportInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SysUserCompanyRight.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SysUserCompanyRight.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SysUserCompanyRight as SimbaModel;
+
+class SysUserCompanyRight extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/System.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/System.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\System as SimbaModel;
+
+class System extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/SystemConfig.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/SystemConfig.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\SystemConfig as SimbaModel;
+
+class SystemConfig extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaDieuChinh.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaDieuChinh.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaDieuChinh as SimbaModel;
+
+class TaDieuChinh extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaIn.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaIn.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaIn as SimbaModel;
+
+class TaIn extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaKhaiVat.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaKhaiVat.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaKhaiVat as SimbaModel;
+
+class TaKhaiVat extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaOut.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaOut.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaOut as SimbaModel;
+
+class TaOut extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaTndn01a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaTndn01a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaTndn01a as SimbaModel;
+
+class TaTndn01a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaTndn01a_dc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaTndn01a_dc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaTndn01a_dc as SimbaModel;
+
+class TaTndn01a_dc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaTndn01b.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaTndn01b.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaTndn01b as SimbaModel;
+
+class TaTndn01b extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaTndn03.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaTndn03.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaTndn03 as SimbaModel;
+
+class TaTndn03 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaTndn031a.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaTndn031a.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaTndn031a as SimbaModel;
+
+class TaTndn031a extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/TaTndn03_dc.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/TaTndn03_dc.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\TaTndn03_dc as SimbaModel;
+
+class TaTndn03_dc extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ZSysReportInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ZSysReportInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ZSysReportInfo as SimbaModel;
+
+class ZSysReportInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysCalcInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysCalcInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysCalcInfo as SimbaModel;
+
+class sysCalcInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDAOInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDAOInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDAOInfo as SimbaModel;
+
+class sysDAOInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDashBoard.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDashBoard.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDashBoard as SimbaModel;
+
+class sysDashBoard extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDashFrequentlyFunction.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDashFrequentlyFunction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDashFrequentlyFunction as SimbaModel;
+
+class sysDashFrequentlyFunction extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDashFunction.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDashFunction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDashFunction as SimbaModel;
+
+class sysDashFunction extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDashFunctionResX.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDashFunctionResX.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDashFunctionResX as SimbaModel;
+
+class sysDashFunctionResX extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDashParameter.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDashParameter.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDashParameter as SimbaModel;
+
+class sysDashParameter extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDashletType.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDashletType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDashletType as SimbaModel;
+
+class sysDashletType extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDictionaryComplexInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDictionaryComplexInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDictionaryComplexInfo as SimbaModel;
+
+class sysDictionaryComplexInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDictionaryComplexResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDictionaryComplexResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDictionaryComplexResx as SimbaModel;
+
+class sysDictionaryComplexResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDictionaryResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDictionaryResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDictionaryResx as SimbaModel;
+
+class sysDictionaryResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDmMagd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDmMagd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDmMagd as SimbaModel;
+
+class sysDmMagd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDmMagdResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDmMagdResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDmMagdResx as SimbaModel;
+
+class sysDmMagdResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDmTrangThai.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDmTrangThai.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDmTrangThai as SimbaModel;
+
+class sysDmTrangThai extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysDmTrangThaiResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysDmTrangThaiResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysDmTrangThaiResx as SimbaModel;
+
+class sysDmTrangThaiResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysGroupCompanyRight.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysGroupCompanyRight.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysGroupCompanyRight as SimbaModel;
+
+class sysGroupCompanyRight extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysGroupInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysGroupInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysGroupInfo as SimbaModel;
+
+class sysGroupInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysGroupRight.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysGroupRight.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysGroupRight as SimbaModel;
+
+class sysGroupRight extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysKyBaoCao.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysKyBaoCao.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysKyBaoCao as SimbaModel;
+
+class sysKyBaoCao extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysKyBaoCaoResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysKyBaoCaoResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysKyBaoCaoResx as SimbaModel;
+
+class sysKyBaoCaoResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLangDictResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLangDictResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLangDictResx as SimbaModel;
+
+class sysLangDictResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLangFrameworkResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLangFrameworkResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLangFrameworkResx as SimbaModel;
+
+class sysLangFrameworkResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLangSysMessageResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLangSysMessageResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLangSysMessageResx as SimbaModel;
+
+class sysLangSysMessageResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLangTranslationResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLangTranslationResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLangTranslationResx as SimbaModel;
+
+class sysLangTranslationResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLogSys.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLogSys.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLogSys as SimbaModel;
+
+class sysLogSys extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLookupInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLookupInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLookupInfo as SimbaModel;
+
+class sysLookupInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysLookupResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysLookupResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysLookupResx as SimbaModel;
+
+class sysLookupResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysMenuResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysMenuResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysMenuResx as SimbaModel;
+
+class sysMenuResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysOpeningBalanceInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysOpeningBalanceInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysOpeningBalanceInfo as SimbaModel;
+
+class sysOpeningBalanceInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysOpeningBalanceResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysOpeningBalanceResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysOpeningBalanceResx as SimbaModel;
+
+class sysOpeningBalanceResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysOptFieldInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysOptFieldInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysOptFieldInfo as SimbaModel;
+
+class sysOptFieldInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysOptFieldSetup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysOptFieldSetup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysOptFieldSetup as SimbaModel;
+
+class sysOptFieldSetup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysReportChart.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysReportChart.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysReportChart as SimbaModel;
+
+class sysReportChart extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysReportResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysReportResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysReportResx as SimbaModel;
+
+class sysReportResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysSetupModule.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysSetupModule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysSetupModule as SimbaModel;
+
+class sysSetupModule extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysStartupMenu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysStartupMenu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysStartupMenu as SimbaModel;
+
+class sysStartupMenu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysUserDashRight.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysUserDashRight.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysUserDashRight as SimbaModel;
+
+class sysUserDashRight extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysUserGroup.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysUserGroup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysUserGroup as SimbaModel;
+
+class sysUserGroup extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysUserRight.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysUserRight.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysUserRight as SimbaModel;
+
+class sysUserRight extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysVideoInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysVideoInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysVideoInfo as SimbaModel;
+
+class sysVideoInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysVideoResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysVideoResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysVideoResx as SimbaModel;
+
+class sysVideoResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysVoucherInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysVoucherInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysVoucherInfo as SimbaModel;
+
+class sysVoucherInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysVoucherResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysVoucherResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysVoucherResx as SimbaModel;
+
+class sysVoucherResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/sysdiagrams.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/sysdiagrams.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\sysdiagrams as SimbaModel;
+
+class sysdiagrams extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/takhaivat_data.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/takhaivat_data.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\takhaivat_data as SimbaModel;
+
+class takhaivat_data extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z as SimbaModel;
+
+class z extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zAS.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zAS.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zAS as SimbaModel;
+
+class zAS extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zBs.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zBs.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zBs as SimbaModel;
+
+class zBs extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zCDT_DmTk.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zCDT_DmTk.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zCDT_DmTk as SimbaModel;
+
+class zCDT_DmTk extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zCDT_NHSPCT.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zCDT_NHSPCT.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zCDT_NHSPCT as SimbaModel;
+
+class zCDT_NHSPCT extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zCDT_SPCT.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zCDT_SPCT.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zCDT_SPCT as SimbaModel;
+
+class zCDT_SPCT extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zCDT_ct00.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zCDT_ct00.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zCDT_ct00 as SimbaModel;
+
+class zCDT_ct00 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zCongThucLuong.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zCongThucLuong.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zCongThucLuong as SimbaModel;
+
+class zCongThucLuong extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zDictInfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zDictInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zDictInfo as SimbaModel;
+
+class zDictInfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zInCt6.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zInCt6.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zInCt6 as SimbaModel;
+
+class zInCt6 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zInCt7.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zInCt7.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zInCt7 as SimbaModel;
+
+class zInCt7 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zInPh7.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zInPh7.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zInPh7 as SimbaModel;
+
+class zInPh7 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zInPh8.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zInPh8.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zInPh8 as SimbaModel;
+
+class zInPh8 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zMS.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zMS.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zMS as SimbaModel;
+
+class zMS extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zQuocGia.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zQuocGia.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zQuocGia as SimbaModel;
+
+class zQuocGia extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zSA.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zSA.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zSA as SimbaModel;
+
+class zSA extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zSODMCA.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zSODMCA.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zSODMCA as SimbaModel;
+
+class zSODMCA extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zSysReportResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zSysReportResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zSysReportResx as SimbaModel;
+
+class zSysReportResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zSysvarEn_US.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zSysvarEn_US.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zSysvarEn_US as SimbaModel;
+
+class zSysvarEn_US extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zSysvarMsDescEn_US.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zSysvarMsDescEn_US.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zSysvarMsDescEn_US as SimbaModel;
+
+class zSysvarMsDescEn_US extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_ABC.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_ABC.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_ABC as SimbaModel;
+
+class z_ABC extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_DashFunctionDefaultParameter_xxx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_DashFunctionDefaultParameter_xxx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_DashFunctionDefaultParameter_xxx as SimbaModel;
+
+class z_DashFunctionDefaultParameter_xxx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_Formulars.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_Formulars.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_Formulars as SimbaModel;
+
+class z_Formulars extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_Table_1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_Table_1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_Table_1 as SimbaModel;
+
+class z_Table_1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_arcdkh13_dchp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_arcdkh13_dchp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_arcdkh13_dchp as SimbaModel;
+
+class z_arcdkh13_dchp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_arcdkh_dchp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_arcdkh_dchp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_arcdkh_dchp as SimbaModel;
+
+class z_arcdkh_dchp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_codmbom.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_codmbom.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_codmbom as SimbaModel;
+
+class z_codmbom extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_dtsd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_dtsd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_dtsd as SimbaModel;
+
+class z_dtsd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_glcdtk_dchp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_glcdtk_dchp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_glcdtk_dchp as SimbaModel;
+
+class z_glcdtk_dchp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_glct_dchp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_glct_dchp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_glct_dchp as SimbaModel;
+
+class z_glct_dchp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_gldmtk_dchp.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_gldmtk_dchp.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_gldmtk_dchp as SimbaModel;
+
+class z_gldmtk_dchp extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_indmvt901.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_indmvt901.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_indmvt901 as SimbaModel;
+
+class z_indmvt901 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_mytbl2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_mytbl2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_mytbl2 as SimbaModel;
+
+class z_mytbl2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_ngay_sd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_ngay_sd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_ngay_sd as SimbaModel;
+
+class z_ngay_sd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_sd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_sd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_sd as SimbaModel;
+
+class z_sd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_sidmmazzz.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_sidmmazzz.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_sidmmazzz as SimbaModel;
+
+class z_sidmmazzz extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_t1.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_t1.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_t1 as SimbaModel;
+
+class z_t1 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_zsd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_zsd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_zsd as SimbaModel;
+
+class z_zsd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_zzsochu.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_zzsochu.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_zzsochu as SimbaModel;
+
+class z_zzsochu extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/z_zzzzzza.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/z_zzzzzza.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\z_zzzzzza as SimbaModel;
+
+class z_zzzzzza extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zindmloaigiaton.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zindmloaigiaton.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zindmloaigiaton as SimbaModel;
+
+class zindmloaigiaton extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zpmct2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zpmct2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zpmct2 as SimbaModel;
+
+class zpmct2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zpmph2.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zpmph2.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zpmph2 as SimbaModel;
+
+class zpmph2 extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/ztadmmhd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/ztadmmhd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\ztadmmhd as SimbaModel;
+
+class ztadmmhd extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zzSysReportResx.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zzSysReportResx.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zzSysReportResx as SimbaModel;
+
+class zzSysReportResx extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zzSysReportinfo.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zzSysReportinfo.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zzSysReportinfo as SimbaModel;
+
+class zzSysReportinfo extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zzz.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zzz.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zzz as SimbaModel;
+
+class zzz extends SimbaModel
+{
+}

--- a/diepxuan/laravel-catalog/src/Models/Simba/zzzmhd.php
+++ b/diepxuan/laravel-catalog/src/Models/Simba/zzzmhd.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Models\Simba;
+
+use Diepxuan\Simba\Models\zzzmhd as SimbaModel;
+
+class zzzmhd extends SimbaModel
+{
+}

--- a/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
+++ b/tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php
@@ -37,6 +37,7 @@ final class SimbaModelLayerResponsibilityTest extends TestCase
     private const SMODEL_DIR    = __DIR__ . '/../../../../diepxuan/laravel-simba/src/SModel';
     private const SIMBA_DIR     = __DIR__ . '/../../../../diepxuan/laravel-simba/src/Models';
     private const CATALOG_DIR   = __DIR__ . '/../../../../diepxuan/laravel-catalog/src/Models';
+    private const CATALOG_SIMBA_DIR = __DIR__ . '/../../../../diepxuan/laravel-catalog/src/Models/Simba';
 
     /**
      * Whitelist method từ concern nghiệp vụ không được phép xuất hiện ở Simba Models.
@@ -96,6 +97,23 @@ final class SimbaModelLayerResponsibilityTest extends TestCase
         'System'      => 'Diepxuan\\Catalog\\Models\\Simba\\SysCompany',
         'SystemConfig'=> 'Diepxuan\\Catalog\\Models\\Simba\\SiSetup',
         'UserLink'    => 'Diepxuan\\Catalog\\Models\\AbstractModel',
+    ];
+
+    /**
+     * Catalog wrapper có tên khác Simba model cha.
+     */
+    private const CATALOG_SIMBA_ALIAS_WRAPPERS = [
+        'InventoryTicket'     => 'PhieuChuyenKho',
+        'InventoryTicketItem' => 'PhieuChuyenKhoCT',
+    ];
+
+    /**
+     * Simba model được cover bằng merge-wrapper Catalog tên khác.
+     */
+    private const CATALOG_SIMBA_COVERAGE_ALIASES = [
+        'PhieuChuyenKho'   => 'InventoryTicket',
+        'PhieuChuyenKhoCT' => 'InventoryTicketItem',
+        'zsysmenu'         => 'Zsysmenu',
     ];
 
     /**
@@ -354,10 +372,103 @@ final class SimbaModelLayerResponsibilityTest extends TestCase
         self::assertSame([], $violations, "Catalog\\Models extends SModel trực tiếp:\n" . implode("\n", $violations));
     }
 
+    /**
+     * Mỗi Simba Model lớp 2 phải có wrapper lớp 3 tương ứng trong Catalog.
+     */
+    public function testCatalogSimbaWrappersCoverAllSimbaModels(): void
+    {
+        $simbaModels = $this->modelShortNames(self::SIMBA_DIR);
+        $catalogWrappers = $this->modelShortNames(self::CATALOG_SIMBA_DIR);
+
+        $covered = [];
+        foreach ($catalogWrappers as $wrapper) {
+            $covered[strtolower($wrapper)] = $wrapper;
+        }
+        foreach (self::CATALOG_SIMBA_COVERAGE_ALIASES as $simbaModel => $wrapper) {
+            $covered[strtolower($simbaModel)] = $wrapper;
+        }
+
+        $missing = [];
+        foreach ($simbaModels as $simbaModel) {
+            if (!isset($covered[strtolower($simbaModel)])) {
+                $missing[] = $simbaModel;
+            }
+        }
+
+        sort($missing, SORT_NATURAL | SORT_FLAG_CASE);
+        self::assertSame([], $missing, "Catalog\\Models\\Simba thiếu wrapper cho Simba\\Models:\n" . implode("\n", $missing));
+    }
+
+    /**
+     * Wrapper trong Catalog\Models\Simba phải đi qua Diepxuan\Simba\Models\*
+     * thay vì extend trực tiếp raw SModel.
+     */
+    public function testCatalogSimbaWrappersExtendSimbaModels(): void
+    {
+        $files = glob(self::CATALOG_SIMBA_DIR . '/*.php') ?: [];
+        $violations = [];
+        foreach ($files as $file) {
+            $shortName = basename($file, '.php');
+            if ($shortName === 'README') {
+                continue;
+            }
+            $class = $this->resolveClass('Diepxuan\\Catalog\\Models\\Simba', $shortName);
+            if ($class === null) {
+                $violations[] = "Catalog\\Models\\Simba\\{$shortName}: class không autoload được";
+                continue;
+            }
+            $reflection = new \ReflectionClass($class);
+            if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+                continue;
+            }
+            $parent = $reflection->getParentClass();
+            if ($parent === false) {
+                $violations[] = "Catalog\\Models\\Simba\\{$shortName}: không có parent class";
+                continue;
+            }
+            $parentName = $parent->getName();
+            $expectedParent = $this->expectedCatalogSimbaParent($shortName);
+            if ($parentName !== $expectedParent) {
+                $violations[] = "Catalog\\Models\\Simba\\{$shortName}: parent {$parentName} phải là {$expectedParent}";
+            }
+        }
+
+        self::assertSame([], $violations, "Catalog\\Models\\Simba extend sai:\n" . implode("\n", $violations));
+    }
+
     private function resolveClass(string $namespace, string $shortName): ?string
     {
         $class = $namespace . '\\' . $shortName;
         return class_exists($class) ? $class : null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function modelShortNames(string $dir): array
+    {
+        $files = glob($dir . '/*.php') ?: [];
+        $names = [];
+        foreach ($files as $file) {
+            $shortName = basename($file, '.php');
+            if ($shortName === 'README') {
+                continue;
+            }
+            $names[] = $shortName;
+        }
+        sort($names, SORT_NATURAL | SORT_FLAG_CASE);
+
+        return $names;
+    }
+
+    private function expectedCatalogSimbaParent(string $shortName): string
+    {
+        if ($shortName === 'Zsysmenu') {
+            return 'Diepxuan\\Catalog\\Models\\Simba\\SysMenu';
+        }
+        $simbaParent = self::CATALOG_SIMBA_ALIAS_WRAPPERS[$shortName] ?? $shortName;
+
+        return 'Diepxuan\\Simba\\Models\\' . $simbaParent;
     }
 
     private function isRelationMethod(\ReflectionMethod $method): bool


### PR DESCRIPTION
## What changed

- Added passthrough `Diepxuan\Catalog\Models\Simba\*` wrappers for all missing `Diepxuan\Simba\Models\*` classes.
- Kept wrappers thin: each new class aliases the Simba model parent as `SimbaModel` and does not redefine schema metadata.
- Added model-layer guard tests to ensure Catalog Simba wrappers cover every Simba model and extend through `Diepxuan\Simba\Models\*`.
- Updated Catalog model documentation to describe full wrapper coverage, alias exceptions, and the behavior-bearing wrapper list.

## Why

Catalog code should be able to depend on the Catalog model namespace consistently while still inheriting Simba table schema and query behavior from the Simba package. The previous Catalog wrapper set covered only a subset of Simba models.

## Validation

- `php -l` for all 445 files under `diepxuan/laravel-catalog/src/Models/Simba`
- `./vendor/bin/phpunit tests/Unit/Packages/Simba/SimbaModelLayerResponsibilityTest.php` -> 10 tests, 12 assertions
- `git diff --check`
- pre-commit checks from `git commit`