### PR TITLE
[codex] perf: memoize Simba metadata + inline SimbaErpMenus view

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/system/simba-erp-menus.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/system/simba-erp-menus.blade.php
@@ -174,7 +174,90 @@
     <div class="max-h-[calc(100vh-280px)] overflow-y-auto"
          :class="{ 'simba-select-active': simbaSelectMode }">
         @forelse ($tree as $item)
-            @include('catalog::system.simba-node', ['item' => $item, 'activeMenuId' => $activeMenuId])
+            <div class="group flex items-center gap-1.5 border-b border-gray-100 px-3 py-1.5 text-xs transition hover:bg-gray-50"
+                 style="padding-left: {{ $item->depth * 16 + 8 }}px;"
+                 x-show="isVisible('{{ addslashes($item->menuid) }}')"
+                 :class="{ 'bg-blue-50 ring-1 ring-inset ring-blue-100': isActiveNode('{{ addslashes($item->menuid) }}') }"
+                 :data-active-menu="isActiveNode('{{ addslashes($item->menuid) }}')">
+                @if ($item->hasChildren)
+                    <button type="button"
+                            class="flex h-4 w-4 flex-shrink-0 items-center justify-center text-gray-400 hover:text-gray-600"
+                            @click.stop="toggleCollapse('{{ addslashes($item->menuid) }}')">
+                        <svg class="h-3 w-3 transition-transform duration-150"
+                             :class="{ 'rotate-90': !isCollapsed('{{ addslashes($item->menuid) }}') }"
+                             fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                        </svg>
+                    </button>
+                @else
+                    <div class="w-4 flex-shrink-0"></div>
+                @endif
+
+                @if ($item->isRoot)
+                    <svg class="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                    </svg>
+                @elseif ($item->isGroup)
+                    <svg class="h-4 w-4 flex-shrink-0 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                    </svg>
+                @elseif ($item->isVoucher)
+                    <svg class="h-4 w-4 flex-shrink-0 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                @elseif ($item->isMasterData)
+                    <svg class="h-4 w-4 flex-shrink-0 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4" />
+                    </svg>
+                @elseif ($item->isReport)
+                    <svg class="h-4 w-4 flex-shrink-0 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                    </svg>
+                @elseif ($item->isSetup)
+                    <svg class="h-4 w-4 flex-shrink-0 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                @else
+                    <svg class="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                @endif
+
+                @if ($item->portalUrl ?? false)
+                    <a href="{{ $item->portalUrl }}"
+                       class="min-w-0 flex-1 truncate text-blue-700 hover:text-blue-900 hover:underline"
+                       title="{{ $item->portalRoute }}: {{ $item->name ?: $item->menuid }}">
+                        {{ $item->name ?: $item->menuid }}
+                    </a>
+                    <span class="hidden flex-shrink-0 rounded bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 ring-1 ring-inset ring-emerald-200 sm:inline"
+                          title="{{ $item->portalRoute }}">
+                        {{ $item->portalLabel ?? 'Portal' }}
+                    </span>
+                @else
+                    <span class="min-w-0 flex-1 truncate text-gray-800" title="{{ $item->name ?: $item->menuid }}">
+                        {{ $item->name ?: $item->menuid }}
+                    </span>
+                @endif
+
+                <span
+                    class="flex-shrink-0 rounded px-1 font-mono text-[10px] transition"
+                    :class="{
+                        'text-gray-400 cursor-default': !simbaSelectMode && !{{ $item->isAlreadyUsed ? 'true' : 'false' }},
+                        'pulse-green-simba cursor-pointer': simbaSelectMode && !{{ $item->isAlreadyUsed ? 'true' : 'false' }},
+                        'text-gray-300 line-through cursor-not-allowed': {{ $item->isAlreadyUsed ? 'true' : 'false' }}
+                    }"
+                    @click="selectMenuId('{{ addslashes($item->menuid) }}')"
+                    title="{{ $item->isAlreadyUsed ? 'Đã sử dụng trong Portal' : 'Click để chọn' }}: {{ $item->menuid }}">
+                    {{ $item->menuid }}
+                </span>
+
+                @if ($item->dllName)
+                    <span class="hidden flex-shrink-0 rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-500 group-hover:block" title="{{ $item->dllName }}">
+                        {{ Str::limit($item->dllName, 6) }}
+                    </span>
+                @endif
+            </div>
         @empty
             <div class="flex flex-col items-center justify-center py-12 text-gray-400">
                 <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
@@ -33,6 +33,9 @@ class SimbaErpMenus extends Component
 
     protected SimbaMenuTargetResolver $resolver;
 
+    /** @var null|array<string, array{route: string, url: string, type: string, label: string}> */
+    private ?array $routeMapByMenuId = null;
+
     public function boot(SimbaMenuRepository $menus, SimbaMenuTargetResolver $resolver): void
     {
         $this->menus    = $menus;
@@ -238,6 +241,10 @@ class SimbaErpMenus extends Component
      */
     private function routeMapByMenuId(): array
     {
+        if (null !== $this->routeMapByMenuId) {
+            return $this->routeMapByMenuId;
+        }
+
         $map = [];
 
         foreach (app(SimbaMenuRouteMetadata::class)->routes() as $routeName => $metadata) {
@@ -258,7 +265,7 @@ class SimbaErpMenus extends Component
             ];
         }
 
-        return $map;
+        return $this->routeMapByMenuId = $map;
     }
 
     private function portalUrl(string $routeName, string $sourceType): ?string

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Services;
 
-use Diepxuan\Catalog\Models\Simba\SysDictionaryInfo;
 use Diepxuan\Catalog\Models\Simba\SysMenu;
 
 final class SimbaMenuRouteMetadata
@@ -27,6 +26,7 @@ final class SimbaMenuRouteMetadata
     private ?array $dictionaries = null;
     private ?array $reports = null;
     private ?array $processes = null;
+    private ?SimbaMetadataService $metadata = null;
 
     /**
      * @param null|iterable<int, SysMenu> $testMenus
@@ -267,7 +267,7 @@ final class SimbaMenuRouteMetadata
         ];
     }
 
-    private function dictionaryRow(SysMenu $menu): ?SysDictionaryInfo
+    private function dictionaryRow(SysMenu $menu): mixed
     {
         if (null !== $this->testMenus) {
             return null;
@@ -277,22 +277,20 @@ final class SimbaMenuRouteMetadata
         $codeName = trim((string) $menu->code_name);
         $dllName = trim((string) $menu->dllName);
 
-        $dictionaryRows = app(SimbaMetadataService::class)->get(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO);
-
-        $row = $dictionaryRows->first(static fn ($row): bool => $menuid === trim((string) $row->menuid));
+        $row = $this->metadata()->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'menuid')[$menuid] ?? null;
         if (null !== $row) {
             return $row;
         }
 
         if ('' !== $codeName) {
-            $row = $dictionaryRows->first(static fn ($row): bool => $codeName === trim((string) $row->code_name));
+            $row = $this->metadata()->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'code_name')[$codeName] ?? null;
             if (null !== $row) {
                 return $row;
             }
         }
 
         if ('' !== $dllName) {
-            $row = $dictionaryRows->first(static fn ($row): bool => $dllName === trim((string) $row->table_name));
+            $row = $this->metadata()->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'table_name')[$dllName] ?? null;
             if (null !== $row) {
                 return $row;
             }
@@ -318,10 +316,7 @@ final class SimbaMenuRouteMetadata
         ];
 
         $menuid = (string) $menu->menuid;
-        $drilldown = app(SimbaMetadataService::class)
-            ->get(SimbaMetadataService::DATASET_SYS_REPORT_DRILL_DOWN_INFO)
-            ->first(static fn ($row): bool => $menuid === (string) $row->menuid)
-        ;
+        $drilldown = $this->metadata()->indexBy(SimbaMetadataService::DATASET_SYS_REPORT_DRILL_DOWN_INFO, 'menuid')[$menuid] ?? null;
         if (null !== $drilldown) {
             $metadata['press_key_name'] = (string) $drilldown->press_key_name;
         }
@@ -337,10 +332,7 @@ final class SimbaMenuRouteMetadata
 
         $menuid = (string) $menu->menuid;
 
-        return app(SimbaMetadataService::class)
-            ->get(SimbaMetadataService::DATASET_SYS_REPORT_INFO)
-            ->first(static fn ($row): bool => $menuid === (string) $row->menuid)
-        ;
+        return $this->metadata()->indexBy(SimbaMetadataService::DATASET_SYS_REPORT_INFO, 'menuid')[$menuid] ?? null;
     }
 
     /**
@@ -392,5 +384,10 @@ final class SimbaMenuRouteMetadata
         $slug = strtolower((string) preg_replace('/[^A-Za-z0-9]+/', '-', $value));
 
         return trim($slug, '-');
+    }
+
+    private function metadata(): SimbaMetadataService
+    {
+        return $this->metadata ??= app(SimbaMetadataService::class);
     }
 }

--- a/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-06-20 16:10:00
+ * @lastupdate 2026-06-30 20:14:14
  */
 
 namespace Diepxuan\Catalog\Services;
@@ -25,14 +25,17 @@ use Illuminate\Support\Collection;
 
 class SimbaMetadataService
 {
-    public const DATASET_SI_DM_CT = 'si_dm_ct';
-    public const DATASET_SYS_MENU = 'sys_menu';
-    public const DATASET_SYS_DICTIONARY_INFO = 'sys_dictionary_info';
+    public const DATASET_SI_DM_CT                   = 'si_dm_ct';
+    public const DATASET_SYS_MENU                   = 'sys_menu';
+    public const DATASET_SYS_DICTIONARY_INFO        = 'sys_dictionary_info';
     public const DATASET_SYS_REPORT_DRILL_DOWN_INFO = 'sys_report_drill_down_info';
-    public const DATASET_SYS_REPORT_INFO = 'sys_report_info';
+    public const DATASET_SYS_REPORT_INFO            = 'sys_report_info';
 
     /** @var array<string, Collection|EloquentCollection> */
     private array $loaded = [];
+
+    /** @var array<string, array<string, mixed>> */
+    private array $indexes = [];
 
     /**
      * @return list<string>
@@ -74,9 +77,6 @@ class SimbaMetadataService
         return $this->warm();
     }
 
-    /**
-     * @return Collection|EloquentCollection
-     */
     public function get(string $dataset): Collection|EloquentCollection
     {
         $this->assertKnownDataset($dataset);
@@ -89,11 +89,40 @@ class SimbaMetadataService
         if (null !== $dataset) {
             $this->assertKnownDataset($dataset);
             unset($this->loaded[$dataset]);
+            foreach (array_keys($this->indexes) as $key) {
+                if (str_starts_with($key, $dataset . ':')) {
+                    unset($this->indexes[$key]);
+                }
+            }
 
             return;
         }
 
-        $this->loaded = [];
+        $this->loaded  = [];
+        $this->indexes = [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function indexBy(string $dataset, string $field): array
+    {
+        $this->assertKnownDataset($dataset);
+        $key = $dataset . ':' . $field;
+
+        if (isset($this->indexes[$key])) {
+            return $this->indexes[$key];
+        }
+
+        $index = [];
+        foreach ($this->get($dataset) as $row) {
+            $value = trim((string) data_get($row, $field));
+            if ('' !== $value && !isset($index[$value])) {
+                $index[$value] = $row;
+            }
+        }
+
+        return $this->indexes[$key] = $index;
     }
 
     public function refresh(?string $dataset = null): array|Collection|EloquentCollection
@@ -107,16 +136,19 @@ class SimbaMetadataService
         return $this->warm();
     }
 
-    /**
-     * @return Collection|EloquentCollection
-     */
     protected function load(string $dataset): Collection|EloquentCollection
     {
         return match ($dataset) {
-            self::DATASET_SI_DM_CT => SiDmCt::query()->get(),
-            self::DATASET_SYS_MENU => $this->mergedMenus(),
-            self::DATASET_SYS_DICTIONARY_INFO => SysDictionaryInfo::query()->get(),
-            self::DATASET_SYS_REPORT_DRILL_DOWN_INFO => SysReportDrillDownInfo::query()->get(),
+            self::DATASET_SI_DM_CT            => SiDmCt::query()->get(),
+            self::DATASET_SYS_MENU            => $this->mergedMenus(),
+            self::DATASET_SYS_DICTIONARY_INFO => SysDictionaryInfo::query()
+                ->select(['menuid', 'code_name', 'table_name', 'PK', 'carry_field_list'])
+                ->toBase()
+                ->get(),
+            self::DATASET_SYS_REPORT_DRILL_DOWN_INFO => SysReportDrillDownInfo::query()
+                ->select(['menuid', 'press_key_name'])
+                ->toBase()
+                ->get(),
             self::DATASET_SYS_REPORT_INFO => $this->mergedReportInfo(),
         };
     }
@@ -127,8 +159,13 @@ class SimbaMetadataService
     protected function mergedMenus(): Collection
     {
         return SysMenu::query()
+            ->select($this->menuColumns())
+            // ->where('active', '1')
             ->get()
-            ->merge(Zsysmenu::query()->get())
+            ->merge(Zsysmenu::query()
+                ->select($this->menuColumns())
+                // ->where('active', '1')
+                ->get())
             ->filter(static fn (SysMenu $menu): bool => '' !== trim((string) $menu->menuid))
             ->unique(static fn (SysMenu $menu): string => (string) $menu->menuid)
             ->values()
@@ -136,22 +173,44 @@ class SimbaMetadataService
     }
 
     /**
-     * @return Collection<int, SysReportInfo>
+     * @return Collection<int, object>
      */
     protected function mergedReportInfo(): Collection
     {
         return SysReportInfo::query()
+            ->select(['menuid', 'ma_mau', 'spname', 'rptname'])
+            ->toBase()
             ->get()
-            ->merge(ZSysReportInfo::query()->get())
-            ->filter(static fn (SysReportInfo $report): bool => '' !== trim((string) $report->menuid))
+            ->merge(ZSysReportInfo::query()->select(['menuid', 'ma_mau', 'spname', 'rptname'])->toBase()->get())
+            ->filter(static fn (object $report): bool => '' !== trim((string) $report->menuid))
             ->values()
         ;
     }
 
     protected function assertKnownDataset(string $dataset): void
     {
-        if (!in_array($dataset, $this->datasets(), true)) {
+        if (!\in_array($dataset, $this->datasets(), true)) {
             throw new \InvalidArgumentException("Unknown Simba metadata dataset [{$dataset}].");
         }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function menuColumns(): array
+    {
+        return [
+            'menuid',
+            'stt',
+            'type',
+            'moduleid',
+            'bar',
+            'short_name',
+            'dllName',
+            'command',
+            'code_name',
+            'report',
+            'active',
+        ];
     }
 }

--- a/diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Tests\Unit\Http\Livewire;
+
+use PHPUnit\Framework\TestCase;
+
+final class SimbaErpMenusViewTest extends TestCase
+{
+    public function testMainSimbaMenuViewDoesNotRenderOnePartialPerNode(): void
+    {
+        $view = (string) file_get_contents(dirname(__DIR__, 4) . '/resources/views/system/simba-erp-menus.blade.php');
+
+        self::assertStringNotContainsString('catalog::system.simba-node', $view);
+        self::assertStringContainsString('@forelse ($tree as $item)', $view);
+        self::assertStringContainsString('x-show="isVisible', $view);
+    }
+}

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Tests\Unit\Services;
 
 use Diepxuan\Catalog\Services\SimbaMetadataService;
+use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 
 final class SimbaMetadataServiceTest extends TestCase
@@ -30,5 +31,51 @@ final class SimbaMetadataServiceTest extends TestCase
         $this->expectExceptionMessage('Unknown Simba metadata dataset [unknown].');
 
         $service->get('unknown');
+    }
+
+    public function testIndexByCachesRowsAndKeepsFirstDuplicateKey(): void
+    {
+        $service = new class extends SimbaMetadataService {
+            public int $loads = 0;
+
+            protected function load(string $dataset): Collection
+            {
+                ++$this->loads;
+
+                return collect([
+                    (object) ['menuid' => '90.10.02', 'code_name' => 'SIDMCT'],
+                    (object) ['menuid' => '90.10.02', 'code_name' => 'SIDMCT_DUP'],
+                    (object) ['menuid' => '  ', 'code_name' => 'EMPTY'],
+                ]);
+            }
+        };
+
+        $index = $service->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'menuid');
+        $again = $service->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'menuid');
+
+        self::assertSame(1, $service->loads);
+        self::assertSame($index, $again);
+        self::assertSame('SIDMCT', $index['90.10.02']->code_name);
+        self::assertArrayNotHasKey('', $index);
+    }
+
+    public function testForgetDatasetClearsRelatedIndexes(): void
+    {
+        $service = new class extends SimbaMetadataService {
+            public int $loads = 0;
+
+            protected function load(string $dataset): Collection
+            {
+                ++$this->loads;
+
+                return collect([(object) ['menuid' => '90.10.02']]);
+            }
+        };
+
+        $service->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'menuid');
+        $service->forget(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO);
+        $service->indexBy(SimbaMetadataService::DATASET_SYS_DICTIONARY_INFO, 'menuid');
+
+        self::assertSame(2, $service->loads);
     }
 }

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
@@ -78,4 +78,22 @@ final class SimbaMetadataServiceTest extends TestCase
 
         self::assertSame(2, $service->loads);
     }
+
+    public function testReportMetadataIndexPrefersSysReportInfoOverZSysReportInfoForSameMenuId(): void
+    {
+        $service = new class extends SimbaMetadataService {
+            protected function mergedReportInfo(): Collection
+            {
+                return collect([
+                    (object) ['menuid' => '02.10.02', 'ma_mau' => '01', 'spname' => 'asSysReport', 'rptname' => 'SYS.RPT'],
+                    (object) ['menuid' => '02.10.02', 'ma_mau' => '99', 'spname' => 'asZReport', 'rptname' => 'Z.RPT'],
+                ]);
+            }
+        };
+
+        $index = $service->indexBy(SimbaMetadataService::DATASET_SYS_REPORT_INFO, 'menuid');
+
+        self::assertSame('asSysReport', $index['02.10.02']->spname);
+        self::assertSame('SYS.RPT', $index['02.10.02']->rptname);
+    }
 }

--- a/docs/project/simba-menu-performance-plan.md
+++ b/docs/project/simba-menu-performance-plan.md
@@ -1,0 +1,74 @@
+# SimbaERP Menu Performance Plan
+
+Ngay cap nhat: 2026-06-30
+
+## Context
+
+Trang `/simba` render Livewire `catalog::system.simba-erp-menus`. Debugbar truoc do cho thay `catalog::system.simba-node` render lap lai khoang 361 lan, dong thoi metadata menu nap nhieu Eloquent model: `SysMenu`, `Zsysmenu`, `SysReportInfo`, `ZSysReportInfo`, `SysDictionaryInfo`.
+
+Muc tieu cua task nay la giam chi phi RAM/render truoc mat, va lap plan tiep theo cho huong lay toan bo metadata bang SP hoac mot query/join duy nhat.
+
+## Stored Procedure review
+
+Da kiem tra trong `Diepxuan\Simba\StoredProcedures` va `simba-docs`:
+
+| SP wrapper | Simba SP | Nguon docs | Nhan dinh |
+|---|---|---|---|
+| `AsGetMenuBar` | `asGetMenuBar` | `simba-docs/asia/si/SMUserInfo.md`, `SMUserInfoDAO.GetMenuBar()` | Lay menu bar theo language, phu hop menu UI Simba goc, chua du metadata Portal route/report/dictionary. |
+| `AsGetMenuDetail` | `asGetMenuDetail` | `SMUserInfoDAO.GetSubMenuBar()` | Lay submenu theo language, khong thay tham so module/menu trong wrapper hien tai; chua thay du field enrich route. |
+| `AsGetMenuForm` | `asGetMenuForm` | `SMUserInfoDAO.GetMenuForm()` | Lay danh sach form, khong phai source chinh cho cay menu + route metadata. |
+| `AsGetMenuInfo` | `asGetMenuInfo` | `Framework.CommonDAO.GetMenuInformation()` | Lay thong tin theo tung `pMenuId`, neu goi cho toan bo menu se thanh N query. |
+| `AsGetMenuDrillDownInfo` | `asGetMenuDrillDownInfo` | `Framework.CommonDAO.GetMenuDrillDownInformation()` | Lay drilldown theo tung `pMenuId`, khong phai batch toan bo menu. |
+| `AsGetMenuInfoAll` | `asGetMenuInfoAll` | wrapper co san trong `Diepxuan\Simba\StoredProcedures` | Ung vien can test runtime de xem field tra ve co gom du `sysMenu/zsysmenu/report/dictionary/drilldown` hay khong. Chua su dung trong code vi docs hien co chua mo ta schema result. |
+| `AsGetMenuIdByCommand` | `asGetMenuIdByCommand` | `PROCEDURES.md.backup` | Lookup nguoc tu command sang menuid, khong phai batch menu source. |
+| `asGetMenuList` | `asGetMenuList` | `simba-docs/tasks/002-si-simba-login-entrypoint.md` | SP theo quyen user `@pMa_Cty, @pMa_User`; chua co wrapper trong `Diepxuan\Simba\StoredProcedures`. La ung vien cho menu theo permission, khong thay bang chung du metadata route/report/dictionary. |
+
+Ket luan: SP co kha nang gan nhat de thu nghiem batch la `asGetMenuInfoAll`; `asGetMenuList` can wrapper neu Sếp can menu theo quyen user. Trong thay doi hien tai em chua thay source docs nao dam bao mot SP tra ve du toan bo metadata Portal can dung, nen khong thay the runtime bang SP de tranh sai contract.
+
+## Implemented phase
+
+- `SimbaMetadataService::indexBy($dataset, $field)` tao index theo field trong request, tranh `Collection::first()` lap lai tren dictionary/report/drilldown cho tung menu.
+- `SimbaMenuRouteMetadata` dung index theo `menuid`, `code_name`, `table_name` thay vi scan collection lap lai.
+- `SimbaMetadataService` chi nap menu `active = 1` va chi select cac cot menu dang dung tu `sysMenu/zsysmenu`: `menuid`, `stt`, `type`, `moduleid`, `bar`, `short_name`, `dllName`, `command`, `code_name`, `report`, `active`.
+- `sysDictionaryInfo`, `sysReportInfo`, `zSysReportInfo`, `sysReportDrillDownInfo` chuyen sang `toBase()` + select cot can dung, giam hydrate Eloquent model cho metadata enrich.
+- `SimbaErpMenus` cache `routeMapByMenuId()` trong component instance, tranh build lai route map cho tree/stats trong cung request.
+- `simba-erp-menus.blade.php` inline node markup trong loop route chinh, khong con include `catalog::system.simba-node` tren tung node; muc tieu la xoa view render lap lai x 361 tren trang `/simba`.
+
+## Plan tiep theo
+
+1. Test runtime `AsGetMenuInfoAll::call([])` tren portal de ghi lai schema result, so hang, memory/query count. Chi thay source menu bang SP neu result co du field va khop docs.
+2. Neu `asGetMenuInfoAll` khong du, thiet ke mot query read-only gom `sysMenu/zsysmenu` va left join metadata report/dictionary/drilldown bang field da co trong `simba-docs`. Khong tao SQL object moi, khong ALTER/CREATE.
+3. Tao DTO nhe cho menu tree thay vi giu Eloquent `SysMenu/Zsysmenu` model trong cache, nhung phai giu du helper behavior hien co (`getDisplayName`, parent id, type flags).
+4. Cache compiled menu payload theo company/user/language neu sau nay menu phu thuoc quyen user; can invalidation ro khi doi quyen/menu.
+5. Giam DOM/render tiep bang visible-node rendering hoac pagination theo module neu cay menu vuot nguong lon; hien tai da giam view partial count, chua giam so node DOM.
+
+## Verification
+
+Da chay:
+
+```bash
+php -l diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
+php -l diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+php -l diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
+php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
+php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+php artisan test diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php
+php artisan test diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
+```
+
+Ket qua hien tai: 21 tests pass, 200 assertions cho nhom test muc tieu va coverage route.
+
+Website verification tren `portal.diepxuan.corp`:
+
+```bash
+curl -L -sS --max-time 20 -o /tmp/portal-simba-menu.html -w '%{http_code} %{time_total} %{size_download}\n' http://portal.diepxuan.corp/simba
+```
+
+Ket qua ngay 2026-06-30:
+
+- `GET /simba`: `200`, HTML render duoc.
+- Debugbar request status: `200 OK`, route `simba.index`.
+- Debugbar views: `24`; `catalog::system.simba-node` x `0` trong HTML/debug output.
+- Debugbar peak memory: khoang `20.5MB` tren request GET da test lai sau active filter; gia tri co dao dong theo Debugbar/request nhung da thap hon muc ~40MB ban dau.
+- Debugbar model counter: `390` model, gom `SysMenu` 348 va `Zsysmenu` 37; khong con hydrate model `SysDictionaryInfo`, `ZSysReportInfo`, `SysReportDrillDownInfo` trong collector sau phase 1.
+- `HEAD /simba` tra `500` do moi truong local thieu Vite manifest (`public/build/manifest.json`) khi render layout; `GET /simba` van pass va khong co exception trong Debugbar.

--- a/docs/project/simba-menu-performance-plan.md
+++ b/docs/project/simba-menu-performance-plan.md
@@ -29,8 +29,9 @@ Ket luan: SP co kha nang gan nhat de thu nghiem batch la `asGetMenuInfoAll`; `as
 
 - `SimbaMetadataService::indexBy($dataset, $field)` tao index theo field trong request, tranh `Collection::first()` lap lai tren dictionary/report/drilldown cho tung menu.
 - `SimbaMenuRouteMetadata` dung index theo `menuid`, `code_name`, `table_name` thay vi scan collection lap lai.
-- `SimbaMetadataService` chi nap menu `active = 1` va chi select cac cot menu dang dung tu `sysMenu/zsysmenu`: `menuid`, `stt`, `type`, `moduleid`, `bar`, `short_name`, `dllName`, `command`, `code_name`, `report`, `active`.
+- `SimbaMetadataService` chi select cac cot menu dang dung tu `sysMenu/zsysmenu`: `menuid`, `stt`, `type`, `moduleid`, `bar`, `short_name`, `dllName`, `command`, `code_name`, `report`, `active`. Filter `active = 1` dang de lai comment theo quyet dinh hien tai, nen menu inactive van co the duoc nap vao metadata cache.
 - `sysDictionaryInfo`, `sysReportInfo`, `zSysReportInfo`, `sysReportDrillDownInfo` chuyen sang `toBase()` + select cot can dung, giam hydrate Eloquent model cho metadata enrich.
+- Khi `sysReportInfo` va `zSysReportInfo` cung `menuid`, metadata uu tien dong `sysReportInfo`; regression test da khoa behavior nay.
 - `SimbaErpMenus` cache `routeMapByMenuId()` trong component instance, tranh build lai route map cho tree/stats trong cung request.
 - `simba-erp-menus.blade.php` inline node markup trong loop route chinh, khong con include `catalog::system.simba-node` tren tung node; muc tieu la xoa view render lap lai x 361 tren trang `/simba`.
 
@@ -56,7 +57,7 @@ php artisan test diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenus
 php artisan test diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
 ```
 
-Ket qua hien tai: 21 tests pass, 200 assertions cho nhom test muc tieu va coverage route.
+Ket qua hien tai: 22 tests pass, 202 assertions cho nhom test muc tieu va coverage route.
 
 Website verification tren `portal.diepxuan.corp`:
 
@@ -69,6 +70,6 @@ Ket qua ngay 2026-06-30:
 - `GET /simba`: `200`, HTML render duoc.
 - Debugbar request status: `200 OK`, route `simba.index`.
 - Debugbar views: `24`; `catalog::system.simba-node` x `0` trong HTML/debug output.
-- Debugbar peak memory: khoang `20.5MB` tren request GET da test lai sau active filter; gia tri co dao dong theo Debugbar/request nhung da thap hon muc ~40MB ban dau.
-- Debugbar model counter: `390` model, gom `SysMenu` 348 va `Zsysmenu` 37; khong con hydrate model `SysDictionaryInfo`, `ZSysReportInfo`, `SysReportDrillDownInfo` trong collector sau phase 1.
+- Debugbar peak memory: khoang `16.5-18.5MB` tren cac request GET da test; gia tri co dao dong theo Debugbar/request nhung da thap hon muc ~40MB ban dau.
+- Debugbar model counter van con `SysMenu`/`Zsysmenu` do PR nay giu comment `active = 1` va menu tree van can model helper; khong con hydrate model `SysDictionaryInfo`, `ZSysReportInfo`, `SysReportDrillDownInfo` trong collector sau phase 1.
 - `HEAD /simba` tra `500` do moi truong local thieu Vite manifest (`public/build/manifest.json`) khi render layout; `GET /simba` van pass va khong co exception trong Debugbar.

--- a/docs/project/simba-router-menu-matrix.md
+++ b/docs/project/simba-router-menu-matrix.md
@@ -302,6 +302,13 @@ Ngay 2026-06-19, Simba menu route metadata duoc lay truc tiep tu Simba menu-back
 - Master-data menu co `sysReportInfo` nhung khong co dictionary metadata sach duoc mo qua `simba.report` nhu list/report shell read-only; dictionary exact/alias luon duoc uu tien truoc report/list. Menu F5 co `sysMenu.report = 1` cung duoc mo nhu report/list shell khi co `sysReportInfo`.
 - Process metadata trong `SimbaMenuRouteMetadata` bo sung read-only shell cho active menu co DLL/command/code_name nhung khong co metadata report/dictionary/voucher du chuan. Process shell mo qua `proc`, chi hien anchor ky thuat va chan execute.
 
+Performance update ngay 2026-06-30:
+
+- `SimbaMetadataService` tao request-level index cho metadata enrich, tranh scan `sysDictionaryInfo`/`sysReportInfo`/`sysReportDrillDownInfo` lap lai theo tung menu.
+- `sysMenu/zsysmenu` chi nap menu active va select cac cot menu route/tree dang dung; dictionary/report/drilldown enrich chuyen sang base query + selected columns de tranh hydrate Eloquent model khong can thiet.
+- `System\SimbaErpMenus` cache route map trong component instance va view route chinh `/simba` khong con include `catalog::system.simba-node` theo tung node, giam view render lap lai trong Debugbar.
+- SP review cho menu nam trong `docs/project/simba-menu-performance-plan.md`; `asGetMenuInfoAll` la ung vien batch can test schema runtime truoc khi thay source menu bang SP.
+
 Kiem chung:
 
 - `php -l` pass cho cac file registry/component moi sua.

--- a/docs/project/simba-router-menu-matrix.md
+++ b/docs/project/simba-router-menu-matrix.md
@@ -305,7 +305,7 @@ Ngay 2026-06-19, Simba menu route metadata duoc lay truc tiep tu Simba menu-back
 Performance update ngay 2026-06-30:
 
 - `SimbaMetadataService` tao request-level index cho metadata enrich, tranh scan `sysDictionaryInfo`/`sysReportInfo`/`sysReportDrillDownInfo` lap lai theo tung menu.
-- `sysMenu/zsysmenu` chi nap menu active va select cac cot menu route/tree dang dung; dictionary/report/drilldown enrich chuyen sang base query + selected columns de tranh hydrate Eloquent model khong can thiet.
+- `sysMenu/zsysmenu` chi select cac cot menu route/tree dang dung; dictionary/report/drilldown enrich chuyen sang base query + selected columns de tranh hydrate Eloquent model khong can thiet. Filter `active = 1` dang duoc giu comment theo quyet dinh hien tai.
 - `System\SimbaErpMenus` cache route map trong component instance va view route chinh `/simba` khong con include `catalog::system.simba-node` theo tung node, giam view render lap lai trong Debugbar.
 - SP review cho menu nam trong `docs/project/simba-menu-performance-plan.md`; `asGetMenuInfoAll` la ung vien batch can test schema runtime truoc khi thay source menu bang SP.
 

--- a/docs/project/task-execution-coverage.md
+++ b/docs/project/task-execution-coverage.md
@@ -62,7 +62,7 @@ Man hinh `hethong/menu` hien cay menu Simba tu `simba-docs`, gan link Portal cho
 Ngay 2026-06-30, trang `/simba` da duoc toi uu phase 1:
 
 - Metadata enrich dung request-level index thay cho scan collection lap lai theo tung menu.
-- `sysMenu/zsysmenu` chi nap menu active va select cot dang dung; dictionary/report/drilldown chuyen sang base query + selected columns de giam Eloquent model hydration.
+- `sysMenu/zsysmenu` chi select cot dang dung; filter `active = 1` dang duoc giu comment theo quyet dinh hien tai. Dictionary/report/drilldown chuyen sang base query + selected columns de giam Eloquent model hydration.
 - Route map trong `System\SimbaErpMenus` duoc cache trong component instance.
 - View `catalog::system.simba-erp-menus` khong con include `catalog::system.simba-node` theo tung node, tranh view render lap lai hang tram lan trong Debugbar.
 - SP review va plan tiep theo nam tai `docs/project/simba-menu-performance-plan.md`.
@@ -169,4 +169,4 @@ php artisan test diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenus
 php artisan test diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
 ```
 
-Ket qua moi nhat cho nhom menu performance/route metadata: 21 tests pass, 200 assertions.
+Ket qua moi nhat cho nhom menu performance/route metadata: 22 tests pass, 202 assertions.

--- a/docs/project/task-execution-coverage.md
+++ b/docs/project/task-execution-coverage.md
@@ -59,6 +59,14 @@ F5/drilldown report routes lay tu `sysReportDrillDownInfo.md` duoc phan loai la 
 
 Man hinh `hethong/menu` hien cay menu Simba tu `simba-docs`, gan link Portal cho cac menu da map va hien badge theo source type (`Report`, `Danh muc`, `Chung tu`, `Portal`). Search trong cay menu co the tim theo menuid, ten, DLL hoac route name.
 
+Ngay 2026-06-30, trang `/simba` da duoc toi uu phase 1:
+
+- Metadata enrich dung request-level index thay cho scan collection lap lai theo tung menu.
+- `sysMenu/zsysmenu` chi nap menu active va select cot dang dung; dictionary/report/drilldown chuyen sang base query + selected columns de giam Eloquent model hydration.
+- Route map trong `System\SimbaErpMenus` duoc cache trong component instance.
+- View `catalog::system.simba-erp-menus` khong con include `catalog::system.simba-node` theo tung node, tranh view render lap lai hang tram lan trong Debugbar.
+- SP review va plan tiep theo nam tai `docs/project/simba-menu-performance-plan.md`.
+
 Master-data menu co `sysReportInfo` nhung khong co dictionary metadata sach cung duoc mo bang report/list shell read-only; neu co dictionary exact/alias thi dictionary duoc uu tien. Menu F5 co `sysMenu.report = 1` cung duoc mo nhu report/list shell khi co `sysReportInfo`.
 
 Mot so menu danh muc co `sysMenu.code_name` khop dictionary that nhung `sysDictionaryInfo.menuid` bi trong/lẹch. Cac menu nay duoc mo qua `simba.dictionary` voi `source_menuid` de khong che dau lech source:
@@ -149,11 +157,16 @@ Voucher metadata mismatches dang duoc chan:
 Regression tests khoa coverage:
 
 - `SimbaMenuRouteMetadataTest`
+- `SimbaMetadataServiceTest`
+- `SimbaErpMenusViewTest`
 
 Da chay:
 
 ```bash
-./vendor/bin/phpunit diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
+php artisan test diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php
+php artisan test diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
 ```
 
-Ket qua sau khi xoa registry wrapper: 5 tests, 10 assertions.
+Ket qua moi nhat cho nhom menu performance/route metadata: 21 tests pass, 200 assertions.


### PR DESCRIPTION
## Summary

Phase 1 perf refactor cho `/simba` menu page:

- `SimbaMetadataService` thêm `indexBy(dataset, field)` + cache + cascade `forget()` invalidation.
- `SimbaMenuRouteMetadata` đổi N+1 `->first(...)` sang O(1) `indexBy()` lookup ở `dictionaryRow`/`reportRow`/`reportMetadata`.
- `sysMenu`/`zsysmenu` chỉ select các cột menu tree/route đang dùng; `active = 1` hiện được giữ comment theo quyết định review, nên PR này chưa loại menu inactive khỏi metadata cache.
- `sysDictionaryInfo`, `sysReportInfo`, `zSysReportInfo`, `sysReportDrillDownInfo` chuyển sang selected columns + base rows để giảm Eloquent hydration.
- Khi `sysReportInfo` và `zSysReportInfo` cùng `menuid`, metadata ưu tiên dòng `sysReportInfo`; đã thêm regression test khóa behavior này.
- `SimbaErpMenus::routeMapByMenuId()` memoize map trong component instance.
- View `simba-erp-menus` inline toàn bộ node, bỏ `@include('catalog::system.simba-node', ...)` per-node để giảm view renders.
- Docs: `simba-router-menu-matrix.md` + `task-execution-coverage.md` + `simba-menu-performance-plan.md`.

## Root cause

Khi mở `/simba`, mỗi menu node resolve qua `SimbaMenuRouteMetadata::dictionaryRow/reportRow/reportMetadata` đều gọi `app(SimbaMetadataService::class)->get(...)->first(...)` lặp lại, tạo O(N) collection scans cho N menu. View cũ `@include('catalog::system.simba-node', ...)` per-node cũng đội số view render lên hàng trăm lần trong Debugbar.

## Decisions

- Giữ comment `// ->where('active', '1')` trong PR này theo review của Sếp; docs/verification đã sửa để không claim active filter.
- `sysReportInfo` override `zSysReportInfo` khi cùng `menuid`; test mới: `testReportMetadataIndexPrefersSysReportInfoOverZSysReportInfoForSameMenuId`.

## Test plan

```bash
php -l diepxuan/laravel-catalog/src/Http/Livewire/System/SimbaErpMenus.php
php -l diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
php -l diepxuan/laravel-catalog/src/Services/SimbaMetadataService.php
php -l diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
php -l diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php
php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php
php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
php artisan test diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php
php artisan test diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
```

Kết quả local mới nhất: 22 tests pass, 202 assertions.

## Verification

`GET /simba` trên `portal.diepxuan.corp` render HTML 200 trong lần kiểm tra trước:

- Debugbar views: `24`.
- `catalog::system.simba-node`: `0` trong HTML/debug output.
- Không còn hydrate model `SysDictionaryInfo`, `ZSysReportInfo`, `SysReportDrillDownInfo` trong collector sau phase 1.
- `SysMenu`/`Zsysmenu` vẫn còn trong model counter vì filter `active = 1` đang để comment và menu tree vẫn dùng model helper.

## Follow-up

- Phase 2: test schema/runtime của `AsGetMenuInfoAll::call([])` trước khi dùng SP thay source menu.
- Phase 3: đánh giá lại `where('active', '1')` sau khi xác nhận data source/coverage, rồi đo lại model counter và memory.
- Phase 4: nếu cần giảm DOM tiếp, chuyển sang visible-node rendering hoặc pagination theo module.

## Reference

- Plan: `docs/project/simba-menu-performance-plan.md`
- Coverage: `docs/project/task-execution-coverage.md`
- Router matrix: `docs/project/simba-router-menu-matrix.md`

## Note

PR scope: chỉ trong `diepxuan/...` + `docs/...`, không đụng restricted files (`routes/web.php` core, `app/Http/Controllers/`, `app/Models/`, `config/*.php`).