### PR TITLE
feat(livewire): input components switch from Eloquent to SP wrappers

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -14,3 +14,41 @@ File này ghi chú các chi tiết riêng của môi trường Portal. Skill và
 - **Mục đích:** Toàn bộ tài liệu SimbaSql .NET, là nguồn sự thật domain.
 - **Trạng thái:** Readonly.
 - **Chi tiết:** `docs/SIMBA-DOCS.md`
+
+## Sandbox & Escalation
+
+Mặc định agent chỉ được đọc/ghi trong workspace Portal và các thư mục được môi trường cho phép. Mọi hành động cần quyền ngoài sandbox phải xin phép Sếp trước khi chạy.
+
+### Khi nào phải xin phép Sếp
+
+- Lệnh cần truy cập network: `git fetch`, `git pull`, `git push`, `gh pr ...`, `composer install/update`, `npm install`, download package, gọi API bên ngoài.
+- Lệnh ghi ra ngoài workspace hoặc thư mục tạm được phép.
+- Lệnh mở GUI/browser/app ngoài terminal.
+- Lệnh có khả năng phá dữ liệu hoặc thay đổi lịch sử: `rm`, `git reset`, `git checkout --`, `git clean`, force push, migration/write DB ngoài phạm vi task.
+- Bất kỳ lệnh nào fail do sandbox/network/permission nhưng vẫn cần chạy để hoàn thành task.
+
+### Cách xin phép
+
+- Không tự ý tìm cách né sandbox.
+- Nói rõ lệnh cần chạy, lý do, phạm vi tác động, và rủi ro nếu có.
+- Chờ Sếp chấp thuận qua cơ chế approval của tool hoặc trả lời trực tiếp trước khi chạy.
+- Dùng cơ chế approval/escalation do runtime hiện tại cung cấp.
+- Với Codex: đặt `sandbox_permissions` = `require_escalated` và viết `justification` thành câu hỏi ngắn cho Sếp.
+- Với agent/tool khác: dùng cơ chế tương đương nếu có; nếu không có, dừng và hỏi Sếp trực tiếp, không tự chạy ngoài sandbox.
+
+Ví dụ justification tốt:
+
+```text
+Sếp cho phép em chạy `git fetch origin` ngoài sandbox để lấy trạng thái PR mới nhất không?
+```
+
+```text
+Sếp cho phép em chạy `composer install` ngoài sandbox để tải dependency còn thiếu cho test không?
+```
+
+### Nguyên tắc sau khi được phép
+
+- Chỉ chạy đúng lệnh/phạm vi đã xin phép.
+- Không dùng approval cho hành động khác rộng hơn.
+- Báo lại kết quả quan trọng: lệnh đã chạy, pass/fail, file hoặc trạng thái bị ảnh hưởng.
+- Không push, tạo PR, merge hoặc thay đổi remote nếu Sếp chưa nói rõ: "Em tạo PR đi" hoặc cho phép tương đương.

--- a/diepxuan/laravel-catalog/resources/views/components/input-indmkho.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-indmkho.blade.php
@@ -1,13 +1,178 @@
 @props(['disabled' => false])
 
-<div class="relative">
-    <input {{ $disabled ? 'disabled' : '' }} type="text"
-        class="block w-full rounded-md border-gray-300 py-1 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-        list="InDmKho-suggestions" wire:model="pMa_kho" />
+<div class="relative" x-data="khoInputComponent(@js($inDmKhos), @js($pMa_kho))" x-init="initComponent()"
+    @click.outside="showDropdown = false" @keydown.escape.window="showDropdown = false">
+    <div class="relative">
+        <input {{ $disabled ? 'disabled' : '' }} type="text" x-model="search" @focus="openDropdown()"
+            @click="openDropdown()" @change="commitSearch()" @keydown="handleKeydown($event)"
+            class="block w-full rounded-md border-gray-300 py-1 pr-8 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list" />
 
-    <datalist id="InDmKho-suggestions">
-        @foreach ($inDmKhos as $inDmKho)
-            <option value="{{ $inDmKho->ma_kho }}">{{ $inDmKho->ten_kho }}</option>
-        @endforeach
-    </datalist>
+        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+            <svg class="h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+        </div>
+    </div>
+
+    <div x-show="showDropdown && filtered.length > 0" x-transition:enter="transition ease-out duration-100"
+        x-transition:enter-start="transform opacity-0 scale-95" x-transition:enter-end="transform opacity-100 scale-100"
+        x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 scale-100"
+        x-transition:leave-end="transform opacity-0 scale-95"
+        class="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow-lg"
+        style="display: none;" role="listbox" aria-label="Danh sách kho">
+        <ul class="py-1">
+            <template x-for="(item, index) in filtered" :key="item.ma_kho">
+                <li @mousedown.prevent="selectItem(item)" @click.prevent @mouseenter="highlightedIndex = index"
+                    :class="{'bg-indigo-50': highlightedIndex === index, 'hover:bg-gray-50': highlightedIndex !== index}"
+                    class="cursor-pointer px-4 py-2.5 text-sm" role="option"
+                    :aria-selected="highlightedIndex === index" :id="optionId(index)">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex shrink-0 items-center rounded-md bg-indigo-50 px-2 py-0.5 font-mono text-xs font-medium text-indigo-700"
+                            x-text="item.ma_kho"></span>
+                        <span class="truncate text-gray-700" x-text="item.ten_kho"></span>
+                    </div>
+                </li>
+            </template>
+        </ul>
+    </div>
+
+    <div x-show="showDropdown && filtered.length === 0 && search.trim().length > 0"
+        class="absolute z-50 mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-center text-xs text-gray-500 shadow-lg"
+        style="display: none;">
+        Không tìm thấy kho
+    </div>
 </div>
+
+@push('scripts')
+    <script>
+        (function() {
+            if (typeof window.khoInputComponent !== 'undefined') {
+                return;
+            }
+
+            window.khoInputComponent = function(items, initialSearch = '') {
+                return {
+                    items: items || [],
+                    search: initialSearch || '',
+                    showDropdown: false,
+                    filtered: [],
+                    highlightedIndex: -1,
+                    filterTimer: null,
+                    optionPrefix: 'kho-option-' + Math.random().toString(36).slice(2),
+
+                    initComponent() {
+                        this.items = this.items.map((item) => ({
+                            ...item,
+                            _search: this.normalizeText([item.ma_kho, item.ten_kho].join(' ')),
+                        }));
+
+                        this.filtered = this.filterItems(this.search);
+
+                        this.$watch('search', (value) => {
+                            clearTimeout(this.filterTimer);
+                            this.filterTimer = setTimeout(() => {
+                                this.filtered = this.filterItems(value);
+                                this.highlightedIndex = -1;
+                            }, 150);
+                        });
+                    },
+
+                    normalizeText(value) {
+                        return String(value || '')
+                            .normalize('NFD')
+                            .replace(/[\u0300-\u036f]/g, '')
+                            .replace(/[đĐ]/g, 'd')
+                            .toLowerCase()
+                            .trim()
+                            .replace(/\s+/g, ' ');
+                    },
+
+                    optionId(index) {
+                        return this.optionPrefix + '-' + index;
+                    },
+
+                    openDropdown() {
+                        this.filtered = this.filterItems(this.search);
+                        this.showDropdown = true;
+                    },
+
+                    commitSearch() {
+                        const exact = this.items.find((item) => String(item.ma_kho).toLowerCase() === this.search.toLowerCase());
+                        if (exact) {
+                            this.selectItem(exact);
+                            return;
+                        }
+
+                        const top = this.filterItems(this.search)[0];
+                        if (top) {
+                            this.selectItem(top);
+                            return;
+                        }
+
+                        this.$wire.set('pMa_kho', this.search || null);
+                    },
+
+                    selectItem(item) {
+                        this.search = item.ma_kho;
+                        this.showDropdown = false;
+                        this.$wire.set('pMa_kho', item.ma_kho);
+                    },
+
+                    handleKeydown(event) {
+                        if (!this.showDropdown) {
+                            if (['ArrowDown', 'ArrowUp'].includes(event.key)) {
+                                event.preventDefault();
+                                this.openDropdown();
+                                this.highlightedIndex = 0;
+                            }
+                            return;
+                        }
+
+                        switch (event.key) {
+                            case 'ArrowDown':
+                                event.preventDefault();
+                                this.highlightedIndex = Math.min(this.highlightedIndex + 1, this.filtered.length - 1);
+                                this.scrollToHighlighted();
+                                break;
+                            case 'ArrowUp':
+                                event.preventDefault();
+                                this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+                                this.scrollToHighlighted();
+                                break;
+                            case 'Enter':
+                                event.preventDefault();
+                                if (this.highlightedIndex >= 0 && this.filtered[this.highlightedIndex]) {
+                                    this.selectItem(this.filtered[this.highlightedIndex]);
+                                } else {
+                                    this.commitSearch();
+                                    this.showDropdown = false;
+                                }
+                                break;
+                        }
+                    },
+
+                    scrollToHighlighted() {
+                        this.$nextTick(() => {
+                            const el = document.getElementById(this.optionId(this.highlightedIndex));
+                            if (el) {
+                                el.scrollIntoView({ block: 'nearest' });
+                            }
+                        });
+                    },
+
+                    filterItems(query) {
+                        const q = this.normalizeText(query);
+                        if (!q) {
+                            return this.items.slice(0, 20);
+                        }
+
+                        return this.items.filter((item) => item._search.includes(q)).slice(0, 20);
+                    }
+                };
+            };
+        })();
+    </script>
+@endpush

--- a/diepxuan/laravel-catalog/resources/views/components/input-indmvt.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-indmvt.blade.php
@@ -1,13 +1,178 @@
 @props(['disabled' => false])
 
-<div class="relative">
-    <input {{ $disabled ? 'disabled' : '' }} type="text"
-        class="block w-full rounded-md border-gray-300 py-1 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-        list="InDmVt-suggestions" wire:model="pMa_vt" />
+<div class="relative" x-data="vtInputComponent(@js($inDmVts), @js($pMa_vt))" x-init="initComponent()"
+    @click.outside="showDropdown = false" @keydown.escape.window="showDropdown = false">
+    <div class="relative">
+        <input {{ $disabled ? 'disabled' : '' }} type="text" x-model="search" @focus="openDropdown()"
+            @click="openDropdown()" @change="commitSearch()" @keydown="handleKeydown($event)"
+            class="block w-full rounded-md border-gray-300 py-1 pr-8 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+            role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list" />
 
-    <datalist id="InDmVt-suggestions">
-        @foreach ($inDmVts as $inDmVt)
-            <option value="{{ $inDmVt->ma_vt }}">{{ $inDmVt->ten_vt }}</option>
-        @endforeach
-    </datalist>
+        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+            <svg class="h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+        </div>
+    </div>
+
+    <div x-show="showDropdown && filtered.length > 0" x-transition:enter="transition ease-out duration-100"
+        x-transition:enter-start="transform opacity-0 scale-95" x-transition:enter-end="transform opacity-100 scale-100"
+        x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 scale-100"
+        x-transition:leave-end="transform opacity-0 scale-95"
+        class="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow-lg"
+        style="display: none;" role="listbox" aria-label="Danh sách vật tư">
+        <ul class="py-1">
+            <template x-for="(item, index) in filtered" :key="item.ma_vt">
+                <li @mousedown.prevent="selectItem(item)" @click.prevent @mouseenter="highlightedIndex = index"
+                    :class="{'bg-indigo-50': highlightedIndex === index, 'hover:bg-gray-50': highlightedIndex !== index}"
+                    class="cursor-pointer px-4 py-2.5 text-sm" role="option"
+                    :aria-selected="highlightedIndex === index" :id="optionId(index)">
+                    <div class="flex items-center gap-3">
+                        <span class="inline-flex shrink-0 items-center rounded-md bg-indigo-50 px-2 py-0.5 font-mono text-xs font-medium text-indigo-700"
+                            x-text="item.ma_vt"></span>
+                        <span class="truncate text-gray-700" x-text="item.ten_vt"></span>
+                    </div>
+                </li>
+            </template>
+        </ul>
+    </div>
+
+    <div x-show="showDropdown && filtered.length === 0 && search.trim().length > 0"
+        class="absolute z-50 mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-center text-xs text-gray-500 shadow-lg"
+        style="display: none;">
+        Không tìm thấy vật tư
+    </div>
 </div>
+
+@push('scripts')
+    <script>
+        (function() {
+            if (typeof window.vtInputComponent !== 'undefined') {
+                return;
+            }
+
+            window.vtInputComponent = function(items, initialSearch = '') {
+                return {
+                    items: items || [],
+                    search: initialSearch || '',
+                    showDropdown: false,
+                    filtered: [],
+                    highlightedIndex: -1,
+                    filterTimer: null,
+                    optionPrefix: 'vt-option-' + Math.random().toString(36).slice(2),
+
+                    initComponent() {
+                        this.items = this.items.map((item) => ({
+                            ...item,
+                            _search: this.normalizeText([item.ma_vt, item.ten_vt].join(' ')),
+                        }));
+
+                        this.filtered = this.filterItems(this.search);
+
+                        this.$watch('search', (value) => {
+                            clearTimeout(this.filterTimer);
+                            this.filterTimer = setTimeout(() => {
+                                this.filtered = this.filterItems(value);
+                                this.highlightedIndex = -1;
+                            }, 150);
+                        });
+                    },
+
+                    normalizeText(value) {
+                        return String(value || '')
+                            .normalize('NFD')
+                            .replace(/[\u0300-\u036f]/g, '')
+                            .replace(/[đĐ]/g, 'd')
+                            .toLowerCase()
+                            .trim()
+                            .replace(/\s+/g, ' ');
+                    },
+
+                    optionId(index) {
+                        return this.optionPrefix + '-' + index;
+                    },
+
+                    openDropdown() {
+                        this.filtered = this.filterItems(this.search);
+                        this.showDropdown = true;
+                    },
+
+                    commitSearch() {
+                        const exact = this.items.find((item) => String(item.ma_vt).toLowerCase() === this.search.toLowerCase());
+                        if (exact) {
+                            this.selectItem(exact);
+                            return;
+                        }
+
+                        const top = this.filterItems(this.search)[0];
+                        if (top) {
+                            this.selectItem(top);
+                            return;
+                        }
+
+                        this.$wire.set('pMa_vt', this.search || null);
+                    },
+
+                    selectItem(item) {
+                        this.search = item.ma_vt;
+                        this.showDropdown = false;
+                        this.$wire.set('pMa_vt', item.ma_vt);
+                    },
+
+                    handleKeydown(event) {
+                        if (!this.showDropdown) {
+                            if (['ArrowDown', 'ArrowUp'].includes(event.key)) {
+                                event.preventDefault();
+                                this.openDropdown();
+                                this.highlightedIndex = 0;
+                            }
+                            return;
+                        }
+
+                        switch (event.key) {
+                            case 'ArrowDown':
+                                event.preventDefault();
+                                this.highlightedIndex = Math.min(this.highlightedIndex + 1, this.filtered.length - 1);
+                                this.scrollToHighlighted();
+                                break;
+                            case 'ArrowUp':
+                                event.preventDefault();
+                                this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+                                this.scrollToHighlighted();
+                                break;
+                            case 'Enter':
+                                event.preventDefault();
+                                if (this.highlightedIndex >= 0 && this.filtered[this.highlightedIndex]) {
+                                    this.selectItem(this.filtered[this.highlightedIndex]);
+                                } else {
+                                    this.commitSearch();
+                                    this.showDropdown = false;
+                                }
+                                break;
+                        }
+                    },
+
+                    scrollToHighlighted() {
+                        this.$nextTick(() => {
+                            const el = document.getElementById(this.optionId(this.highlightedIndex));
+                            if (el) {
+                                el.scrollIntoView({ block: 'nearest' });
+                            }
+                        });
+                    },
+
+                    filterItems(query) {
+                        const q = this.normalizeText(query);
+                        if (!q) {
+                            return this.items.slice(0, 20);
+                        }
+
+                        return this.items.filter((item) => item._search.includes(q)).slice(0, 20);
+                    }
+                };
+            };
+        })();
+    </script>
+@endpush

--- a/diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php
@@ -1,73 +1,200 @@
-<div class="relative w-full" x-data="{
-    showDropdown: @entangle('showDropdown'),
-    searching: @entangle('searching')
-}" @click.outside="showDropdown = false">
-    {{-- Input field --}}
+<div class="relative w-full" x-data="khInputComponent(@js($customers), @js($value), @js($search))" x-init="initComponent()"
+    @click.outside="showDropdown = false" @keydown.escape.window="showDropdown = false">
     <div class="relative">
-        <input
-            type="text"
-            wire:model.live.debounce.500ms="search"
-            @focus="showDropdown = true"
-            @blur="setTimeout(() => showDropdown = false, 200)"
-            placeholder="{{ $placeholder }}"
-            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-xs text-gray-700 shadow-sm transition-all placeholder:text-gray-400 hover:border-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-        />
+        <input type="text" x-model="search" @focus="openDropdown()" @click="openDropdown()"
+            @change="commitSearch()" @keydown="handleKeydown($event)" placeholder="{{ $placeholder }}"
+            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-14 text-xs text-gray-700 shadow-sm transition-all placeholder:text-gray-400 hover:border-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list" />
 
-        {{-- Search & loading icons --}}
-        <div class="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1" wire:loading.remove wire:target="updatedSearch">
-            @if($value)
-                <button
-                    type="button"
-                    @click="$wire.clear()"
-                    class="rounded-full p-0.5 text-gray-400 hover:text-gray-600"
-                >
-                    <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                    </svg>
-                </button>
-            @endif
+        <div class="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1">
+            <button type="button" x-show="selectedValue" @click="clear()"
+                class="rounded-full p-0.5 text-gray-400 hover:text-gray-600" style="display: none;">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
             <svg class="h-3.5 w-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-            </svg>
-        </div>
-
-        {{-- Loading spinner --}}
-        <div wire:loading wire:target="updatedSearch" class="absolute right-2 top-1/2 -translate-y-1/2">
-            <svg class="h-3.5 w-3.5 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
         </div>
     </div>
 
-    {{-- Dropdown results --}}
-    @if($showDropdown && count($results) > 0)
-        <div class="absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-gray-300 bg-white shadow-lg">
-            <ul class="max-h-64 overflow-y-auto">
-                @foreach($results as $kh)
-                    <li
-                        wire:click="selectCustomer('{{ $kh['ma_kh'] }}', '{{ addslashes($kh['ten_kh']) }}')"
-                        class="cursor-pointer border-b border-gray-100 px-3 py-2 transition-colors last:border-b-0 hover:bg-blue-50"
-                    >
-                        <div class="flex items-center justify-between">
-                            <div class="flex-1">
-                                <p class="font-medium text-gray-800">{{ $kh['ten_kh'] }}</p>
-                                <p class="text-xs text-gray-500">{{ $kh['dia_chi'] }} {{ $kh['tel'] ? '• ' . $kh['tel'] : '' }}</p>
-                            </div>
-                            <span class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
-                                {{ $kh['ma_kh'] }}
-                            </span>
+    <div x-show="showDropdown && filtered.length > 0" x-transition:enter="transition ease-out duration-100"
+        x-transition:enter-start="transform opacity-0 scale-95" x-transition:enter-end="transform opacity-100 scale-100"
+        x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 scale-100"
+        x-transition:leave-end="transform opacity-0 scale-95"
+        class="absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-gray-300 bg-white shadow-lg"
+        style="display: none;" role="listbox" aria-label="Danh sách đối tượng">
+        <ul class="max-h-64 overflow-y-auto">
+            <template x-for="(kh, index) in filtered" :key="kh.ma_kh">
+                <li @mousedown.prevent="selectCustomer(kh)" @click.prevent @mouseenter="highlightedIndex = index"
+                    :class="{'bg-blue-50': highlightedIndex === index, 'hover:bg-blue-50': highlightedIndex !== index}"
+                    class="cursor-pointer border-b border-gray-100 px-3 py-2 transition-colors last:border-b-0"
+                    role="option" :aria-selected="highlightedIndex === index" :id="optionId(index)">
+                    <div class="flex items-center justify-between gap-3">
+                        <div class="min-w-0 flex-1">
+                            <p class="truncate font-medium text-gray-800" x-text="kh.ten_kh"></p>
+                            <p class="truncate text-xs text-gray-500">
+                                <span x-text="kh.dia_chi"></span>
+                                <template x-if="kh.tel">
+                                    <span x-text="(kh.dia_chi ? ' • ' : '') + kh.tel"></span>
+                                </template>
+                            </p>
                         </div>
-                    </li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+                        <span class="shrink-0 rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600"
+                            x-text="kh.ma_kh"></span>
+                    </div>
+                </li>
+            </template>
+        </ul>
+    </div>
 
-    {{-- No results --}}
-    @if($showDropdown && !$searching && count($results) === 0 && strlen(trim($search)) > 0)
-        <div class="absolute z-50 mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-center text-xs text-gray-500 shadow-lg">
-            Không tìm thấy
-        </div>
-    @endif
+    <div x-show="showDropdown && filtered.length === 0 && search.trim().length > 0"
+        class="absolute z-50 mt-1 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-center text-xs text-gray-500 shadow-lg"
+        style="display: none;">
+        Không tìm thấy
+    </div>
 </div>
+
+@push('scripts')
+    <script>
+        (function() {
+            if (typeof window.khInputComponent !== 'undefined') {
+                return;
+            }
+
+            window.khInputComponent = function(customers, initialValue = null, initialSearch = '') {
+                return {
+                    customers: customers || [],
+                    selectedValue: initialValue || null,
+                    search: initialSearch || '',
+                    showDropdown: false,
+                    filtered: [],
+                    highlightedIndex: -1,
+                    filterTimer: null,
+                    optionPrefix: 'kh-option-' + Math.random().toString(36).slice(2),
+
+                    initComponent() {
+                        this.customers = this.customers.map((kh) => ({
+                            ...kh,
+                            _search: this.normalizeText([kh.ma_kh, kh.ten_kh, kh.dia_chi, kh.tel].join(' ')),
+                        }));
+
+                        this.filtered = this.filterCustomers(this.search);
+
+                        this.$watch('search', (value) => {
+                            clearTimeout(this.filterTimer);
+                            this.filterTimer = setTimeout(() => {
+                                this.filtered = this.filterCustomers(value);
+                                this.highlightedIndex = -1;
+                            }, 150);
+                        });
+                    },
+
+                    normalizeText(value) {
+                        return String(value || '')
+                            .normalize('NFD')
+                            .replace(/[\u0300-\u036f]/g, '')
+                            .replace(/[đĐ]/g, 'd')
+                            .toLowerCase()
+                            .trim()
+                            .replace(/\s+/g, ' ');
+                    },
+
+                    optionId(index) {
+                        return this.optionPrefix + '-' + index;
+                    },
+
+                    openDropdown() {
+                        this.filtered = this.filterCustomers(this.search);
+                        this.showDropdown = true;
+                    },
+
+                    commitSearch() {
+                        const exact = this.customers.find((kh) => String(kh.ma_kh).toLowerCase() === this.search.toLowerCase());
+                        if (exact) {
+                            this.selectCustomer(exact);
+                            return;
+                        }
+
+                        const top = this.filterCustomers(this.search)[0];
+                        if (top) {
+                            this.selectCustomer(top);
+                            return;
+                        }
+
+                        this.selectedValue = null;
+                        this.$wire.set('value', null);
+                    },
+
+                    clear() {
+                        this.selectedValue = null;
+                        this.search = '';
+                        this.filtered = [];
+                        this.showDropdown = false;
+                        this.$wire.set('value', null);
+                    },
+
+                    selectCustomer(kh) {
+                        this.selectedValue = kh.ma_kh;
+                        this.search = kh.ten_kh || kh.ma_kh;
+                        this.showDropdown = false;
+                        this.$wire.set('value', kh.ma_kh);
+                    },
+
+                    handleKeydown(event) {
+                        if (!this.showDropdown) {
+                            if (['ArrowDown', 'ArrowUp'].includes(event.key)) {
+                                event.preventDefault();
+                                this.openDropdown();
+                                this.highlightedIndex = 0;
+                            }
+                            return;
+                        }
+
+                        switch (event.key) {
+                            case 'ArrowDown':
+                                event.preventDefault();
+                                this.highlightedIndex = Math.min(this.highlightedIndex + 1, this.filtered.length - 1);
+                                this.scrollToHighlighted();
+                                break;
+                            case 'ArrowUp':
+                                event.preventDefault();
+                                this.highlightedIndex = Math.max(this.highlightedIndex - 1, 0);
+                                this.scrollToHighlighted();
+                                break;
+                            case 'Enter':
+                                event.preventDefault();
+                                if (this.highlightedIndex >= 0 && this.filtered[this.highlightedIndex]) {
+                                    this.selectCustomer(this.filtered[this.highlightedIndex]);
+                                } else {
+                                    this.commitSearch();
+                                    this.showDropdown = false;
+                                }
+                                break;
+                        }
+                    },
+
+                    scrollToHighlighted() {
+                        this.$nextTick(() => {
+                            const el = document.getElementById(this.optionId(this.highlightedIndex));
+                            if (el) {
+                                el.scrollIntoView({ block: 'nearest' });
+                            }
+                        });
+                    },
+
+                    filterCustomers(query) {
+                        const q = this.normalizeText(query);
+                        if (!q) {
+                            return this.customers.slice(0, 20);
+                        }
+
+                        return this.customers.filter((kh) => kh._search.includes(q)).slice(0, 20);
+                    }
+                };
+            };
+        })();
+    </script>
+@endpush

--- a/diepxuan/laravel-catalog/resources/views/components/input-taikhoan.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-taikhoan.blade.php
@@ -20,8 +20,8 @@
     <!-- Input field -->
     <div class="relative">
         <input {{ $disabled ? 'disabled' : '' }} type="text" placeholder="{{ $placeholder }}" x-model="search"
-            @focus="showDropdown = true" @click="showDropdown = true"
-            @keydown="handleKeydown($event)" wire:model.live.debounce.500ms="pTk"
+            @focus="openDropdown()" @click="openDropdown()" @change="commitSearch()"
+            @keydown="handleKeydown($event)"
             class="{{ $class }} block w-full rounded-md border-gray-300 py-1 pr-8 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
             role="combobox" aria-expanded="false" aria-haspopup="listbox" aria-autocomplete="list" />
 
@@ -47,7 +47,7 @@
             <ul class="py-1">
                 <template x-for="(acc, index) in filtered">
                     <li>
-                        <a href="#" @click.prevent="selectAccount(acc)" @keydown.enter="selectAccount(acc)"
+                        <a href="#" @mousedown.prevent="selectAccount(acc)" @click.prevent @keydown.enter="selectAccount(acc)"
                             @mouseenter="highlightedIndex = index"
                             :class="{'bg-indigo-50': highlightedIndex === index, 'hover:bg-gray-50': highlightedIndex !== index}"
                             class="flex items-center justify-between px-4 py-2.5 text-sm cursor-pointer outline-none focus:bg-indigo-50"
@@ -128,6 +128,13 @@
                     },
 
                     initComponent() {
+                        this.accounts = this.accounts.map((acc) => ({
+                            ...acc,
+                            _search: this.normalizeText([acc.tk, acc.ten_tk].join(' ')),
+                        }));
+
+                        this.filtered = this.filterAccounts(this.search);
+
                         // Wait briefly after typing before filtering the client-side list.
                         this.$watch('search', (value) => {
                             clearTimeout(this.filterTimer);
@@ -136,6 +143,37 @@
                                 this.highlightedIndex = -1; // Reset highlight khi filter thay đổi
                             }, 500);
                         });
+                    },
+
+                    normalizeText(value) {
+                        return String(value || '')
+                            .normalize('NFD')
+                            .replace(/[\u0300-\u036f]/g, '')
+                            .replace(/[đĐ]/g, 'd')
+                            .toLowerCase()
+                            .trim()
+                            .replace(/\s+/g, ' ');
+                    },
+
+                    openDropdown() {
+                        this.filtered = this.filterAccounts(this.search);
+                        this.showDropdown = true;
+                    },
+
+                    commitSearch() {
+                        const exact = this.accounts.find((acc) => String(acc.tk).toLowerCase() === this.search.toLowerCase());
+                        if (exact) {
+                            this.selectAccount(exact);
+                            return;
+                        }
+
+                        const top = this.filterAccounts(this.search)[0];
+                        if (top) {
+                            this.selectAccount(top);
+                            return;
+                        }
+
+                        this.$wire.set('pTk', this.search || null);
                     },
 
                     handleKeydown(event) {
@@ -164,6 +202,9 @@
                                 event.preventDefault();
                                 if (this.highlightedIndex >= 0 && this.filtered[this.highlightedIndex]) {
                                     this.selectAccount(this.filtered[this.highlightedIndex]);
+                                } else {
+                                    this.commitSearch();
+                                    this.showDropdown = false;
                                 }
                                 break;
 
@@ -183,23 +224,17 @@
                     },
 
                     selectAccount(acc) {
-                        // Điền mã tài khoản vào input
                         this.search = acc.tk;
-                        // Đóng dropdown
                         this.showDropdown = false;
-                        // Không lưu ra param ngoài - chỉ hiển thị trong input
+                        this.$wire.set('pTk', acc.tk);
                     },
 
                     filterAccounts(query) {
                         const base = this.applyFilters(this.accounts);
                         if (!query) return base.slice(0, 10);
 
-                        const q = query.toLowerCase();
-                        return base.filter(acc => {
-                            const tk = acc.tk.toString().toLowerCase();
-                            const ten = acc.ten_tk.toLowerCase();
-                            return tk === q || ten === q || tk.includes(q) || ten.includes(q);
-                        }).slice(0, 10);
+                        const q = this.normalizeText(query);
+                        return base.filter(acc => acc._search.includes(q)).slice(0, 10);
                     }
                 }
             }

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono/Phieubaono.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Cash/Nganhang/Baono/Phieubaono.php
@@ -15,7 +15,6 @@ namespace Diepxuan\Catalog\Http\Livewire\Cash\Nganhang\Baono;
 
 use Diepxuan\Catalog\Models\Simba\ArDmKh;
 use Diepxuan\Catalog\Models\Simba\CaCt2;
-use Diepxuan\Simba\Models\GlDmTk;
 use Diepxuan\Simba\StoredProcedures\AsCADelCT2;
 use Diepxuan\Simba\StoredProcedures\AsCAGetPH2;
 use Diepxuan\Simba\StoredProcedures\AsCAInsCT2;
@@ -71,9 +70,6 @@ class Phieubaono extends Component
 
     // Số dư cho từng dòng chi tiết
     public Collection $pSoDuCts;
-
-    // Danh sách tài khoản cho datalist
-    public $glDmTks = [];
 
     protected $rules = [
         'pMa_Kh'          => 'required',
@@ -143,13 +139,6 @@ class Phieubaono extends Component
         } elseif (!empty($this->pStt_Rec)) {
             $this->loadPhieu();
         }
-
-        // Load danh sách tài khoản cho datalist
-        $this->glDmTks = GlDmTk::select('tk', 'ten_tk')
-            ->orderBy('tk')
-            ->limit(100)
-            ->get()
-        ;
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmkho.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmkho.php
@@ -15,6 +15,7 @@ namespace Diepxuan\Catalog\Http\Livewire\Component;
 
 use Diepxuan\Simba\StoredProcedures\AsINGetDMKHO;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
 
@@ -22,7 +23,7 @@ class InputIndmkho extends Component
 {
     #[Modelable]
     public $pMa_kho;
-    protected $inDmKhos;
+    protected Collection $inDmKhos;
 
     public function boot(): void
     {
@@ -41,7 +42,24 @@ class InputIndmkho extends Component
     public function render(): \Closure|string|View
     {
         return view('catalog::components.input-indmkho', [
-            'inDmKhos' => $this->inDmKhos,
+            'inDmKhos' => $this->warehouseOptions(),
         ]);
+    }
+
+    /**
+     * Danh sách rút gọn cho Alpine local search.
+     *
+     * @return array<int, array{ma_kho: string, ten_kho: string}>
+     */
+    protected function warehouseOptions(): array
+    {
+        return $this->inDmKhos
+            ->map(static fn ($item): array => [
+                'ma_kho'  => (string) ($item->ma_kho ?? $item->MA_KHO ?? ''),
+                'ten_kho' => (string) ($item->ten_kho ?? $item->TEN_KHO ?? ''),
+            ])
+            ->filter(static fn (array $item): bool => '' !== $item['ma_kho'])
+            ->values()
+            ->all();
     }
 }

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2025-08-03 07:54:57
+ * @lastupdate 2026-07-09
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Catalog\Models\Simba\InDmVt;
+use Diepxuan\Simba\StoredProcedures\AsINGetDMVT;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
@@ -26,7 +26,12 @@ class InputIndmvt extends Component
 
     public function boot(): void
     {
-        $this->inDmVts = InDmVt::select('ma_vt', 'ten_vt')->get();
+        $this->inDmVts = AsINGetDMVT::call([
+            'pMa_cty'   => \CatalogService::company()->id,
+            'pMa_vt'    => null,
+            'pStruct'   => null,
+            'pLanguage' => null,
+        ]);
     }
 
     public function mount(): void {}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php
@@ -15,6 +15,7 @@ namespace Diepxuan\Catalog\Http\Livewire\Component;
 
 use Diepxuan\Simba\StoredProcedures\AsINGetDMVT;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
 
@@ -22,7 +23,7 @@ class InputIndmvt extends Component
 {
     #[Modelable]
     public $pMa_vt;
-    protected $inDmVts;
+    protected Collection $inDmVts;
 
     public function boot(): void
     {
@@ -42,7 +43,24 @@ class InputIndmvt extends Component
     public function render(): \Closure|string|View
     {
         return view('catalog::components.input-indmvt', [
-            'inDmVts' => $this->inDmVts,
+            'inDmVts' => $this->itemOptions(),
         ]);
+    }
+
+    /**
+     * Danh sách rút gọn cho Alpine local search.
+     *
+     * @return array<int, array{ma_vt: string, ten_vt: string}>
+     */
+    protected function itemOptions(): array
+    {
+        return $this->inDmVts
+            ->map(static fn ($item): array => [
+                'ma_vt'  => (string) ($item->ma_vt ?? $item->MA_VT ?? ''),
+                'ten_vt' => (string) ($item->ten_vt ?? $item->TEN_VT ?? ''),
+            ])
+            ->filter(static fn (array $item): bool => '' !== $item['ma_vt'])
+            ->values()
+            ->all();
     }
 }

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
@@ -8,14 +8,13 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-03-16 14:15:00
+ * @lastupdate 2026-07-09
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Catalog\Models\Simba\ArDmKh;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\View\View;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
 
@@ -23,63 +22,47 @@ use Livewire\Component;
  * Input autocomplete đối tượng (khách hàng, nhà cung cấp, nhân viên).
  *
  * Hỗ trợ nhiều mode (single hoặc multi-mode, OR logic):
- * - khachhang: Chỉ khách hàng (isKh = true)
- * - nhacungcap: Chỉ nhà cung cấp (isNcc = true)
- * - nhanvien: Chỉ nhân viên (isNv = true)
- * - all: Tất cả (không lọc)
- * - Multi-mode OR: khachhang,nhacungcap (isKh = true OR isNcc = true)
+ *   - khachhang  -> SP asARGetDMKH(pModuleId = 'AR')
+ *   - nhacungcap -> SP asARGetDMKH(pModuleId = 'AP')
+ *   - nhanvien   -> SP asARGetDMKH(pModuleId = 'CA')
+ *   - all        -> tổng hợp cả 3 module
  *
- * Lưu ý: Cả comma (,) và pipe (|) đều dùng OR logic
+ * Nguồn tra cứu:
+ *   - simba-docs/data/sysDictionaryInfo.md (MA_KH, MA_NCC -> ARDMKH)
+ *   - simba-docs/data/sysDAOInfo.md        (ARDMKH -> asARGetDMKH)
+ *   - simba-docs/procedures/AR/procedures.md (asARGetDMKH signature)
  *
- * Usage:
- * <livewire:catalog::component.input-khachhang mode="khachhang" wire:model="pMa_Kh" />
- * <livewire:catalog::component.input-khachhang mode="nhanvien" wire:model="pMa_Nv" />
- * <livewire:catalog::component.input-khachhang mode="khachhang,nhanvien" wire:model="pMa_KhachHoacNhanVien" />
- * <livewire:catalog::component.input-khachhang mode="khachhang|nhanvien" wire:model="pMa_KhachHoacNhanVien" />
+ * Lưu ý: Component này chỉ lookup/chọn; thêm/sửa/xóa thuộc task nghiệp vụ.
  */
 class InputKhachhang extends Component
 {
-    /**
-     * Mode lọc đối tượng.
-     */
+    /** Mode lọc đối tượng. */
     public string $mode = 'khachhang';
 
-    /**
-     * Giá trị selected (mã đối tượng).
-     */
+    /** Giá trị selected (mã đối tượng). */
     #[Modelable]
     public ?string $value = null;
 
-    /**
-     * Text hiển thị (tên đối tượng).
-     */
+    /** Text hiển thị (tên đối tượng). */
     public string $search = '';
 
-    /**
-     * Danh sách kết quả tìm kiếm.
-     */
+    /** Danh sách kết quả tìm kiếm. */
     public array $results = [];
 
-    /**
-     * Có đang tìm kiếm không.
-     */
+    /** Có đang tìm kiếm không. */
     public bool $searching = false;
 
-    /**
-     * Có đang hiển thị dropdown không.
-     */
+    /** Có đang hiển thị dropdown không. */
     public bool $showDropdown = false;
 
-    /**
-     * Placeholder text.
-     */
+    /** Placeholder text. */
     public string $placeholder = '';
+
+    /** Cache lookup theo module để tránh gọi SP lặp lại. */
+    protected array $dmCache = [];
 
     /**
      * Mount component.
-     *
-     * @param null|string $value Giá trị khởi tạo
-     * @param string      $mode  Mode lọc (khachhang|nhacungcap|nhanvien|khachhang-va-nhacungcap|all)
      */
     public function mount(?string $value = null, string $mode = 'khachhang'): void
     {
@@ -87,11 +70,11 @@ class InputKhachhang extends Component
         $this->mode        = $mode;
         $this->placeholder = $this->getPlaceholderByMode();
 
-        // Load tên đối tượng nếu có value
         if ($value) {
-            $kh = ArDmKh::find($value);
-            if ($kh) {
-                $this->search = $kh->ten_kh ?? '';
+            // Load tên đối tượng qua cùng nguồn SP/wrapper
+            $row = $this->findOneByMaKh($value);
+            if ($row) {
+                $this->search = $row['ten_kh'] ?? '';
             }
         }
     }
@@ -117,50 +100,34 @@ class InputKhachhang extends Component
             return;
         }
 
-        // Build query theo mode (OR logic - comma hoặc pipe)
-        // Mode: khachhang,nhacungcap,nhanvien (isKh = true OR isNcc = true OR isNv = true)
-        $query = ArDmKh::query();
+        $modules = $this->resolveModules();
+        $seen    = [];
+        $merged  = [];
 
-        // Parse mode (hỗ trợ cả comma và pipe, đều là OR logic)
-        $modes = array_map('trim', preg_split('/[,.|]/', $this->mode));
-
-        // Dùng nested closure cho OR logic với scopes
-        $query->where(static function (Builder $q) use ($modes): void {
-            foreach ($modes as $i => $m) {
-                if (0 === $i) {
-                    // Điều kiện đầu tiên dùng where
-                    match ($m) {
-                        'khachhang'  => $q->laKhachHang(),
-                        'nhacungcap' => $q->laNhaCungCap(),
-                        'nhanvien'   => $q->laNhanVien(),
-                        default      => null,
-                    };
-                } else {
-                    // Các điều kiện sau dùng orWhere với scope
-                    match ($m) {
-                        'khachhang'  => $q->orWhere(static fn ($sq) => $sq->laKhachHang()),
-                        'nhacungcap' => $q->orWhere(static fn ($sq) => $sq->laNhaCungCap()),
-                        'nhanvien'   => $q->orWhere(static fn ($sq) => $sq->laNhanVien()),
-                        default      => null,
-                    };
+        foreach ($modules as $moduleId) {
+            $rows = $this->fetchDmKhByModule($moduleId);
+            foreach ($rows as $row) {
+                $maKh = $row['ma_kh'] ?? null;
+                if (null === $maKh || isset($seen[$maKh])) {
+                    continue;
+                }
+                if (!$this->matchesSearch($row, $search)) {
+                    continue;
+                }
+                $seen[$maKh] = true;
+                $merged[]    = [
+                    'ma_kh'   => $maKh,
+                    'ten_kh'  => $row['ten_kh']  ?? '',
+                    'dia_chi' => $row['dia_chi'] ?? '',
+                    'tel'     => $row['tel']     ?? '',
+                ];
+                if (\count($merged) >= 20) {
+                    break 2;
                 }
             }
-        });
+        }
 
-        // Tìm kiếm theo mã, tên, địa chỉ, tel
-        $this->results = $query
-            ->search($search)
-            ->limit(20)
-            ->get()
-            ->map(static fn ($kh) => [
-                'ma_kh'   => $kh->ma_kh,
-                'ten_kh'  => $kh->ten_kh,
-                'dia_chi' => $kh->dia_chi ?? '',
-                'tel'     => $kh->tel ?? '',
-            ])
-            ->toArray()
-        ;
-
+        $this->results      = $merged;
         $this->searching    = false;
         $this->showDropdown = true;
     }
@@ -175,8 +142,6 @@ class InputKhachhang extends Component
         $this->showDropdown = false;
         $this->results      = [];
 
-        // Dispatch event để parent component biết value đã thay đổi
-        // Giúp trigger updated* hook trong parent khi dùng #[Modelable]
         $this->dispatch('value-updated', $ma_kh);
     }
 
@@ -185,7 +150,6 @@ class InputKhachhang extends Component
      */
     public function blur(): void
     {
-        // Delay đóng dropdown để click vào item hoạt động
         $this->dispatch('close-dropdown');
     }
 
@@ -210,20 +174,121 @@ class InputKhachhang extends Component
     }
 
     /**
+     * Map mode -> danh sách pModuleId.
+     *
+     * @return array<int, string>
+     */
+    protected function resolveModules(): array
+    {
+        $modes = array_map('trim', preg_split('/[,.|]/', $this->mode) ?: []);
+
+        if (\in_array('all', $modes, true)) {
+            return ['AR', 'AP', 'CA'];
+        }
+
+        $map = [
+            'khachhang'  => 'AR',
+            'nhacungcap' => 'AP',
+            'nhanvien'   => 'CA',
+        ];
+
+        $modules = [];
+        foreach ($modes as $m) {
+            if (isset($map[$m])) {
+                $modules[] = $map[$m];
+            }
+        }
+
+        return [] === $modules ? ['AR'] : array_values(array_unique($modules));
+    }
+
+    /**
+     * Gọi SP asARGetDMKH cho 1 module, có cache trong vòng đời component.
+     */
+    protected function fetchDmKhByModule(string $moduleId): array
+    {
+        if (isset($this->dmCache[$moduleId])) {
+            return $this->dmCache[$moduleId];
+        }
+
+        $rows = AsARGetDMKH::call([
+            'pMa_cty'   => \CatalogService::company()->id,
+            'pMa_kh'    => null,
+            'pStruct'   => '0',
+            'pModuleId' => $moduleId,
+        ])->all();
+
+        // Chuẩn hóa key thường gặp: ma_kh, ten_kh, dia_chi, tel
+        return $this->dmCache[$moduleId] = array_map(
+            static function ($row) {
+                if (\is_array($row)) {
+                    return $row;
+                }
+                $obj = (array) $row;
+                $lower = [];
+                foreach ($obj as $k => $v) {
+                    $lower[strtolower((string) $k)] = $v;
+                }
+
+                return $lower;
+            },
+            $rows
+        );
+    }
+
+    /**
+     * Tìm 1 record theo mã đối tượng, dùng cùng SP để tránh nguồn khác.
+     */
+    protected function findOneByMaKh(string $maKh): ?array
+    {
+        foreach ($this->resolveModules() as $moduleId) {
+            $rows = AsARGetDMKH::call([
+                'pMa_cty'   => \CatalogService::company()->id,
+                'pMa_kh'    => $maKh,
+                'pStruct'   => '0',
+                'pModuleId' => $moduleId,
+            ])->all();
+            foreach ($rows as $row) {
+                $obj = \is_array($row) ? $row : (array) $row;
+                $lower = [];
+                foreach ($obj as $k => $v) {
+                    $lower[strtolower((string) $k)] = $v;
+                }
+                if (($lower['ma_kh'] ?? null) === $maKh) {
+                    return $lower;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Match từ khóa với mã/tên/địa chỉ/tel.
+     */
+    protected function matchesSearch(array $row, string $search): bool
+    {
+        $hay = strtolower(implode(' ', [
+            (string) ($row['ma_kh']   ?? ''),
+            (string) ($row['ten_kh']  ?? ''),
+            (string) ($row['dia_chi'] ?? ''),
+            (string) ($row['tel']     ?? ''),
+        ]));
+
+        return str_contains($hay, strtolower($search));
+    }
+
+    /**
      * Lấy placeholder theo mode.
      */
     protected function getPlaceholderByMode(): string
     {
-        // Parse mode để hiển thị placeholder phù hợp
-        // Hỗ trợ cả comma và pipe (đều là OR logic)
-        $modes = array_map('trim', preg_split('/[,.|]/', $this->mode));
+        $modes = array_map('trim', preg_split('/[,.|]/', $this->mode) ?: []);
 
-        // Nếu có nhiều mode hoặc all → placeholder chung
         if (\count($modes) > 1 || \in_array('all', $modes, true)) {
             return 'Chọn đối tượng...';
         }
 
-        // Single mode
         return match ($modes[0]) {
             'khachhang'  => 'Chọn khách hàng...',
             'nhacungcap' => 'Chọn nhà cung cấp...',

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
@@ -46,25 +46,15 @@ class InputKhachhang extends Component
     /** Text hiển thị (tên đối tượng). */
     public string $search = '';
 
-    /** Danh sách kết quả tìm kiếm. */
-    public array $results = [];
-
-    /** Có đang tìm kiếm không. */
-    public bool $searching = false;
-
-    /** Có đang hiển thị dropdown không. */
-    public bool $showDropdown = false;
-
     /** Placeholder text. */
     public string $placeholder = '';
 
     /**
-     * Cache danh mục theo module để tránh gọi SP lặp lại giữa các
-     * request Livewire (phải khai báo `public` để Livewire persist).
+     * Cache danh mục theo module trong lifecycle render hiện tại.
      *
      * @var array<string, array<int, array<string, mixed>>>
      */
-    public array $dmCache = [];
+    protected array $dmCache = [];
 
     /**
      * Mount component.
@@ -76,7 +66,6 @@ class InputKhachhang extends Component
         $this->placeholder = $this->getPlaceholderByMode();
 
         if ($value) {
-            // Load tên đối tượng qua cùng nguồn SP/wrapper
             $row = $this->findOneByMaKh($value);
             if ($row) {
                 $this->search = $row['ten_kh'] ?? '';
@@ -85,67 +74,12 @@ class InputKhachhang extends Component
     }
 
     /**
-     * Xử lý khi search input thay đổi.
-     */
-    public function updatedSearch(): void
-    {
-        $this->searching = true;
-
-        $search = trim($this->search);
-
-        if ($this->value) {
-            $this->value = null;
-            $this->dispatch('value-updated', null);
-        }
-
-        if ('' === $search) {
-            $this->results   = [];
-            $this->searching = false;
-
-            return;
-        }
-
-        $modules = $this->resolveModules();
-        $seen    = [];
-        $merged  = [];
-
-        foreach ($modules as $moduleId) {
-            $rows = $this->fetchDmKhByModule($moduleId);
-            foreach ($rows as $row) {
-                $maKh = $row['ma_kh'] ?? null;
-                if (null === $maKh || isset($seen[$maKh])) {
-                    continue;
-                }
-                if (!$this->matchesSearch($row, $search)) {
-                    continue;
-                }
-                $seen[$maKh] = true;
-                $merged[]    = [
-                    'ma_kh'   => $maKh,
-                    'ten_kh'  => $row['ten_kh']  ?? '',
-                    'dia_chi' => $row['dia_chi'] ?? '',
-                    'tel'     => $row['tel']     ?? '',
-                ];
-                if (\count($merged) >= 20) {
-                    break 2;
-                }
-            }
-        }
-
-        $this->results      = $merged;
-        $this->searching    = false;
-        $this->showDropdown = true;
-    }
-
-    /**
      * Chọn đối tượng từ dropdown.
      */
     public function selectCustomer(string $ma_kh, string $ten_kh): void
     {
-        $this->value        = $ma_kh;
-        $this->search       = $ten_kh;
-        $this->showDropdown = false;
-        $this->results      = [];
+        $this->value  = $ma_kh;
+        $this->search = $ten_kh;
 
         $this->dispatch('value-updated', $ma_kh);
     }
@@ -163,10 +97,8 @@ class InputKhachhang extends Component
      */
     public function clear(): void
     {
-        $this->value        = null;
-        $this->search       = '';
-        $this->results      = [];
-        $this->showDropdown = false;
+        $this->value  = null;
+        $this->search = '';
         $this->dispatch('value-updated', null);
     }
 
@@ -175,7 +107,39 @@ class InputKhachhang extends Component
      */
     public function render(): View
     {
-        return view('catalog::components.input-khachhang');
+        return view('catalog::components.input-khachhang', [
+            'customers' => $this->customerOptions(),
+        ]);
+    }
+
+    /**
+     * Danh sách rút gọn cho Alpine local search.
+     *
+     * @return array<int, array{ma_kh: string, ten_kh: string, dia_chi: string, tel: string}>
+     */
+    protected function customerOptions(): array
+    {
+        $seen   = [];
+        $merged = [];
+
+        foreach ($this->resolveModules() as $moduleId) {
+            foreach ($this->fetchDmKhByModule($moduleId) as $row) {
+                $maKh = $row['ma_kh'] ?? null;
+                if (null === $maKh || isset($seen[$maKh])) {
+                    continue;
+                }
+
+                $seen[$maKh] = true;
+                $merged[]    = [
+                    'ma_kh'   => (string) $maKh,
+                    'ten_kh'  => (string) ($row['ten_kh']  ?? ''),
+                    'dia_chi' => (string) ($row['dia_chi'] ?? ''),
+                    'tel'     => (string) ($row['tel']     ?? ''),
+                ];
+            }
+        }
+
+        return $merged;
     }
 
     /**
@@ -208,10 +172,9 @@ class InputKhachhang extends Component
     }
 
     /**
-     * Gọi SP asARGetDMKH cho 1 module, có cache persist qua Livewire request.
+     * Gọi SP asARGetDMKH cho 1 module.
      *
-     * Mặc định lọc bản ghi đang sử dụng (ksd = 1) để giữ hành vi tương
-     * đương global scope `ksd` trên model ArDmKh trước đây.
+     * Simba dùng `ksd = 0` cho bản ghi đang sử dụng, `ksd = 1` là khóa.
      */
     protected function fetchDmKhByModule(string $moduleId): array
     {
@@ -226,8 +189,6 @@ class InputKhachhang extends Component
             'pModuleId' => $moduleId,
         ])->all();
 
-        // Chuẩn hóa key về lowercase và lọc ksd = 1 (truthy) ngay tại đây
-        // để bù global scope cũ của ArDmKh. SP asARGetDMKH không filter ksd.
         return $this->dmCache[$moduleId] = array_values(array_filter(
             array_map(
                 static function ($row) {
@@ -242,7 +203,7 @@ class InputKhachhang extends Component
                 },
                 $rows
             ),
-            static fn (array $row): bool => (bool) ($row['ksd'] ?? false)
+            static fn (array $row): bool => self::isActiveRow($row)
         ));
     }
 
@@ -261,7 +222,7 @@ class InputKhachhang extends Component
 
     /**
      * Tìm 1 record theo mã đối tượng, dùng cùng SP để tránh nguồn khác.
-     * Cũng áp dụng lọc ksd = 1 để bù global scope cũ.
+     * Cũng áp dụng lọc `ksd = 0` theo lookup Simba.
      */
     protected function findOneByMaKh(string $maKh): ?array
     {
@@ -275,7 +236,7 @@ class InputKhachhang extends Component
             foreach ($rows as $row) {
                 $obj = \is_array($row) ? $row : (array) $row;
                 $lower = self::normalizeRow($obj);
-                if (($lower['ma_kh'] ?? null) === $maKh && (bool) ($lower['ksd'] ?? false)) {
+                if (($lower['ma_kh'] ?? null) === $maKh && self::isActiveRow($lower)) {
                     return $lower;
                 }
             }
@@ -284,19 +245,14 @@ class InputKhachhang extends Component
         return null;
     }
 
-    /**
-     * Match từ khóa với mã/tên/địa chỉ/tel.
-     */
-    protected function matchesSearch(array $row, string $search): bool
+    protected static function isActiveRow(array $row): bool
     {
-        $hay = strtolower(implode(' ', [
-            (string) ($row['ma_kh']   ?? ''),
-            (string) ($row['ten_kh']  ?? ''),
-            (string) ($row['dia_chi'] ?? ''),
-            (string) ($row['tel']     ?? ''),
-        ]));
+        $ksd = $row['ksd'] ?? false;
+        if (\is_string($ksd)) {
+            $ksd = trim($ksd);
+        }
 
-        return str_contains($hay, strtolower($search));
+        return !\in_array($ksd, [true, 1, '1'], true);
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php
@@ -58,8 +58,13 @@ class InputKhachhang extends Component
     /** Placeholder text. */
     public string $placeholder = '';
 
-    /** Cache lookup theo module để tránh gọi SP lặp lại. */
-    protected array $dmCache = [];
+    /**
+     * Cache danh mục theo module để tránh gọi SP lặp lại giữa các
+     * request Livewire (phải khai báo `public` để Livewire persist).
+     *
+     * @var array<string, array<int, array<string, mixed>>>
+     */
+    public array $dmCache = [];
 
     /**
      * Mount component.
@@ -203,7 +208,10 @@ class InputKhachhang extends Component
     }
 
     /**
-     * Gọi SP asARGetDMKH cho 1 module, có cache trong vòng đời component.
+     * Gọi SP asARGetDMKH cho 1 module, có cache persist qua Livewire request.
+     *
+     * Mặc định lọc bản ghi đang sử dụng (ksd = 1) để giữ hành vi tương
+     * đương global scope `ksd` trên model ArDmKh trước đây.
      */
     protected function fetchDmKhByModule(string $moduleId): array
     {
@@ -218,26 +226,42 @@ class InputKhachhang extends Component
             'pModuleId' => $moduleId,
         ])->all();
 
-        // Chuẩn hóa key thường gặp: ma_kh, ten_kh, dia_chi, tel
-        return $this->dmCache[$moduleId] = array_map(
-            static function ($row) {
-                if (\is_array($row)) {
-                    return $row;
-                }
-                $obj = (array) $row;
-                $lower = [];
-                foreach ($obj as $k => $v) {
-                    $lower[strtolower((string) $k)] = $v;
-                }
+        // Chuẩn hóa key về lowercase và lọc ksd = 1 (truthy) ngay tại đây
+        // để bù global scope cũ của ArDmKh. SP asARGetDMKH không filter ksd.
+        return $this->dmCache[$moduleId] = array_values(array_filter(
+            array_map(
+                static function ($row) {
+                    if (\is_array($row)) {
+                        return self::normalizeRow($row);
+                    }
+                    if (\is_object($row)) {
+                        return self::normalizeRow((array) $row);
+                    }
 
-                return $lower;
-            },
-            $rows
-        );
+                    return [];
+                },
+                $rows
+            ),
+            static fn (array $row): bool => (bool) ($row['ksd'] ?? false)
+        ));
+    }
+
+    /**
+     * Chuẩn hóa key của một row về lowercase (giữ nguyên thứ tự key).
+     */
+    protected static function normalizeRow(array $row): array
+    {
+        $lower = [];
+        foreach ($row as $k => $v) {
+            $lower[strtolower((string) $k)] = $v;
+        }
+
+        return $lower;
     }
 
     /**
      * Tìm 1 record theo mã đối tượng, dùng cùng SP để tránh nguồn khác.
+     * Cũng áp dụng lọc ksd = 1 để bù global scope cũ.
      */
     protected function findOneByMaKh(string $maKh): ?array
     {
@@ -250,11 +274,8 @@ class InputKhachhang extends Component
             ])->all();
             foreach ($rows as $row) {
                 $obj = \is_array($row) ? $row : (array) $row;
-                $lower = [];
-                foreach ($obj as $k => $v) {
-                    $lower[strtolower((string) $k)] = $v;
-                }
-                if (($lower['ma_kh'] ?? null) === $maKh) {
+                $lower = self::normalizeRow($obj);
+                if (($lower['ma_kh'] ?? null) === $maKh && (bool) ($lower['ksd'] ?? false)) {
                     return $lower;
                 }
             }

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
-use Diepxuan\Simba\StoredProcedures\AsGLGetDMTK;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
@@ -40,11 +39,10 @@ class InputTaikhoan extends Component
 
     public function boot(): void
     {
-        $this->glDmTks = AsGLGetDMTK::call([
-            'pMa_cty' => \CatalogService::company()->id,
-            'pTk'     => null,
-            'pStruct' => null,
-        ])->all();
+        // CatalogService::glDmTks() có cache theo (ma_cty, pTk, pStruct)
+        // — quan trọng khi form có nhiều instance input-taikhoan
+        // (ví dụ phiếu nhiều dòng chi tiết).
+        $this->glDmTks = \CatalogService::glDmTks();
     }
 
     public function mount(): void {}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-03-15 22:49:13
+ * @lastupdate 2026-07-09
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
+use Diepxuan\Simba\StoredProcedures\AsGLGetDMTK;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Component;
@@ -25,6 +26,11 @@ use Livewire\Component;
  * - Hiển thị cả mã và tên tài khoản trong dropdown
  * - Dropdown styling đẹp
  * - Support keyboard navigation
+ *
+ * Nguồn dữ liệu: SP asGLGetDMTK (table GLDMTK, code MA_TK / TK).
+ *   - simba-docs/data/sysDictionaryInfo.md (MA_TK, TK -> GLDMTK)
+ *   - simba-docs/data/sysDAOInfo.md        (GLDMTK -> asGLGetDMTK)
+ *   - simba-docs/reference/CODE_REFERENCE.md (GetDmTk)
  */
 class InputTaikhoan extends Component
 {
@@ -34,7 +40,11 @@ class InputTaikhoan extends Component
 
     public function boot(): void
     {
-        $this->glDmTks = \CatalogService::glDmTks();
+        $this->glDmTks = AsGLGetDMTK::call([
+            'pMa_cty' => \CatalogService::company()->id,
+            'pTk'     => null,
+            'pStruct' => null,
+        ])->all();
     }
 
     public function mount(): void {}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php
@@ -39,9 +39,9 @@ class InputTaikhoan extends Component
 
     public function boot(): void
     {
-        // CatalogService::glDmTks() có cache theo (ma_cty, pTk, pStruct)
-        // — quan trọng khi form có nhiều instance input-taikhoan
-        // (ví dụ phiếu nhiều dòng chi tiết).
+        // CatalogService::glDmTks() cache full list theo (ma_cty, pStruct),
+        // rồi input-taikhoan ưu tiên search/filter bằng Alpine local JS.
+        // Cách này tránh gọi SP lặp lại khi form có nhiều dòng chi tiết.
         $this->glDmTks = \CatalogService::glDmTks();
     }
 

--- a/diepxuan/laravel-catalog/src/Services/CatalogService.php
+++ b/diepxuan/laravel-catalog/src/Services/CatalogService.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-03-26 19:38:48
+ * @lastupdate 2026-07-11 14:35:01
  */
 
 namespace Diepxuan\Catalog\Services;
@@ -133,12 +133,16 @@ class CatalogService
     public function glDmTks(?string $pTk = null, ?string $pStruct = null): Collection
     {
         $maCty = $this->company()->id;
-        $key   = implode('|', [$maCty, $pTk ?? '', $pStruct ?? '']);
+        $key   = implode('|', [$maCty, $pStruct ?? '']);
 
-        return $this->glDmTks[$key] ??= AsGLGetDMTK::call([
+        $this->glDmTks[$key] ??= AsGLGetDMTK::call([
             'pMa_cty' => $maCty,
-            'pTk'     => $pTk,
+            'pTk'     => null,
             'pStruct' => $pStruct,
         ]);
+
+        return $this->glDmTks[$key]
+            ->filter(static fn ($item) => null === $pTk || (string) $item->tk === $pTk)
+            ->values();
     }
 }

--- a/diepxuan/laravel-catalog/src/Services/CatalogService.php
+++ b/diepxuan/laravel-catalog/src/Services/CatalogService.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace Diepxuan\Catalog\Services;
 
 use Diepxuan\Catalog\Config\TimerConfig;
-use Diepxuan\Catalog\Models\Simba\GlDmTk;
 use Diepxuan\Catalog\Models\Simba\SysCompany;
 use Diepxuan\Catalog\Models\Simba\SysLanguage;
 use Diepxuan\Catalog\Models\Simba\SysUserInfo;
 use Diepxuan\Catalog\Models\User;
+use Diepxuan\Simba\StoredProcedures\AsGLGetDMTK;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 
 class CatalogService
@@ -29,7 +30,7 @@ class CatalogService
     protected ?SysCompany $company = null;
     protected string $maNt;
     protected string $id;
-    protected $glDmTks;
+    protected array $glDmTks = [];
 
     public function __construct()
     {
@@ -129,8 +130,15 @@ class CatalogService
         return $this->maNt ?? $this->maNt = ($this->company()->siSetup->ma_nt0 ?? 'VND');
     }
 
-    public function glDmTks()
+    public function glDmTks(?string $pTk = null, ?string $pStruct = null): Collection
     {
-        return $this->glDmTks ?? $this->glDmTks = GlDmTk::all();
+        $maCty = $this->company()->id;
+        $key   = implode('|', [$maCty, $pTk ?? '', $pStruct ?? '']);
+
+        return $this->glDmTks[$key] ??= AsGLGetDMTK::call([
+            'pMa_cty' => $maCty,
+            'pTk'     => $pTk,
+            'pStruct' => $pStruct,
+        ]);
     }
 }

--- a/docs/tasks/357-system-livewire-input-components.md
+++ b/docs/tasks/357-system-livewire-input-components.md
@@ -86,15 +86,15 @@ Mọi thao tác hiển thị danh sách, search, lookup, validate selected value
 
 | # | Công việc | Trạng thái |
 |---|---|---|
-| 1 | Audit toàn bộ `Input*` component hiện có | TODO |
-| 2 | Lập Data Access Map thực tế từ `simba-docs` cho từng component | TODO |
-| 3 | Thay Eloquent/query trực tiếp bằng SP wrapper khi có SP phù hợp | TODO |
-| 4 | Giữ tương thích `wire:model`, props, event, view đang dùng | TODO |
-| 5 | Bổ sung validate selected value theo cùng SP/wrapper | TODO |
-| 6 | Kiểm tra các màn hình đang dùng component, tối thiểu CA4 và các form IN liên quan | TODO |
-| 7 | Chạy `php -l` cho file PHP sửa đổi | TODO |
-| 8 | Chạy test/lint liên quan hoặc ghi rõ lý do chưa chạy được | TODO |
-| 9 | Cập nhật task docs/PR body với bằng chứng SP wrapper đã dùng | TODO |
+| 1 | Audit toàn bộ `Input*` component hiện có | IN_PROGRESS |
+| 2 | Lập Data Access Map thực tế từ `simba-docs` cho từng component | DONE cho `input-khachhang`, `input-taikhoan`, `input-indmvt`, `input-indmkho`; TODO phần còn lại |
+| 3 | Thay Eloquent/query trực tiếp bằng SP wrapper khi có SP phù hợp | DONE cho `InputKhachhang`, `InputTaikhoan`, `InputIndmvt`, `InputIndmkho` |
+| 4 | Giữ tương thích `wire:model`, props, event, view đang dùng | IN_PROGRESS — contract modelable giữ nguyên; cần browser verify |
+| 5 | Bổ sung validate selected value theo cùng SP/wrapper | IN_PROGRESS — `input-khachhang` mount/find dùng `AsARGetDMKH`; `input-taikhoan`/`input-indmvt` commit exact/top local từ SP list |
+| 6 | Kiểm tra các màn hình đang dùng component, tối thiểu CA4 và các form IN liên quan | TODO browser verify |
+| 7 | Chạy `php -l` cho file PHP sửa đổi | DONE |
+| 8 | Chạy test/lint liên quan hoặc ghi rõ lý do chưa chạy được | DONE lint + unit metadata; TODO browser E2E |
+| 9 | Cập nhật task docs/PR body với bằng chứng SP wrapper đã dùng | IN_PROGRESS |
 
 ## Tiêu chí hoàn thành
 
@@ -116,3 +116,41 @@ Mọi thao tác hiển thị danh sách, search, lookup, validate selected value
 - `Phieubaono.php` da bo import `GlDmTk`, bo property `$glDmTks`, bo load datalist cu vi `phieubaono.blade.php` da dung `input-taikhoan` cho TK Co va TK No.
 - `Gl\Taikhoan.php` giu nguyen dung `GlDmTk::all()` theo chi dao cua Sep.
 - `php -l` pass cho `CatalogService.php`, `InputTaikhoan.php`, `Phieubaono.php`, `Gl\Taikhoan.php`.
+
+### Cap nhat 2026-07-11 — Local search cho input lookup dùng chung
+
+- `InputKhachhang` dùng `StoredProcedures\AsARGetDMKH` theo mode:
+  - `khachhang` -> `pModuleId = AR`
+  - `nhacungcap` -> `pModuleId = AP`
+  - `nhanvien` -> `pModuleId = CA`
+  - multi-mode/all merge danh sách, dedupe theo `ma_kh`.
+- `InputKhachhang` bỏ server-side search qua `updatedSearch()`/`wire:model.live`; view `input-khachhang.blade.php` preload danh sách rút gọn `ma_kh`, `ten_kh`, `dia_chi`, `tel` và filter bằng Alpine local JS.
+- `InputKhachhang` không còn public-cache full row qua Livewire state; cache SP theo module là protected trong lifecycle component, output xuống client chỉ là field cần cho lookup.
+- `InputKhachhang` sửa nghĩa `ksd` theo Simba lookup: `ksd = 0` là đang sử dụng, `ksd = 1` là khóa; `findOneByMaKh()` và danh sách lookup cùng áp dụng logic này.
+- `InputIndmvt` dùng `StoredProcedures\AsINGetDMVT`, pass danh sách rút gọn `ma_vt`, `ten_vt` xuống view; bỏ datalist + `wire:model` trực tiếp, chuyển sang Alpine dropdown local search.
+- `InputIndmkho` dùng `StoredProcedures\AsINGetDMKHO`, pass danh sách rút gọn `ma_kho`, `ten_kho` xuống view; bỏ datalist + `wire:model` trực tiếp, chuyển sang Alpine dropdown local search.
+- `InputTaikhoan` tiếp tục dùng `\CatalogService::glDmTks()`; `CatalogService::glDmTks()` được chỉnh cache full list theo `ma_cty|pStruct`, gọi `AsGLGetDMTK` với `pTk = null`, sau đó filter local theo `pTk` khi cần.
+- `input-taikhoan`, `input-khachhang`, `input-indmvt`, `input-indmkho` hiện ưu tiên local JS search: khi gõ không bắn Livewire request; chỉ sync Livewire khi chọn item, nhấn Enter commit, hoặc input change/Tab khỏi field.
+- Cả 4 input build `_search` một lần trong Alpine init, dùng normalize bỏ dấu tiếng Việt:
+  - Unicode normalize `NFD`
+  - bỏ combining marks
+  - đổi `đ/Đ` thành `d`
+  - lowercase, trim, gom khoảng trắng
+- Search không dấu đã hỗ trợ case như `mai ho xa` match `Mai Hồ Xá`, `dang` match `Đặng`, `dai ly` match `Đại lý`.
+- Khi người dùng gõ rồi Tab/chuyển field:
+  - ưu tiên chọn exact code (`ma_kh`, `ma_vt`, `tk`)
+  - nếu không có exact code, tự chọn dòng đầu tiên trong danh sách local filter hiện tại
+  - ví dụ `mai ho xa` rồi Tab sẽ chọn `Mai Hồ Xá` nếu dòng này là kết quả đầu/top result.
+- Dropdown item dùng `mousedown.prevent` để chọn item trước khi input phát sinh `change/blur`, tránh race condition khi click chọn.
+
+### Kiem chung 2026-07-11
+
+- `git diff --check`: pass.
+- `php -l` pass cho:
+  - `diepxuan/laravel-catalog/src/Services/CatalogService.php`
+  - `diepxuan/laravel-catalog/src/Http/Livewire/Component/InputTaikhoan.php`
+  - `diepxuan/laravel-catalog/src/Http/Livewire/Component/InputKhachhang.php`
+  - `diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmvt.php`
+  - `diepxuan/laravel-catalog/src/Http/Livewire/Component/InputIndmkho.php`
+- `php artisan test diepxuan/laravel-catalog/tests/Unit/Services/SimbaMetadataServiceTest.php`: pass, 5 tests / 10 assertions.
+- Chua chay browser E2E/dev server cho CA4, ARRptBCCN01, INRptCD02; can verify UI thuc te truoc khi merge.

--- a/docs/tasks/357-system-livewire-input-components.md
+++ b/docs/tasks/357-system-livewire-input-components.md
@@ -71,7 +71,7 @@ Mọi thao tác hiển thị danh sách, search, lookup, validate selected value
 - `InputIndmvt` dùng trực tiếp `StoredProcedures\AsINGetDMVT` cho danh sách/lookup vật tư.
 - `InputIndmnhvt` dùng trực tiếp `StoredProcedures\AsINGetDMNHVT` cho danh sách/lookup nhóm vật tư.
 - `InputKhachhang` dùng `StoredProcedures\AsARGetDMKH` và map mode khách hàng/nhà cung cấp/nhân viên theo nguồn `ARDMKH`.
-- `InputTaikhoan` dùng `StoredProcedures\AsGLGetDMTK` theo code `TK` / `MA_TK` và điều kiện lookup từ form đang gọi.
+- `InputTaikhoan` dùng `\CatalogService::glDmTks()`; `CatalogService::glDmTks()` là điểm tích hợp `StoredProcedures\AsGLGetDMTK` theo code `TK` / `MA_TK` để các nơi dùng chung không gọi SP lặp lại.
 - `InputDonVi` chưa được đổi khi chưa xác minh đúng dictionary/table/SP theo context sử dụng.
 
 ## Không thuộc phạm vi
@@ -106,6 +106,13 @@ Mọi thao tác hiển thị danh sách, search, lookup, validate selected value
 
 ## Audit Status
 
-- **Status:** PENDING
-- **Ngay audit/cap nhat:** 2026-07-09
+- **Status:** IN_PROGRESS — audit/refactor input components, cap nhat 2026-07-09
 - **Nguoi audit:** Bột (Portal Agent)
+
+### Cap nhat 2026-07-09 — InputTaikhoan/GLDMTK
+
+- `CatalogService::glDmTks()` da duoc chuyen sang SP-first qua `StoredProcedures\AsGLGetDMTK`, cache theo `ma_cty|pTk|pStruct` trong lifecycle service.
+- `InputTaikhoan` khong goi `AsGLGetDMTK` truc tiep nua; component dung `\CatalogService::glDmTks()` (tra Collection) de tai su dung cache/service chung.
+- `Phieubaono.php` da bo import `GlDmTk`, bo property `$glDmTks`, bo load datalist cu vi `phieubaono.blade.php` da dung `input-taikhoan` cho TK Co va TK No.
+- `Gl\Taikhoan.php` giu nguyen dung `GlDmTk::all()` theo chi dao cua Sep.
+- `php -l` pass cho `CatalogService.php`, `InputTaikhoan.php`, `Phieubaono.php`, `Gl\Taikhoan.php`.


### PR DESCRIPTION
## Tóm tắt

Thay nguồn dữ liệu Eloquent trực tiếp bằng Stored Procedure wrapper từ `diepxuan/laravel-simba`, theo policy ưu tiên SP cho data SimbaERP (xem `docs/policy/data-access.md`, PR #241).

## Thay đổi

| Component | Trước | Sau |
|---|---|---|
| `InputIndmvt` | `InDmVt::select('ma_vt','ten_vt')->get()` | `AsINGetDMVT::call([...])` |
| `InputKhachhang` | `ArDmKh` + scopes `laKhachHang/laNhaCungCap/laNhanVien` | `AsARGetDMKH::call([...,'pModuleId'=>...])` |
| `InputTaikhoan` | `\CatalogService::glDmTks()` → `GlDmTk::all()` | `AsGLGetDMTK::call([...])` |

## Nguồn tra cứu simba-docs

- `InputIndmvt`: sysDictionaryInfo (MA_VT) + sysDAOInfo (INDMVT) + reference/CODE_REFERENCE (GetDmVt)
- `InputKhachhang`: sysDictionaryInfo (MA_KH, MA_NCC) + sysDAOInfo (ARDMKH) + procedures/AR/procedures.md
- `InputTaikhoan`: sysDictionaryInfo (MA_TK) + sysDAOInfo (GLDMTK) + reference/CODE_REFERENCE (GetDmTk)

Không bịa tên bảng/SP/field — wrapper class + signature đối chiếu trực tiếp từ `simba-docs/` và `diepxuan/laravel-simba/src/StoredProcedures/`.

## Tương thích giữ nguyên

- props + `wire:model` contract: `mode` (string, comma/pipe OR logic), `value` (`#[Modelable]`)
- View blade không đổi: input-{indmvt,khachhang,taikhoan}.blade.php
- `InputKhachhang`:
  - Mode map: `khachhang→AR`, `nhacungcap→AP`, `nhanvien→CA`, `all→union 3 module`
  - Validate selected value qua cùng SP (`findOneByMaKh`) để lấy `ten_kh`
  - `$results` giữ shape: `ma_kh`, `ten_kh`, `dia_chi`, `tel`
  - Cache theo module trong vòng đời component (`dmCache`) — keystroke tiếp theo trong cùng mode không gọi lại SP
  - Match từ khóa ở client (`ma_kh`, `ten_kh`, `dia_chi`, `tel`)
  - Placeholder theo mode giữ nguyên
- `InputTaikhoan`:
  - Trả về `Collection` → `->all()` để `@js($glDmTks)` view nhận array OK
  - Prop `filter` (Alpine JS filter client-side) giữ nguyên

## Kiểm chứng

- [x] `php -l` pass cho cả 3 file
- [x] Signature SP wrapper khớp `simba-docs` + `diepxuan/laravel-simba/src/StoredProcedures/`
- [x] Mode parsing (`khachhang,nhacungcap`, `khachhang|nhacungcap`, `all`) giữ logic OR cũ
- [x] Không tạo/sửa SQL
- [x] Không đụng core Laravel files (chỉ `diepxuan/laravel-catalog`)

## Deferred (đã ghi vào task 357)

- **Performance**: `InputIndmvt`/`InputKhachhang` gọi SP không truyền `pMa_kh` = load full DM mỗi keystroke đầu (đặc biệt mode `all` gọi 3 SP). Cần benchmark ở DB thật hoặc đợi Simba bổ sung `pSearch`/`pMa_kh` prefix param.
- **`InputDonVi`**: chưa đối chiếu SP phù hợp theo context (kho/vt/bp/nt); giữ Eloquent.

## Liên quan

- Tiếp nối policy trong `docs/policy/data-access.md` (PR #241)
- Tiếp nối script `scripts/audit-catalog-model-layer.php` (PR #231)
- Liên quan task `docs/tasks/357-system-livewire-input-components.md`

## Checklist

- [x] Audit code xong
- [x] Có nguồn tra cứu cho từng SP wrapper
- [x] Lint pass
- [ ] Review và merge