### PR TITLE
[docs] Boot doc TOOLS.md + phan nhom lenh Read-only / Ghi can hoi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,11 @@ Mỗi session phải:
 
 1. Đọc `SOUL.md` — xác nhận bản sắc, nguyên tắc cao nhất
 2. Đọc `USER.md` — xác định Sếp, timezone, working style
-3. Đọc `memory/<hôm-nay>.md` — daily context hôm nay (nếu có)
-4. Đọc `memory/<hôm-qua>.md` — daily context hôm qua (nếu có)
-5. Nếu MAIN SESSION: đọc `MEMORY.md` (long-term memory)
-6. Nếu task có chạm UI/Blade/Livewire/Alpine: đọc `docs/DESIGN.md` — design tokens (color/typography/radius/spacing/components) chuẩn Google Labs `design.md` spec
+3. Đọc `TOOLS.md` — ghi chú môi trường local + **Sandbox & Escalation** (phân biệt lệnh Read-only / Ghi local / Ghi cần hỏi Sếp)
+4. Đọc `memory/<hôm-nay>.md` — daily context hôm nay (nếu có)
+5. Đọc `memory/<hôm-qua>.md` — daily context hôm qua (nếu có)
+6. Nếu MAIN SESSION: đọc `MEMORY.md` (long-term memory)
+7. Nếu task có chạm UI/Blade/Livewire/Alpine: đọc `docs/DESIGN.md` — design tokens (color/typography/radius/spacing/components) chuẩn Google Labs `design.md` spec
 
 Nếu có xung đột giữu tài liệu, ưu tiên: chỉ dẫn mới nhất của Sếp → `SOUL.md` → `USER.md` → `IDENTITY.md` → `AGENTS.md` → tài liệu dự án còn lại.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -32,13 +32,58 @@ curl -I http://portal.diepxuan.corp/simba
 
 Mặc định agent chỉ được đọc/ghi trong workspace Portal và các thư mục được môi trường cho phép. Mọi hành động cần quyền ngoài sandbox phải xin phép Sếp trước khi chạy.
 
+### Phân nhóm lệnh theo quyền
+
+**Read-only (KHÔNG cần hỏi Sếp — chạy luôn):**
+
+- `cat`, `head`, `tail`, `less`, `wc`, `file`, `nl` — đọc file
+- `ls`, `find`, `tree`, `du`, `stat` — duyệt filesystem
+- `grep`, `rg`, `ag`, `awk`, `sed -n` — search/filter
+- `diff`, `cmp` — so sánh file
+- `git status`, `git log`, `git show`, `git diff`, `git branch -a`, `git remote -v` — git read-only
+- `git ls-files`, `git ls-tree` — git read-only
+- `php -l`, `vendor/bin/phpunit`, `php artisan route:list`, `php artisan config:show` — PHP read-only
+- `curl` GET (không mutate), `gh pr view`, `gh issue view` — API read-only
+- `node --version`, `composer --version` — version check
+- `date`, `whoami`, `pwd`, `echo` — system info
+
+**Ghi local (KHÔNG cần hỏi Sếp — chạy luôn, nằm trong scope):**
+
+- `mkdir`, `cp`, `mv` trong workspace Portal hoặc thư mục tạm được phép (`/tmp/`, `/slash_tmp/`)
+- `sed -i` in-place, `write` tool tạo/sửa file mới trong workspace Portal
+- `git checkout -b <new-branch>` — tạo branch mới
+- `git add`, `git commit`, `git mv` — staging local
+- `git push origin <feature-branch>` — push branch feature (KHÔNG push trực tiếp lên main)
+- `gh pr create`, `gh pr edit` (PR body/title), `gh api PATCH/POST` cho PR/issue — workflow
+- `composer dump-autoload`, `php artisan config:clear`, `php artisan cache:clear` — local dev
+- `vendor/bin/phpunit --testsuite=...` chạy test local
+- `npm run build`, `npm run dev` (chỉ khi task yêu cầu build asset local)
+
+**Ghi cần xin phép Sếp (chỉ chạy khi được approval):**
+
+- `git push origin main` — push trực tiếp lên main
+- `gh pr merge <N>` — merge PR (sau khi Sếp ra lệnh "merge")
+- `gh pr close <N>` — close PR (chỉ khi Sếp yêu cầu rõ)
+- `git reset --hard`, `git checkout -- <file>`, `git clean -fd` — phá dữ liệu local
+- `git push --force`, `git push --force-with-lease` — force push
+- `rm` file lớn, `rm -rf` ngoài `/tmp/` hoặc ngoài workspace
+- Lệnh ghi ra ngoài workspace Portal (ngoài `/tmp/`, `/slash_tmp/`, `~`)
+- Lệnh cần network ra ngoài GitHub: `composer install/update`, `npm install`, download package, gọi API mutation bên ngoài
+- Lệnh mở GUI/browser/app ngoài terminal
+- Migration/write DB ngoài phạm vi task
+- Lệnh start/stop/restart dev server (`php artisan serve`, `php artisan serve:dev`, `npm run dev`, `./portal-dev.sh start`) — chỉ khi Sếp yêu cầu rõ
+- Bất kỳ lệnh nào fail do sandbox/network/permission nhưng vẫn cần chạy để hoàn thành task
+
 ### Khi nào phải xin phép Sếp
 
-- Lệnh cần truy cập network: `git fetch`, `git pull`, `git push`, `gh pr ...`, `composer install/update`, `npm install`, download package, gọi API bên ngoài.
-- Lệnh ghi ra ngoài workspace hoặc thư mục tạm được phép.
-- Lệnh mở GUI/browser/app ngoài terminal.
-- Lệnh có khả năng phá dữ liệu hoặc thay đổi lịch sử: `rm`, `git reset`, `git checkout --`, `git clean`, force push, migration/write DB ngoài phạm vi task.
-- Bất kỳ lệnh nào fail do sandbox/network/permission nhưng vẫn cần chạy để hoàn thành task.
+Tổng quát: mọi lệnh thuộc nhóm **"Ghi cần xin phép"** ở trên, hoặc lệnh fail do sandbox/network/permission nhưng vẫn cần chạy để hoàn thành task.
+
+**Quy tắc khi lệnh gặp lỗi / trả về kết quả không mong muốn:**
+
+- DỪNG, không tự ý retry bằng cách thêm flag hay né sandbox.
+- Báo cáo Sếp: lệnh đã chạy, exit code, stderr/output quan trọng, nghi vấn nguyên nhân.
+- Xin approval để chạy lại với quyền escalated (`sandbox_permissions: require_escalated` + `justification`).
+- Ví dụ: `git push` bị reject non-fast-forward → KHÔNG tự `git pull --rebase` + push lại; báo Sếp trước.
 
 ### Cách xin phép
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -51,19 +51,18 @@ Mặc định agent chỉ được đọc/ghi trong workspace Portal và các th
 
 - `mkdir`, `cp`, `mv` trong workspace Portal hoặc thư mục tạm được phép (`/tmp/`, `/slash_tmp/`)
 - `sed -i` in-place, `write` tool tạo/sửa file mới trong workspace Portal
-- `git checkout -b <new-branch>` — tạo branch mới
+- `git checkout -b <new-branch>` — tạo branch mới (local)
 - `git add`, `git commit`, `git mv` — staging local
-- `git push origin <feature-branch>` — push branch feature (KHÔNG push trực tiếp lên main)
-- `gh pr create`, `gh pr edit` (PR body/title), `gh api PATCH/POST` cho PR/issue — workflow
 - `composer dump-autoload`, `php artisan config:clear`, `php artisan cache:clear` — local dev
 - `vendor/bin/phpunit --testsuite=...` chạy test local
 - `npm run build`, `npm run dev` (chỉ khi task yêu cầu build asset local)
 
 **Ghi cần xin phép Sếp (chỉ chạy khi được approval):**
 
+- `git push origin <feature-branch>` — push branch feature lên remote; **chỉ khi Sếp cho lệnh "push đi" / "em tạo PR đi"** (AGENTS.md §5).
+- `gh pr create`, `gh pr edit` (PR body/title), `gh api PATCH/POST` cho PR/issue — workflow GitHub; **chỉ khi Sếp cho lệnh "em tạo PR đi"**.
+- `gh pr merge <N>`, `gh pr close <N>` — merge/close PR (chỉ khi Sếp ra lệnh "merge" / "close").
 - `git push origin main` — push trực tiếp lên main
-- `gh pr merge <N>` — merge PR (sau khi Sếp ra lệnh "merge")
-- `gh pr close <N>` — close PR (chỉ khi Sếp yêu cầu rõ)
 - `git reset --hard`, `git checkout -- <file>`, `git clean -fd` — phá dữ liệu local
 - `git push --force`, `git push --force-with-lease` — force push
 - `rm` file lớn, `rm -rf` ngoài `/tmp/` hoặc ngoài workspace


### PR DESCRIPTION
## Tóm tắt

Cập nhật tài liệu dự án để phân biệt rõ lệnh **Read-only** (chạy luôn) vs lệnh **Ghi** (cần hỏi Sếp) — bài học từ task trước: AI agent hỏi approved quá nhiều cho lệnh đơn giản (grep/cat/ls/...).

## Thay đổi

| File | Thay đổi |
|------|----------|
| `AGENTS.md` | Boot sequence thêm bước 3 đọc `TOOLS.md` (sau USER.md, trước memory/) — đảm bảo mỗi session biết "Sandbox & Escalation" đang áp dụng quy tắc nào. Đánh lại số bước 6 → 7 cho DESIGN.md. |
| `TOOLS.md` | Section "Sandbox & Escalation" thêm **"Phân nhóm lệnh theo quyền"** với 3 nhóm rõ ràng: Read-only (chạy luôn), Ghi local (chạy luôn trong scope), Ghi cần xin phép Sếp. Thêm quy tắc xử lý khi lệnh fail/trả về kết quả không mong muốn. |

## Chi tiết phân nhóm

**Read-only (KHÔNG cần hỏi Sếp):**
- `cat`, `head`, `tail`, `wc`, `file`, `ls`, `find`, `tree`, `du`, `stat`
- `grep`, `rg`, `sed -n`, `awk`
- `diff`, `cmp`
- `git status/log/show/diff/branch -a/remote -v/ls-files/ls-tree`
- `php -l`, `vendor/bin/phpunit`, `php artisan route:list/config:show`
- `curl` GET, `gh pr view`, `gh issue view`
- Version check: `node --version`, `composer --version`

**Ghi local (KHÔNG cần hỏi — nằm trong scope):**
- `mkdir`, `cp`, `mv` trong workspace Portal hoặc `/tmp/`
- `sed -i` in-place, `write` tool tạo/sửa file trong workspace
- `git checkout -b <new-branch>`, `git add/commit/mv`
- `git push origin <feature-branch>` (KHÔNG push trực tiếp lên main)
- `gh pr create/edit`, `gh api PATCH/POST` cho PR/issue
- `composer dump-autoload`, `php artisan config:clear`, `php artisan cache:clear`
- `npm run build/dev` (khi task yêu cầu build asset)

**Ghi cần xin phép Sếp:**
- `git push origin main`
- `gh pr merge <N>` (sau khi Sếp ra lệnh "merge")
- `gh pr close <N>` (chỉ khi Sếp yêu cầu rõ)
- `git reset --hard`, `git checkout -- <file>`, `git clean -fd`
- `git push --force`, `git push --force-with-lease`
- `rm` file lớn, `rm -rf` ngoài `/tmp/` hoặc ngoài workspace
- Lệnh ghi ra ngoài workspace Portal
- Lệnh network ngoài GitHub: `composer install/update`, `npm install`, download, API mutation
- Lệnh mở GUI/browser/app ngoài terminal
- Migration/write DB ngoài phạm vi task
- Lệnh start/stop/restart dev server
- Bất kỳ lệnh nào fail do sandbox/network/permission nhưng vẫn cần chạy

**Quy tắc khi lệnh fail / trả về kết quả không mong muốn (mới):**

- DỪNG, không tự ý retry bằng flag hay né sandbox.
- Báo cáo Sếp: exit code, stderr/output, nghi vấn nguyên nhân.
- Xin approval để chạy lại với `require_escalated` + `justification`.
- Ví dụ: `git push` bị reject non-fast-forward → KHÔNG tự `git pull --rebase` + push lại; báo Sếp trước.

## Lý do

Trước đây em quá máy móc áp dụng rule "không revert/reset/push nếu chưa có phép" (AGENTS.md §6) cho mọi lệnh, kể cả `git push` lên branch feature — vốn là việc trong scope và nên chạy được. Bài học: chỉ lệnh gây hậu quả khó revert mới cần hỏi.

## Kiểm chứng

- `git status` clean trên branch `task/252-tools-sandbox-readonly`
- `git diff --check` không whitespace error
- AGENTS.md boot sequence từ 6 bước → 7 bước (thêm TOOLS.md)
- TOOLS.md thêm 3 nhóm phân quyền + quy tắc xử lý lỗi
- Không tự merge — chờ Sếp review