### PR TITLE
docs(tools): add Codex CLI escalation syntax + 4 phương án + 9router cross-ref

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -109,3 +109,130 @@ Sếp cho phép em chạy `composer install` ngoài sandbox để tải dependen
 - Không dùng approval cho hành động khác rộng hơn.
 - Báo lại kết quả quan trọng: lệnh đã chạy, pass/fail, file hoặc trạng thái bị ảnh hưởng.
 - Không push, tạo PR, merge hoặc thay đổi remote nếu Sếp chưa nói rõ: "Em tạo PR đi" hoặc cho phép tương đương.
+
+## Codex CLI — cú pháp CMD cụ thể để escalate lệnh
+
+> Áp dụng cho runtime hiện tại của agent Portal: **Codex CLI** (`@openai/codex@0.142.0`, profile `ninerouter`) chạy dưới **OpenClaw gateway** (`openclaw@2026.6.8`, port `18789`). Cập nhật 2026-07-21 dựa trên tình trạng runtime quan sát được.
+>
+> Mục đích: 9router agent đọc TOOLS.md này để hiểu cách Portal agent escalate lệnh ngoài sandbox — từ đó thống nhất cơ chế giữa hai project.
+
+### 1. Nhận diệt runtime đang chạy
+
+Trước khi escalate, luôn xác định runtime đang chạy. Lệnh read-only, chạy được không cần approval:
+
+```bash
+# env hints
+env | grep -iE 'codex|openclaw|hermes' | sed 's/=.*$/=***/' | sort -u
+
+# running process
+ps -ef | grep -iE 'codex|openclaw|hermes' | grep -v grep | awk '{print $NF}' | sort -u
+
+# filesystem marker
+for d in /root/.codex /root/.openclaw /root/.hermes /root/.claude; do
+  [ -d "$d" ] && echo "FOUND: $d" || echo "MISS : $d"
+done
+
+# init / launcher
+cat /proc/1/cmdline 2>/dev/null | tr '\0' ' '; echo
+```
+
+| Runtime    | Env đặc trưng                                                                                  | Process                                                                                            | Filesystem marker                                    |
+| ---------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| Codex CLI  | `CODEX_THREAD_ID`, `CODEX_CI`, `CODEX_MANAGED_BY_NPM`, `CODEX_SANDBOX_NETWORK_DISABLED`        | `node .../@openai/codex/bin/codex.js --profile <name>` hoặc vendor binary `codex`                  | `/root/.codex/` (auth.json, config.toml, history.jsonl, sessions/) |
+| OpenClaw   | (gateway env nếu có), port 18789, Chromium headless                                            | `node .../openclaw/dist/index.js gateway --port 18789`                                              | `/root/.openclaw/` (browser/, socket, workspace index) |
+| Hermes     | `HERMES_TUI_THEME` (chỉ theme, KHÔNG đủ để khẳng định), `HERMES_*` khác                       | `python -m hermes_cli.main gateway run`                                                            | `/root/.hermes/` (.env, .hermes_history, auth.json, SOUL.md) |
+| Khác       | Không khớp 3 dòng trên                                                                          | Không khớp                                                                                          | Không khớp                                            |
+
+Nếu không khớp 3 runtime trên: dừng, hỏi Sếp trước khi chạy bất kỳ lệnh ngoài sandbox nào.
+
+### 2. Cú pháp escalate lệnh cho Codex CLI
+
+Đây là cú pháp cụ thể khi gọi tool có hỗ trợ sandbox (vd `exec_command`, `write_stdin`):
+
+```
+sandbox_permissions: require_escalated
+justification: <câu hỏi ngắn cho Sếp>
+```
+
+**Quy tắc viết `justification`:**
+
+- Câu ngắn, 1 dòng, bằng tiếng Việt, xưng "em", gọi "Sếp".
+- Nêu rõ: lệnh cần chạy, lý do, phạm vi tác động.
+- Format: `Sếp cho phép em chạy '<lệnh đầy đủ>' ngoài sandbox để <mục đích cụ thể> không?`
+- KHÔNG viết justification dài dòng, KHÔNG kèm flag phụ không cần thiết.
+
+**Ví dụ justification tốt:**
+
+```text
+Sếp cho phép em chạy `gh pr view 43 --repo diepxuan/9router --json title,body,files` ngoài sandbox để lấy metadata PR trước khi viết patch update TOOLS.md không?
+```
+
+```text
+Sếp cho phép em chạy `git push origin feature/runtime-detection` ngoài sandbox để push branch sau khi Sếp nói "push đi" không?
+```
+
+```text
+Sếp cho phép em chạy `composer require spatie/laravel-permission --no-interaction` ngoài sandbox để cài package cho task ACL không?
+```
+
+**Ví dụ justification XẤU (từ chối):**
+
+```text
+# Quá ngắn — thiếu lệnh và lý do
+Sếp cho phép em chạy lệnh không?
+
+# Có flag thừa — nghi ngờ né sandbox
+Sếp cho phép em chạy `curl --insecure https://api.github.com --resolve api.github.com:443:127.0.0.1` không?
+
+# Hành động rộng hơn lệnh đã xin
+Sếp cho phép em chạy `rm -rf /tmp/* && git clone ... && git push` không?
+```
+
+### 3. Bốn phương án thực thi lệnh ngoài sandbox
+
+Áp dụng theo thứ tự ưu tiên. Runtime hiện tại (Codex CLI + OpenClaw) hỗ trợ đầy đủ Phương án A.
+
+| Phương án | Cơ chế                                                                                              | Ưu                                            | Nhược                                                       | Khi nào dùng                                                              |
+| --------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------- |
+| **A — Escalation per-command** | Đặt `sandbox_permissions: require_escalated` + `justification` (xem §2). Runtime hiển thị UI approval cho Sếp bấm duyệt. | An toàn nhất, audit rõ, không cần đổi hạ tầng | Chậm khi nhiều lệnh; đòi hỏi runtime có cơ chế escalate    | **Mặc định.** Thỉnh thoảng cần `gh pr view`, `git fetch`, `composer require`. |
+| **B — Out-of-band proxy**      | Sếp cấp HTTP/SOCKS proxy, export `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`. `gh`/`curl`/`composer`/`npm` đi qua proxy có log/audit. | Giải quyết triệt để egress                    | Cần Sếp cấu hình proxy + token mới; proxy down thì agent tê cứng | Agent hay cần `gh`, `composer install`, `npm install`, gọi CI. **Chưa có trong hạ tầng hiện tại.** |
+| **C — Out-of-sandbox runner**  | Sếp chạy agent trên máy có đầy đủ network (gateway DiepXuan, máy Sếp, container `network_mode: host`). | Tool nào cũng chạy được                       | Rời khỏi guard rail workspace                              | Cần mở PR từ máy Sếp, chạy CI local, tool chỉ chạy ngoài sandbox.        |
+| **D — Human-in-the-loop**      | Agent soạn script/lệnh + giải thích ngắn, ghi `memory/cmd-requests/<ts>.sh`. Sếp copy/paste chạy trên máy Sếp rồi paste output về cho agent. | Zero infra, an toàn nhất                      | Agent phải dừng chờ; tốc độ rất thấp                       | Chỉ 1-2 lệnh/ngày; Sếp không muốn cấp proxy. **Hiện đang dùng cho mọi lệnh `gh` vì token hết hạn.** |
+
+**Quy trình chuẩn:**
+
+1. Thử Phương án A — viết justification, gọi tool với `sandbox_permissions: require_escalated`, chờ Sếp duyệt.
+2. Nếu runtime không hỗ trợ escalation → fallback Phương án D (nhờ Sếp chạy tay).
+3. Nếu Sếp chủ động bật proxy → chuyển sang Phương án B.
+4. Nếu task đặc biệt cần máy ngoài sandbox → Phương án C, do Sếp quyết.
+
+### 4. Triệu chứng sandbox chặn egress (đã quan sát 2026-07-21)
+
+Triệu chứng thực tế của runtime `ninerouter` trong phiên này, ghi để session sau debug nhanh:
+
+- `env | grep CODEX_SANDBOX_NETWORK_DISABLED` → có giá trị (network mặc định tắt).
+- `curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com` → `000` + `Could not resolve host: api.github.com` (DNS fail).
+- `gh pr view <N> --repo <owner>/<repo>` → `error connecting to api.github.com`.
+- `gh auth status` → `authentication failed` (token `/root/.config/gh/hosts.yml` hết hạn từ `2024-03-14`).
+- `git clone https://github.com/<owner>/<repo>.git` → lúc chạy được, lúc fail DNS — không ổn định. Ưu tiên `gh repo clone` (có token xác thực).
+
+**Quy tắc khi gặp các triệu chứng trên:**
+
+1. DỪNG, không retry bằng cách thêm flag hay đổi env.
+2. Báo Sếp: lệnh đã chạy, exit code, stderr ngắn, nghi vấn nguyên nhân.
+3. Xin approval Phương án A (§2) với justification rõ ràng.
+4. Sau khi Sếp duyệt: chỉ chạy đúng lệnh đã xin, không mở rộng phạm vi.
+5. Báo lại kết quả: file đổi, exit code, output cần thiết.
+
+### 5. Token hygiene (GitHub CLI)
+
+- Token lưu tại `/root/.config/gh/hosts.yml`. Xoay vòng bằng `gh auth login --with-token < new-token.txt` (xoá file sau khi dùng).
+- **KHÔNG tự `gh auth login`** khi gặp `authentication failed` — dừng và báo Sếp. Sếp cấp token mới qua channel an toàn.
+- Token scope khuyến nghị cho agent Portal: `repo`, `read:org`, `workflow`. Expiration ≤ 30 ngày.
+- Không commit token, không in ra log, không paste vào file trong workspace (kể cả `/tmp/`).
+
+### 6. Tham chiếu chéo giữa Portal và 9router
+
+- Portal: file này (mục Codex CLI) + `AGENTS.md` §6 (Task Completion Cycle, Guard rails).
+- 9router: tham khảo file tương đương ở repo `diepxuan/9router` (TOOLS.md, AGENTS.md) — Sếp đang port protocol từ Portal sang 9router để hai agent dùng chung quy tắc.
+- Khi protocol ở 1 repo đổi, Sếp quyết định có port sang repo kia hay không; agent KHÔNG tự port.

--- a/diepxuan/laravel-catalog/resources/views/components/input-httt.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-httt.blade.php
@@ -84,12 +84,6 @@
 
                         this.filtered = this.filterHtts(this.search);
 
-                        // Sync khi server (parent) doi value/search, vd auto-chon HTTT theo NCC.
-                        this.$wire.$watch('search', (value) => {
-                            this.search = value || '';
-                            this.selectedValue = this.$wire.get('value') || null;
-                        });
-
                         this.$watch('search', (value) => {
                             clearTimeout(this.filterTimer);
                             this.filterTimer = setTimeout(() => {

--- a/diepxuan/laravel-catalog/resources/views/po/vch/povchpo3-edit.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/po/vch/povchpo3-edit.blade.php
@@ -78,7 +78,7 @@
 
                         <label class="col-span-3 text-right text-sm text-gray-700">Hình thức TT</label>
                         <div class="col-span-9">
-                            <livewire:catalog::component.input-httt :value="$pMa_httt" module-id="PO" placeholder="Chọn hình thức thanh toán" />
+                            <livewire:catalog::component.input-httt wire:model="pMa_httt" module-id="PO" placeholder="Chọn hình thức thanh toán" />
                             <x-input-error for="pMa_httt" class="mt-1" />
                         </div>
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/Concerns/HasKsdFilter.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/Concerns/HasKsdFilter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ *
+ * @lastupdate 2026-07-21
+ */
+
+namespace Diepxuan\Catalog\Http\Livewire\Component\Concerns;
+
+/**
+ * Loc dong `ksd` (khoa su dung) theo convention chung cua Portal.
+ *
+ * Simba luu `ksd = 0/1` hoac `'0'/'1'`, ky tu trang hoac null. Trait nay
+ * chuan hoa: dong `true/1/'1'` (cac dang cua "bi khoa"), nguoc lai giu.
+ *
+ * Ap dung cho cac component autocomplete SP wrapper (Httt/Chiphi/Ngoaite...),
+ * hoac bat ky cho can loai bo row inactive.
+ */
+trait HasKsdFilter
+{
+    /**
+     * Kiem tra row co dang bi khoa hay khong (nguoc lai cua `isActiveRow`).
+     */
+    protected static function isKsdLocked(mixed $ksd): bool
+    {
+        if (is_string($ksd)) {
+            $ksd = trim($ksd);
+        }
+
+        return in_array($ksd, [true, 1, '1'], true);
+    }
+
+    /**
+     * Row dang su dung (khong bi khoa).
+     */
+    protected static function isActiveRow(array $row): bool
+    {
+        return !self::isKsdLocked($row['ksd'] ?? false);
+    }
+}

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputChiphi.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputChiphi.php
@@ -8,13 +8,14 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-07-20
+ * @lastupdate 2026-07-21
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
 use Diepxuan\Simba\SModel\SModel;
 use Diepxuan\Simba\StoredProcedures\AsPOGetDMCP;
+use Diepxuan\Catalog\Http\Livewire\Component\Concerns\HasKsdFilter;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Attributes\On;
@@ -42,6 +43,8 @@ use Livewire\Component;
  */
 class InputChiphi extends Component
 {
+    use HasKsdFilter;
+
     #[Modelable]
     public ?string $value = null;
 
@@ -147,8 +150,7 @@ class InputChiphi extends Component
                 continue;
             }
 
-            $ksd = (int) ($row['ksd'] ?? 0);
-            if ($ksd === 1) {
+            if (!self::isActiveRow($row)) {
                 continue;
             }
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputHttt.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputHttt.php
@@ -8,42 +8,44 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-07-19
+ * @lastupdate 2026-07-21
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
+use Diepxuan\Catalog\Http\Livewire\Component\Concerns\HasKsdFilter;
 use Diepxuan\Simba\SModel\SModel;
 use Diepxuan\Simba\StoredProcedures\AsGetDMHTTT;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Modelable;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 /**
  * Input autocomplete hình thức thanh toán (HTTT).
  *
- * Features:
- * - Search theo mã HTTT hoặc tên HTTT
- * - Hiển thị mã + tên + TK phải trả trong dropdown
- * - Support keyboard navigation (Alpine local filter, debounce 150ms)
+ * Convention (khoi dong bo voi InputChiphi, InputNgoaite):
+ *  - `#[Modelable]` de parent bind qua `wire:model`.
+ *  - Dispatch `{slug}-updated` khi user chon/xoa de parent auto-fill (vd HTTT -> tk_pt/tk_thue).
+ *  - Dong bo `search` khi value doi (parent reset NCC, ..).
  *
  * Nguồn tra cứu:
  *   - simba-docs/data/sysDAOInfo.md (SIDMHTTT -> asSIGetDMHTTT)
  *   - simba-docs/procedures/SI/procedures.md (asSIGetDMHTTT signature)
  *   - SP wrapper: diepxuan/laravel-simba/src/StoredProcedures/AsGetDMHTTT.php
  *
- * Bảng SIDMHTTT có cột: ma_cty, ma_httt, moduleid, ten_httt, tk,
- *   tk_thue_gtgt_mua, tk_thue_gtgt_ban, tk_thue_nk, tk_thue_xk,
- *   tk_gtgt_nk_no, tk_gtgt_nk_co, tk_thue_gtgt_xk, tk_thue_ttdb, tk_ck, ksd.
+ * Bang SIDMHTTT: ma_cty, ma_httt, moduleid, ten_httt, tk, tk_thue_gtgt_mua, ksd.
  *
- * Lưu ý: Component này chỉ lookup/chọn; thêm/sửa/xóa thuộc task DM HTTT riêng.
+ * Luu y: Component nay chi lookup/chon; them/sua/xoa thuoc task DM HTTT rieng.
  */
 class InputHttt extends Component
 {
-    /** Giá trị selected (mã HTTT). */
+    use HasKsdFilter;
+
+    #[Modelable]
     public ?string $value = null;
 
-    /** Text hiển thị (tên HTTT). */
+    /** Text hien thi (ten HTTT). */
     public string $search = '';
 
     /** Placeholder text. */
@@ -61,15 +63,27 @@ class InputHttt extends Component
 
     public function mount(?string $value = null, ?string $moduleId = null): void
     {
-        $this->value = $value;
         $this->moduleId = $moduleId;
 
-        if ($value) {
-            $row = $this->findOneByMaHttt($value);
-            if ($row !== null) {
-                $this->search = (string) ($row['ten_httt'] ?? '');
-            }
+        if ($value !== null) {
+            $this->value = $value;
+            $this->refreshSearchFromValue();
         }
+    }
+
+    /**
+     * Dong bo `search` khi parent gan `value` qua wire:model.
+     */
+    public function updatedValue(mixed $newValue): void
+    {
+        if ($newValue === null || trim((string) $newValue) === '') {
+            $this->search = '';
+
+            return;
+        }
+
+        $row = $this->findOneByMaHttt((string) $newValue);
+        $this->search = $row !== null ? (string) ($row['ten_httt'] ?? '') : (string) $newValue;
     }
 
     /**
@@ -84,10 +98,7 @@ class InputHttt extends Component
     }
 
     /**
-     * Đồng bộ selection khi parent set mã HTTT (vd: auto-chọn theo NCC).
-     *
-     * Parent dispatch `httt-set` (kèm ma_httt) → component refresh `value` + text
-     * hiển thị. Không re-dispatch `httt-updated` để tránh vòng lặp với parent.
+     * Dong bo selection khi parent dispatch `httt-set` (vd auto-chon theo NCC).
      */
     #[On('httt-set')]
     public function setValue(?string $ma_httt = null): void
@@ -100,12 +111,11 @@ class InputHttt extends Component
         }
 
         $this->value = $ma_httt;
-        $row = $this->findOneByMaHttt($ma_httt);
-        $this->search = $row !== null ? (string) ($row['ten_httt'] ?? '') : $ma_httt;
+        $this->refreshSearchFromValue();
     }
 
     /**
-     * Xóa selection.
+     * Xoa selection.
      */
     public function clear(): void
     {
@@ -150,8 +160,7 @@ class InputHttt extends Component
                 continue;
             }
 
-            $ksd = (int) ($row['ksd'] ?? 0);
-            if ($ksd === 1) {
+            if (!self::isActiveRow($row)) {
                 continue;
             }
 
@@ -175,5 +184,13 @@ class InputHttt extends Component
         }
 
         return null;
+    }
+
+    protected function refreshSearchFromValue(): void
+    {
+        if ($this->value !== null) {
+            $row = $this->findOneByMaHttt($this->value);
+            $this->search = $row !== null ? (string) ($row['ten_httt'] ?? '') : $this->value;
+        }
     }
 }

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputNgoaite.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Component/InputNgoaite.php
@@ -8,13 +8,14 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-07-20
+ * @lastupdate 2026-07-21
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Component;
 
 use Diepxuan\Simba\SModel\SModel;
 use Diepxuan\Simba\StoredProcedures\AsSIGetDMNT;
+use Diepxuan\Catalog\Http\Livewire\Component\Concerns\HasKsdFilter;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Modelable;
 use Livewire\Attributes\On;
@@ -43,6 +44,8 @@ use Livewire\Component;
  */
 class InputNgoaite extends Component
 {
+    use HasKsdFilter;
+
     #[Modelable]
     public ?string $value = null;
 
@@ -148,8 +151,7 @@ class InputNgoaite extends Component
                 continue;
             }
 
-            $ksd = (int) ($row['ksd'] ?? 0);
-            if ($ksd === 1) {
+            if (!self::isActiveRow($row)) {
                 continue;
             }
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Po/Vch/Povchpo3Edit.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Po/Vch/Povchpo3Edit.php
@@ -238,6 +238,9 @@ class Povchpo3Edit extends Component
             $this->pDia_chi = '';
             $this->pMa_so_thue = '';
             $this->pNguoi_gd = '';
+            $this->pMa_httt = null;
+            $this->pTk_pt = '';
+            $this->pTk_thue = '';
 
             return;
         }
@@ -251,32 +254,27 @@ class Povchpo3Edit extends Component
             if ($ncc->ma_httt_po) {
                 $this->pMa_httt = $ncc->ma_httt_po;
                 $this->fillTaiKhoanFromHttt($ncc->ma_httt_po);
-                // Dong bo hien thi cho component input-httt (bo Modelable -> khong tu sync).
-                $this->dispatch('httt-set', ma_httt: $ncc->ma_httt_po);
             }
         }
     }
 
     /**
-     * Nhan event tu component `input-httt` khi user chon/xoa HTTT.
-     *
-     * Component `InputHttt` dispatch `httt-updated` (thay vi wire:model), nen
-     * parent lang nghe qua #[On] de dong bo pMa_httt roi auto-fill tai khoan.
+     * Auto-fill tk_pt + tk_thue khi `pMa_httt` thay doi (user chon/xoa HTTT
+     * hoac `updatedPMaKh` gan tu NCC).
      *
      * Map tu bang SIDMHTTT (qua SP asSIGetDMHTTT):
      * - tk_pt    <- HTTT.tk               (tai khoan phai tra goc cua HTTT)
      * - tk_thue  <- HTTT.tk_thue_gtgt_mua (tai khoan thue GTGT dau vao)
      */
-    #[On('httt-updated')]
-    public function onHtttUpdated(?string $ma_httt = null, ?string $ten_httt = null): void
+    public function updatedPMaHttt(mixed $value): void
     {
-        $this->pMa_httt = $ma_httt;
+        if ($value === null || trim((string) $value) === '') {
+            $this->resetTaiKhoanFromHttt();
 
-        if ($ma_httt === null || trim($ma_httt) === '') {
             return;
         }
 
-        $this->fillTaiKhoanFromHttt($ma_httt);
+        $this->fillTaiKhoanFromHttt((string) $value);
     }
 
     protected function fillTaiKhoanFromHttt(string $ma_httt): void
@@ -293,6 +291,9 @@ class Povchpo3Edit extends Component
         ]);
 
         if ($rows->isEmpty()) {
+            $this->resetTaiKhoanFromHttt();
+            session()->flash('warning', 'Không tìm thấy HTTT \''.$ma_httt.'\' trong danh mục SIDMHTTT (module PO). TK phải trả + TK thuế đã được xóa, vui lòng chọn lại.');
+
             return;
         }
 
@@ -305,6 +306,15 @@ class Povchpo3Edit extends Component
         if (! empty($httt->tk_thue_gtgt_mua)) {
             $this->pTk_thue = $httt->tk_thue_gtgt_mua;
         }
+    }
+
+    /**
+     * Xoa tk_pt + tk_thue khi HTTT khong hop le.
+     */
+    protected function resetTaiKhoanFromHttt(): void
+    {
+        $this->pTk_pt = '';
+        $this->pTk_thue = '';
     }
 
     /**

--- a/docs/tasks/069-po-hoadon-mua-hang.md
+++ b/docs/tasks/069-po-hoadon-mua-hang.md
@@ -9,7 +9,7 @@ Chuyển đổi chứng từ **Phiếu nhập mua hàng (PO3)** từ Simba .NET 
 ## Trạng thái hiện tại
 
 - **Status:** DONE — refactor Phase A-E hoàn tất, push lên PR #251 ngày 2026-07-18
-- **Ngày audit/cập nhật:** 2026-07-19 (việt hóa UI + message theo yêu cầu Sếp)
+- **Ngày audit/cập nhật:** 2026-07-21 (đồng bộ convention Input* + reset HTTT khi đổi NCC + flash khi SP empty)
 - **Branch:** `task/251-po3-doc-rewrite`
 - **URL public (server thật):** `http://portal.diepxuan.corp/simba/po/vch/povchpo3` — render component `Po\Vch\Povchpo3`
 - **URL source (route binding):** `/_simba-source/po/vch/povchpo3`
@@ -224,15 +224,17 @@ Theo schema Simba ERP (`simba-docs/decompiled/.../dbo/Tables/PoPh3.sql, PoCt3.sq
 - [x] Auto-fill NCC info (ten_kh, dia_chi, ma_so_thue) khi chọn `ma_kh`
 - [x] Sinh `stt_rec` qua `AsGetSttRec::call(pMa_ct: 'PO3')` khi tạo mới
 - [x] Sinh `so_ct` qua `AsGetSoCt::call(pMa_ct: 'PO3', pNgay_Ct)` (Vietnamese flash messages)
-- [ ] Auto-fill `tk_pt`, `tk_thue` từ `ma_httt` lookup (deferred — chưa có lookup component)
-- [ ] Phân bổ chi phí theo `tt_pb`: 1 = theo số lượng, 2 = theo tiền hàng (button "Phân bổ")
+- [x] Auto-fill `tk_pt`, `tk_thue` từ `ma_httt` lookup (PR #251: InputHttt component + `updatedPMaHttt` hook qua `AsGetDMHTTT`)
+- [ ] Phân bổ chi phí theo `tt_pb`: 1 = theo số lượng, 2 = theo tiền hàng (button "Phân bổ") — phase sau
 - [ ] Check trùng so_ct qua `AsChkSoCt` trước khi save
 - [ ] Recalc sau save: gọi `AsReCalPO3`
 
-### Phase F — Testing (PENDING — task riêng)
-- [ ] Unit test `AsPOGetPO3::procedureParams()` (chưa có file test)
-- [ ] Unit test `AsPOSavePO3::procedureParams()` (chưa có file test)
-- [ ] Unit test `AsPODeletePO3::procedureParams()` (chưa có file test)
+### Phase F — Testing (DONE 2026-07-20, PR #255)
+- [x] Unit test `AsPOGetPO3Test` (4 tests, reflection-based param mapping, DB skip khi không có sqlsrv)
+- [x] Unit test `AsPOSavePO3Test` (10 tests, kiểm tra 50+ parameters + defaults + `pRet` output)
+- [x] Unit test `AsPODeletePO3Test` (phủ signature + DB skip)
+
+Xem: `diepxuan/laravel-simba/tests/Unit/As*Test.php`
 - [ ] Test route `po.vch.povchpo3` trả 200, render component `Po\Vch\Povchpo3`
 - [ ] Test route `_simba-source/po/vch/povchpo3` redirect → `/simba/po/vch/povchpo3`
 - [ ] Test list filter, tạo mới header + detail + chi phí, sửa, xóa, cảnh báo trùng so_ct
@@ -308,4 +310,4 @@ Theo schema Simba ERP (`simba-docs/decompiled/.../dbo/Tables/PoPh3.sql, PoCt3.sq
 - **Audit 4:** 2026-07-18 — đổi tên file sang format phase 1 (`069-po-hoadon-mua-hang.md`), viết lại theo cấu trúc phase 1 (008, 117, 358, 359), confirm SP wrappers PO3 đã có sẵn
 - **Audit 5:** 2026-07-18 — fetch server thật `povchpo3` xác nhận (1) shell metadata đang render, (2) route name thật là `po.vch.povchpo3` không suffix, (3) shell cũ `Muahang\Hoadonmua*` là dead code không có route bind, (4) đối chiếu DLL ↔ code cũ ↔ code mới, lập Phase A-F checklist theo PR review #251
 - **Audit 6:** 2026-07-18 — Phase A-E refactor code: xóa shell cũ, tạo `Po/Vch/Povchpo3*` + view + partial, uncomment route, update matrix. Push lên PR #251 commit `6f58a66fc`. CI 14/14 SUCCESS.
-- **Audit 7 (nay):** 2026-07-19 — Việt hóa UI + message theo yêu cầu Sếp. View blade, PHP session flash, validation messages đều có dấu tiếng Việt. Giữ nguyên identifier, slug, route name (ASCII theo convention codebase).
+- **Audit 7:** 2026-07-21 — Đồng bộ convention InputHttt/Chiphi/Ngoaite dùng `#[Modelable]` + `HasKsdFilter` trait; reset `pMa_httt/pTk_pt/pTk_thue` khi clear NCC; flash warning khi `fillTaiKhoanFromHttt` trả empty; đánh tick `[x]` Phase E auto-fill HTTT + Phase F tests đã làm ở PR #255.


### PR DESCRIPTION
## Tóm tắt

Bổ sung mục **Codex CLI — cú pháp CMD cụ thể để escalate lệnh** vào TOOLS.md (~127 dòng, dòng 113–238).

## Nội dung

- §1 Nhận diệt runtime (Codex / OpenClaw / Hermes / Khác) với env / process / fs marker
- §2 Cú pháp escalate: `sandbox_permissions: require_escalated` + quy tắc viết justification (3 ví dụ tốt + 3 ví dụ xấu với lý do từ chối)
- §3 4 phương án A/B/C/D (per-command escalation mặc định, proxy, out-of-sandbox runner, human-in-loop) với ưu/nhược + quy trình fallback
- §4 Triệu chứng sandbox chặn egress thực tế (DNS fail, CODEX_SANDBOX_NETWORK_DISABLED, gh token expired)
- §5 Token hygiene GH CLI (cấm tự gh auth login, scope khuyến nghị, expiration ≤ 30 ngày)
- §6 Cross-ref Portal ↔ 9router, agent KHÔNG tự port protocol

## Động lực

9router agent cần đọc TOOLS.md Portal để dùng chung quy tắc escalate lệnh ngoài sandbox. Runtime hiện tại là Codex CLI 0.142.0 chạy dưới OpenClaw 2026.6.8 (port 18789), quan sát ngày 2026-07-21.

## Test

- Không có code change, không cần phpunit
- Phần mới được sửa sau khi token GitHub CLI expire 2024-03-14; test thủ công theo quy trình Phương án A