### PR TITLE
docs(tools): polish 6 điểm TOOLS.md sau PR #257 review

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -281,3 +281,19 @@ Da hoan thanh viec tao **298 task files** trong `docs/tasks/` cho Portal Project
   + (f) §3 Phuong an A them `git push origin <branch>` example.
 - Diff: +7/-14 tren 1 file (TOOLS.md only).
 - Status: PR #258 OPEN, cho Sep review/merge.
+
+## 2026-07-21: Sửa §4 TOOLS.md phân biệt gh auth status (local) vs gh api (network)
+
+- Commit `a64eef296` trên branch `task/258-tools-md-polish` (chưa merge, đã push).
+- Sua dong "gh auth status -> neu PASS, token van live (xem token scopes + last refresh).
+  Neu authentication failed, dung va bao Sep theo §5." thanh:
+  + **`gh auth status`** (đọc local /root/.config/gh/hosts.yml, KHONG hit network) — PASS
+    khong dam bao lenh gh khac chay duoc (sandbox van chan DNS api.github.com).
+  + Them goi y test `gh api /octocat` truoc khi chay lenh mutation.
+  + Them cau intro noi ro 2 nhom lenh (local vs network).
+- Ly do: o session 2026-07-21, `gh auth status` PASS nhung `gh pr view` fail.
+  Dong cu gay hieu nham rang token fail khi that ra sandbox chan network.
+- Bai hoc: doc/GH CLI phan biet "credentials offline" (chi can token file) vs
+  "API call online" (can route toi api.github.com). FAIL cua network command
+  KHONG nghia la token fail — phan biet truoc khi bao Sep.
+- PR #258 status (luc ghi): OPEN, +51/-15, 2 files (TOOLS.md + MEMORY.md), 3 commits.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -239,3 +239,45 @@ Da hoan thanh viec tao **298 task files** trong `docs/tasks/` cho Portal Project
 - Task files theo khuon mau 002 (9 sections)
 - Task ID unique, khong trung lap
 - Nguon thong tin: SimbaSql/docs/decompiled/asia/{DLL}.dll/README.md
+
+## 2026-07-21: PR #257 Codex CLI escalation syntax + InputHttt refactor (DONE - merged)
+
+- PR #257 squash merged len main: `368f87600 docs(tools): add Codex CLI escalation syntax + 4 phuong an + 9router cross-ref (#257)`.
+- Branch: `task/257-tools-md-codex-escalation` (da xoa remote qua `--delete-branch`;
+  local branch con sot do `.git` read-only, se tu don o session sau).
+- Noi dung gom 2 commit (squash thanh 1):
+  + `c6407a461` refactor(catalog): sync InputHttt convention + HasKsdFilter trait + reset HTTT (PO3)
+    - Trait `Concerns/HasKsdFilter` loc ksd chung (dung cho Httt/Chiphi/Ngoaite).
+    - InputHttt doi tu event-only sang `#[Modelable]` pattern, dong bo voi Chiphi/Ngoaite.
+    - Povchpo3Edit: reset pMa_httt/pTk_pt/pTk_thue khi clear NCC; flash warning khi
+      `asSIGetDMHTTT` tra empty; bo dispatch thu cong, dung `updatedPMaHttt`.
+    - docs/tasks/069: tick [x] Phase E auto-fill HTTT + Phase F tests (PR #255).
+  + `4dfbd0879` docs(tools): Codex CLI escalation syntax + 4 phuong an A/B/C/D
+    + token hygiene + 9router cross-ref.
+- Follow-up PR #258 (cung task nay): branch `task/258-tools-md-polish`, polish 6 diem
+  TOOLS.md (overlap justification, bwrap runtime token, gh auth khong noi 'expired
+  2024-03-14', link repo 9router, rule plain text justification, git push example).
+- Bai hoc ky thuat:
+  + Phai tao branch moi truoc commit (AGENTS.md §5: 1 task = 1 branch = 1 PR).
+    Em da commit nham len `main` o session truoc (c6407a461), khac phuc bang
+    `git reset --hard origin/main` sau khi PR squash merge.
+  + Sentry `.git` read-only trong sandbox mac dinh: phai dung
+    `sandbox_permissions: require_escalated` cho moi lenh `git add/commit/push`
+    va `gh pr create/merge`. Justification tieng Viet, 1 dong, theo format
+    "Sếp cho phép em chạy '<lệnh>' ngoài sandbox để <mục đích> không?"
+  + Token GH: TOOLS.md cu ghi 'expired 2024-03-14' nhung session nay `gh pr create`
+    van chay duoc. Sua o PR #258 (a-f polish).
+- PR state = MERGED, mergeCommit.oid = `368f8760006c7e2b9aa75029cb357ec6a4307745`.
+
+## 2026-07-21: PR #258 polish 6 điểm TOOLS.md (in progress)
+
+- Branch: `task/258-tools-md-polish`, commit `d26746610 docs(tools): polish 6 diem TOOLS.md sau PR #257 review`.
+- Noi dung:
+  + (a) Bo overlap example justification o §Cach xin phep cu, tham chieu §2.
+  + (b) Them `bwrap ... --argv0 codex-linux-sandbox` runtime hien tai o §1.
+  + (c) Sua §4: `gh auth status` neu PASS thi token con live, neu fail dung theo §5.
+  + (d) §6 them link https://github.com/diepxuan/9router.
+  + (e) §2 them rule plain text cho justification.
+  + (f) §3 Phuong an A them `git push origin <branch>` example.
+- Diff: +7/-14 tren 1 file (TOOLS.md only).
+- Status: PR #258 OPEN, cho Sep review/merge.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -201,12 +201,13 @@ Sếp cho phép em chạy `rm -rf /tmp/* && git clone ... && git push` không?
 
 ### 4. Triệu chứng sandbox chặn egress (đã quan sát 2026-07-21)
 
-Triệu chứng thực tế của runtime `ninerouter` trong phiên này, ghi để session sau debug nhanh:
+Triệu chứng thực tế của runtime `ninerouter` trong phiên này, ghi để session sau debug nhanh. **Phân biệt rõ 2 nhóm lệnh** dưới đây: lệnh đọc local (luôn chạy khi có token file) và lệnh hit network (`api.github.com`, fail nếu DNS block).
 
 - `env | grep CODEX_SANDBOX_NETWORK_DISABLED` → có giá trị (network mặc định tắt).
 - `curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com` → `000` + `Could not resolve host: api.github.com` (DNS fail).
 - `gh pr view <N> --repo <owner>/<repo>` → `error connecting to api.github.com`.
-- `gh auth status` → nếu PASS, token vẫn live (xem token scopes + last refresh). Nếu `authentication failed`, dừng và báo Sếp theo §5.
+- **`gh auth status`** (đọc local `/root/.config/gh/hosts.yml`, KHÔNG hit network) — nếu `Logged in to github.com as <user>` → token file tồn tại + scopes parse được. Nếu `Not logged in` / `authentication failed` → dừng và báo Sếp theo §5.
+  ⚠️ `gh auth status` PASS không đảm bảo lệnh `gh` khác chạy được — lệnh network (`gh pr view`, `gh pr create`, `gh api`) vẫn fail vì sandbox chặn DNS ra `api.github.com`. Sau khi `gh auth status` PASS, test thử `gh api /octocat` để xác nhận cả network route mới cho các lệnh mutation.
 - `git clone https://github.com/<owner>/<repo>.git` → lúc chạy được, lúc fail DNS — không ổn định. Ưu tiên `gh repo clone` (có token xác thực, bỏ qua DNS resolution qua giao thức HTTPS).
 
 **Quy tắc khi gặp các triệu chứng trên:**

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -93,15 +93,7 @@ Tổng quát: mọi lệnh thuộc nhóm **"Ghi cần xin phép"** ở trên, ho
 - Với Codex: đặt `sandbox_permissions` = `require_escalated` và viết `justification` thành câu hỏi ngắn cho Sếp.
 - Với agent/tool khác: dùng cơ chế tương đương nếu có; nếu không có, dừng và hỏi Sếp trực tiếp, không tự chạy ngoài sandbox.
 
-Ví dụ justification tốt:
-
-```text
-Sếp cho phép em chạy `git fetch origin` ngoài sandbox để lấy trạng thái PR mới nhất không?
-```
-
-```text
-Sếp cho phép em chạy `composer install` ngoài sandbox để tải dependency còn thiếu cho test không?
-```
+Ví dụ justification tốt — xem §2 ở mục Codex CLI bên dưới (3 ví dụ tốt + 3 ví dụ xấu với lý do từ chối).
 
 ### Nguyên tắc sau khi được phép
 
@@ -138,7 +130,7 @@ cat /proc/1/cmdline 2>/dev/null | tr '\0' ' '; echo
 
 | Runtime    | Env đặc trưng                                                                                  | Process                                                                                            | Filesystem marker                                    |
 | ---------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| Codex CLI  | `CODEX_THREAD_ID`, `CODEX_CI`, `CODEX_MANAGED_BY_NPM`, `CODEX_SANDBOX_NETWORK_DISABLED`        | `node .../@openai/codex/bin/codex.js --profile <name>` hoặc vendor binary `codex`                  | `/root/.codex/` (auth.json, config.toml, history.jsonl, sessions/) |
+| Codex CLI  | `CODEX_THREAD_ID`, `CODEX_CI`, `CODEX_MANAGED_BY_NPM`, `CODEX_SANDBOX_NETWORK_DISABLED`        | `bwrap ... --argv0 codex-linux-sandbox` (runtime hiện tại) HOẶC `node .../@openai/codex/bin/codex.js --profile <name>` HOẶC vendor binary `codex`                  | `/root/.codex/` (auth.json, config.toml, history.jsonl, sessions/) |
 | OpenClaw   | (gateway env nếu có), port 18789, Chromium headless                                            | `node .../openclaw/dist/index.js gateway --port 18789`                                              | `/root/.openclaw/` (browser/, socket, workspace index) |
 | Hermes     | `HERMES_TUI_THEME` (chỉ theme, KHÔNG đủ để khẳng định), `HERMES_*` khác                       | `python -m hermes_cli.main gateway run`                                                            | `/root/.hermes/` (.env, .hermes_history, auth.json, SOUL.md) |
 | Khác       | Không khớp 3 dòng trên                                                                          | Không khớp                                                                                          | Không khớp                                            |
@@ -159,6 +151,7 @@ justification: <câu hỏi ngắn cho Sếp>
 - Câu ngắn, 1 dòng, bằng tiếng Việt, xưng "em", gọi "Sếp".
 - Nêu rõ: lệnh cần chạy, lý do, phạm vi tác động.
 - Format: `Sếp cho phép em chạy '<lệnh đầy đủ>' ngoài sandbox để <mục đích cụ thể> không?`
+- Văn bản thuần (plain text): KHÔNG kèm markdown, code fence, ký tự escape hay định dạng phức tạp — runtime đọc thẳng làm UI prompt cho Sếp duyệt.
 - KHÔNG viết justification dài dòng, KHÔNG kèm flag phụ không cần thiết.
 
 **Ví dụ justification tốt:**
@@ -194,7 +187,7 @@ Sếp cho phép em chạy `rm -rf /tmp/* && git clone ... && git push` không?
 
 | Phương án | Cơ chế                                                                                              | Ưu                                            | Nhược                                                       | Khi nào dùng                                                              |
 | --------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **A — Escalation per-command** | Đặt `sandbox_permissions: require_escalated` + `justification` (xem §2). Runtime hiển thị UI approval cho Sếp bấm duyệt. | An toàn nhất, audit rõ, không cần đổi hạ tầng | Chậm khi nhiều lệnh; đòi hỏi runtime có cơ chế escalate    | **Mặc định.** Thỉnh thoảng cần `gh pr view`, `git fetch`, `composer require`. |
+| **A — Escalation per-command** | Đặt `sandbox_permissions: require_escalated` + `justification` (xem §2). Runtime hiển thị UI approval cho Sếp bấm duyệt. | An toàn nhất, audit rõ, không cần đổi hạ tầng | Chậm khi nhiều lệnh; đòi hỏi runtime có cơ chế escalate    | **Mặc định.** Thỉnh thoảng cần `gh pr view`, `git push origin <branch>`, `composer require`. |
 | **B — Out-of-band proxy**      | Sếp cấp HTTP/SOCKS proxy, export `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY`. `gh`/`curl`/`composer`/`npm` đi qua proxy có log/audit. | Giải quyết triệt để egress                    | Cần Sếp cấu hình proxy + token mới; proxy down thì agent tê cứng | Agent hay cần `gh`, `composer install`, `npm install`, gọi CI. **Chưa có trong hạ tầng hiện tại.** |
 | **C — Out-of-sandbox runner**  | Sếp chạy agent trên máy có đầy đủ network (gateway DiepXuan, máy Sếp, container `network_mode: host`). | Tool nào cũng chạy được                       | Rời khỏi guard rail workspace                              | Cần mở PR từ máy Sếp, chạy CI local, tool chỉ chạy ngoài sandbox.        |
 | **D — Human-in-the-loop**      | Agent soạn script/lệnh + giải thích ngắn, ghi `memory/cmd-requests/<ts>.sh`. Sếp copy/paste chạy trên máy Sếp rồi paste output về cho agent. | Zero infra, an toàn nhất                      | Agent phải dừng chờ; tốc độ rất thấp                       | Chỉ 1-2 lệnh/ngày; Sếp không muốn cấp proxy. **Hiện đang dùng cho mọi lệnh `gh` vì token hết hạn.** |
@@ -213,8 +206,8 @@ Triệu chứng thực tế của runtime `ninerouter` trong phiên này, ghi đ
 - `env | grep CODEX_SANDBOX_NETWORK_DISABLED` → có giá trị (network mặc định tắt).
 - `curl -sS -o /dev/null -w "%{http_code}\n" https://api.github.com` → `000` + `Could not resolve host: api.github.com` (DNS fail).
 - `gh pr view <N> --repo <owner>/<repo>` → `error connecting to api.github.com`.
-- `gh auth status` → `authentication failed` (token `/root/.config/gh/hosts.yml` hết hạn từ `2024-03-14`).
-- `git clone https://github.com/<owner>/<repo>.git` → lúc chạy được, lúc fail DNS — không ổn định. Ưu tiên `gh repo clone` (có token xác thực).
+- `gh auth status` → nếu PASS, token vẫn live (xem token scopes + last refresh). Nếu `authentication failed`, dừng và báo Sếp theo §5.
+- `git clone https://github.com/<owner>/<repo>.git` → lúc chạy được, lúc fail DNS — không ổn định. Ưu tiên `gh repo clone` (có token xác thực, bỏ qua DNS resolution qua giao thức HTTPS).
 
 **Quy tắc khi gặp các triệu chứng trên:**
 
@@ -234,5 +227,5 @@ Triệu chứng thực tế của runtime `ninerouter` trong phiên này, ghi đ
 ### 6. Tham chiếu chéo giữa Portal và 9router
 
 - Portal: file này (mục Codex CLI) + `AGENTS.md` §6 (Task Completion Cycle, Guard rails).
-- 9router: tham khảo file tương đương ở repo `diepxuan/9router` (TOOLS.md, AGENTS.md) — Sếp đang port protocol từ Portal sang 9router để hai agent dùng chung quy tắc.
+- 9router: tham khảo file tương đương ở repo [`diepxuan/9router`](https://github.com/diepxuan/9router) (TOOLS.md, AGENTS.md) — Sếp đang port protocol từ Portal sang 9router để hai agent dùng chung quy tắc.
 - Khi protocol ở 1 repo đổi, Sếp quyết định có port sang repo kia hay không; agent KHÔNG tự port.


### PR DESCRIPTION
## Tóm tắt

Polish 6 điểm nhỏ trong TOOLS.md đã nêu trong review PR #257 — không thêm tính năng mới, chỉ nhất quán doc.

## Thay đổi

| # | Điểm | File/§ | Diff |
|---|------|--------|------|
| a | Bỏ overlap 2 bộ ví dụ justification; tham chiếu §2 | §Cách xin phép (cũ) | -8 dòng |
| b | Bổ sung `bwrap ... --argv0 codex-linux-sandbox` (runtime hiện tại) | §1 bảng nhận diệt runtime | +1 dòng |
| c | `gh auth status` không nói 'token expired 2024-03-14' (session này vẫn live); dẫn sang §5 | §4 triệu chứng sandbox | +1/-1 dòng |
| d | Thêm link repo https://github.com/diepxuan/9router | §6 tham chiếu chéo | +2/-1 dòng |
| e | Thêm rule 'văn bản thuần, không kèm markdown/code fence' | §2 Quy tắc viết justification | +1 dòng |
| f | Phương án A thêm `git push origin <branch>` (lệnh sensitive nhất) | §3 bảng 4 phương án | +1 dòng (thay 'git fetch') |

## Lý do không gấp

Có thể lười review rồi merge sau, nhưng polish sớm để session sau đọc doc nhất quán. Không có breaking change.

## Test

- Không có code change; CI module load vẫn pass.