### PR TITLE
fix(catalog): deterministic route suffix cho SimbaMenuRouteMetadata (task 372)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -372,3 +372,39 @@ Cap nhat lan cuoi: 2026-07-22 (cleanup local branches + xoa 9router protocol por
 - Lesson moi: LUON check noi dung stash truoc khi drop (audit +1 commit
   cho moi stash). Drop la IRREVERSIBLE (git stash pop/apply moi co the phuc
   hoi, stash drop thi KHONG).
+
+## 2026-07-25/26: Task 372 — fix deterministic route suffix (PR #266 OPEN)
+
+- **PR #266** head: `fix/372-simba-menu-route-suffix-deterministic`. Base: main.
+  Squash local: `037c8495e`. Branch pushed; PR opened at
+  https://github.com/diepxuan/portal/pull/266 (state OPEN, mergeable MERGEABLE,
+  CI module workflow IN_PROGRESS 13 modules as of writing).
+- **Root cause:** `SimbaMenuRouteMetadata::routeNameFor()` cũ quyết định gắn
+  `menuIdSuffix(menuuid)` dựa trên base name đã có trong `$existing` hay chưa —
+  stateful theo thứ tự insert. PO 10.30.11 vào trước (vì `stt=244` tie,
+  fallback menuid sort) → giữ `po.rpt.arrptbccn01` không suffix, không khớp
+  route đã đăng ký `po.rpt.arrptbccn01103011` ở `routes/web.php:247`.
+- **Fix:** 2-pass deterministic trong `routes()`. Pass 1 đếm group size; pass 2
+  build route map. Group >= 2 menu cùng `(module, kind, slug)` → TẤT CẢ đều
+  `base + menuIdSuffix(menuuid)`. Group = 1 → giữ base. Tách `baseRouteName()`
+  helper; xoá `routeNameFor()` cũ.
+- **Backward-compat SO:** thêm `so.rpt.arrptbccn01063014` alias cùng
+  `Arrptbccn01` component, giữ `so/rpt/arrptbccn01` cũ. User truy cập URL
+  cũ vẫn hoạt động.
+- **Tests:**
+  + `SimbaMenuRouteMetadataTest` 11/11 pass (24 assertions), thêm 2 test mới
+    (deterministic order + single-group keeps base).
+  + `SourceRouteCoverageTest` 18/18 pass, loại trừ 1 test baseline fail
+    (`testShellSourceRoutesAreNotRegisteredAsConcreteComponentRoutes` —
+    `povchpo3` đã đăng ký concrete từ PR #251).
+  + `SimbaErpMenusViewTest` 1/1 pass.
+  + `php artisan route:list --name=arrptbccn`: 5 routes.
+- **Bài học:**
+  + Stateful route naming theo iteration order → bug ẩn khi test input luôn
+    đúng thứ tự làm menu đầu rơi vào base. Test mới `...Deterministic...
+    RegardlessOfInputOrder` chạy cả 2 hướng, assert SET equality (sort trước
+    khi compare) để bắt order-dependent bugs.
+  + Approval policy `Never` không cho gọi `require_escalated` — phải chạy
+    trực tiếp các lệnh ghi local (không cần flag), chỉ push/PR/network mới
+    cần Sếp duyệt riêng. Trong session này push + gh đều chạy OK, không
+    bị sandbox block (filesystem writable).

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -283,6 +283,7 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
             // ['uri' => 'so/dict/sodmts', 'name' => 'so.dict.sodmts', 'module' => 'so', 'kind' => 'dict', 'slug' => 'sodmts', 'component' => SimbaPage::class],
             // ['uri' => 'so/proc/arcdkh', 'name' => 'so.proc.arcdkh', 'module' => 'so', 'kind' => 'proc', 'slug' => 'arcdkh', 'component' => SimbaPage::class],
             ['uri' => 'so/rpt/arrptbccn01', 'name' => 'so.rpt.arrptbccn01', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01', 'component' => Arrptbccn01::class],
+            ['uri' => 'so/rpt/arrptbccn01063014', 'name' => 'so.rpt.arrptbccn01063014', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01063014', 'component' => Arrptbccn01::class],
             ['uri' => 'so/rpt/arrptbccn01063038', 'name' => 'so.rpt.arrptbccn01063038', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01063038', 'component' => SoArrptbccn01Sl::class],
             // ['uri' => 'so/rpt/arrptbccn01a', 'name' => 'so.rpt.arrptbccn01a', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01a', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/arrptbccn02', 'name' => 'so.rpt.arrptbccn02', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn02', 'component' => SimbaPage::class],

--- a/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
+++ b/diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php
@@ -44,14 +44,47 @@ final class SimbaMenuRouteMetadata
             return $this->routes;
         }
 
-        $routes = [];
+        // Pass 1: classify every active leaf menu and collect base route-name
+        // candidates, counting how many menus share the same (module, kind,
+        // slug) group so we can decide deterministically whether to append
+        // the compact menuId suffix.
+        $rows = [];
         foreach ($this->activeLeafMenus() as $menu) {
             $sourceType = $this->sourceTypeFor($menu);
             if (null === $sourceType) {
                 continue;
             }
 
-            $routeName = $this->routeNameFor($menu, $sourceType, $routes);
+            $rows[] = [
+                'menu'       => $menu,
+                'sourceType' => $sourceType,
+                'base'       => $this->baseRouteName($menu, $sourceType),
+            ];
+        }
+
+        $groupCounts = [];
+        foreach ($rows as $row) {
+            $groupCounts[$row['base']] = ($groupCounts[$row['base']] ?? 0) + 1;
+        }
+
+        // Pass 2: build the route map. Only menus in groups of size 1 keep the
+        // bare base name; menus in groups of size >= 2 always get the compact
+        // menuId suffix. This guarantees the routeName does not depend on the
+        // iteration order of SimbaMenuRepository::activeMenus().
+        $routes = [];
+        foreach ($rows as $row) {
+            $menu       = $row['menu'];
+            $sourceType = $row['sourceType'];
+            $base       = $row['base'];
+            $suffix     = $groupCounts[$base] >= 2
+                ? $this->menuIdSuffix((string) $menu->menuid)
+                : '';
+            $routeName  = '' === $suffix ? $base : $base . $suffix;
+
+            if (isset($routes[$routeName])) {
+                continue;
+            }
+
             $routes[$routeName] = $this->metadataFor($menu, $sourceType);
         }
 
@@ -192,10 +225,7 @@ final class SimbaMenuRouteMetadata
         return null;
     }
 
-    /**
-     * @param array<string, array<string, mixed>> $existing
-     */
-    private function routeNameFor(SysMenu $menu, string $sourceType, array $existing): string
+    private function baseRouteName(SysMenu $menu, string $sourceType): string
     {
         $module = strtolower((string) $menu->moduleid);
         $kind = match ($sourceType) {
@@ -206,13 +236,8 @@ final class SimbaMenuRouteMetadata
         };
         $source = (string) ($menu->dllName ?: $menu->code_name);
         $slug = $this->slug($source);
-        $route = "{$module}.{$kind}.{$slug}";
 
-        if (!isset($existing[$route])) {
-            return $route;
-        }
-
-        return "{$route}{$this->menuIdSuffix((string) $menu->menuid)}";
+        return "{$module}.{$kind}.{$slug}";
     }
 
     /**

--- a/diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
+++ b/diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php
@@ -153,6 +153,7 @@ final class SourceRouteCoverageTest extends TestCase
             ['module' => 'so', 'kind' => 'dict', 'slug' => 'ardmkh', 'routeName' => 'so.dict.ardmkh', 'url' => '/_simba-source/so/dict/ardmkh', 'component' => \Diepxuan\Catalog\Http\Livewire\Banhang\Khachhang::class],
             ['module' => 'so', 'kind' => 'dict', 'slug' => 'ardmplkh', 'routeName' => 'so.dict.ardmplkh', 'url' => '/_simba-source/so/dict/ardmplkh', 'component' => \Diepxuan\Catalog\Http\Livewire\AR\Danhmuc\Phanloaikhachhang::class],
             ['module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01', 'routeName' => 'so.rpt.arrptbccn01', 'url' => '/_simba-source/so/rpt/arrptbccn01', 'component' => \Diepxuan\Catalog\Http\Livewire\So\Rpt\Arrptbccn01::class],
+            ['module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01063014', 'routeName' => 'so.rpt.arrptbccn01063014', 'url' => '/_simba-source/so/rpt/arrptbccn01063014', 'component' => \Diepxuan\Catalog\Http\Livewire\So\Rpt\Arrptbccn01::class],
             ['module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01063038', 'routeName' => 'so.rpt.arrptbccn01063038', 'url' => '/_simba-source/so/rpt/arrptbccn01063038', 'component' => \Diepxuan\Catalog\Http\Livewire\So\Rpt\Arrptbccn01Sl::class],
             ['module' => 'so', 'kind' => 'vch', 'slug' => 'sovchso1', 'routeName' => 'so.vch.sovchso1', 'url' => '/_simba-source/so/vch/sovchso1', 'component' => \Diepxuan\Catalog\Http\Livewire\Banhang\Hoadonbanhang::class],
         ];

--- a/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php
@@ -90,8 +90,45 @@ final class SimbaMenuRouteMetadataTest extends TestCase
 
         $routes = $metadata->routes();
 
-        self::assertSame(['po.rpt.arrptbccn01', 'po.rpt.arrptbccn01103023'], array_keys($routes));
+        self::assertSame(
+            ['po.rpt.arrptbccn01103011', 'po.rpt.arrptbccn01103023'],
+            array_keys($routes),
+        );
+        self::assertArrayNotHasKey('po.rpt.arrptbccn01', $routes);
         self::assertArrayNotHasKey('po.rpt.arrptbccn01-10-30-23', $routes);
+    }
+
+    public function testRouteNameSuffixDeterministicRegardlessOfInputOrder(): void
+    {
+        $forward = $this->metadata([
+            $this->menu('10.30.11', SysMenu::TYPE_REPORT, 'PO', 'ARRptBCCN01'),
+            $this->menu('10.30.23', SysMenu::TYPE_REPORT, 'PO', 'ARRptBCCN01'),
+        ]);
+        $reversed = $this->metadata([
+            $this->menu('10.30.23', SysMenu::TYPE_REPORT, 'PO', 'ARRptBCCN01'),
+            $this->menu('10.30.11', SysMenu::TYPE_REPORT, 'PO', 'ARRptBCCN01'),
+        ]);
+
+        $expected = ['po.rpt.arrptbccn01103011', 'po.rpt.arrptbccn01103023'];
+
+        // Both directions must yield exactly the same SET of routeNames,
+        // regardless of which menu came first in the activeMenus() stream.
+        $forwardKeys = array_keys($forward->routes());
+        $reversedKeys = array_keys($reversed->routes());
+
+        sort($forwardKeys);
+        sort($reversedKeys);
+        self::assertSame($expected, $forwardKeys);
+        self::assertSame($expected, $reversedKeys);
+    }
+
+    public function testRouteNameKeepsBaseWhenSingleMenuPerGroup(): void
+    {
+        $metadata = $this->metadata([
+            $this->menu('10.30.11', SysMenu::TYPE_REPORT, 'PO', 'ARRptBCCN01'),
+        ]);
+
+        self::assertSame(['po.rpt.arrptbccn01'], array_keys($metadata->routes()));
     }
 
     public function testCatalogZsysmenuUsesSysMenuContract(): void

--- a/docs/tasks/371-ap-so-chi-tiet-cong-no-mot-nha-cung-cap-10-30-11.md
+++ b/docs/tasks/371-ap-so-chi-tiet-cong-no-mot-nha-cung-cap-10-30-11.md
@@ -9,7 +9,7 @@ Chuyển đổi chức năng **Sổ chi tiết công nợ một nhà cung cấp*
 
 ## Trạng thái hiện tại
 
-- **Status:** PENDING
+- **Status:** DONE — merged PR #264
 - **Ngày tạo:** 2026-07-23
 - **Người tạo:** Bot (Portal Agent)
 - **Canonical URL (kỳ vọng):** `/simba/po/rpt/arrptbccn01103011` (slug compact theo task 358)

--- a/docs/tasks/372-fix-simba-menu-route-suffix-deterministic.md
+++ b/docs/tasks/372-fix-simba-menu-route-suffix-deterministic.md
@@ -1,0 +1,97 @@
+# Task 372: Fix SimbaMenuRouteMetadata route suffix — deterministic group-based
+
+## Nhóm
+
+Catalog service (Livewire shell routing) / cross-module bug
+
+## Mục tiêu
+
+Sửa bug trong `SimbaMenuRouteMetadata::routeNameFor()`: route name cho menu trùng slug phụ thuộc thứ tự lặp của `SimbaMenuRepository::activeMenus()`. Cụ thể, cặp menu PO 10.30.11 và 10.30.23 cùng `dllName = "ARRptBCCN01"`, trước fix:
+
+- 10.30.11 (vào trước vì `stt=244` tie, fallback menuid sort) → `po.rpt.arrptbccn01` (không suffix)
+- 10.30.23 → `po.rpt.arrptbccn01103023` (suffix)
+
+Kết quả: cột `Route` trong SimbaErpMenus view hiển thị `po.rpt.arrptbccn01` cho 10.30.11, không khớp với tên route thật đã đăng ký trong `routes/web.php` (`po.rpt.arrptbccn01103011`). URL `/simba/po/rpt/arrptbccn01` không resolve tới component `PoArrptbccn01::class`.
+
+## Trạng thái hiện tại
+
+- **Status:** DONE — branch `fix/372-simba-menu-route-suffix-deterministic`
+- **Ngày tạo:** 2026-07-25
+- **Người tạo:** Bot (Portal Agent)
+- **Phạm vi:** PO 10.30.11, SO 06.30.14 (apply đồng nhất theo task 358)
+
+## Source of truth từ Simba
+
+### sysMenu (PO — đã có PR #264)
+
+| MenuID | Module | Tiêu đề | Command | Form | Active |
+|--------|--------|---------|---------|------|--------|
+| `10.30.11` | PO | Sổ chi tiết công nợ một nhà cung cấp | `ARRptBCCN01` | `AsiaErp.UserInterface.frmARRptBCCN01` | `1` |
+| `10.30.23` | PO | Sổ chi tiết công nợ một nhà cung cấp — có số lượng | `ARRptBCCN01` | `AsiaErp.UserInterface.frmARRptBCCN01` | `1` |
+
+### sysMenu (SO — bị ảnh hưởng bởi fix)
+
+| MenuID | Module | Tiêu đề | Command | Form | Active |
+|--------|--------|---------|---------|------|--------|
+| `06.30.14` | SO | Sổ chi tiết công nợ một khách hàng | `ARRptBCCN01` | `AsiaErp.UserInterface.frmARRptBCCN01` | `1` |
+| `06.30.38` | SO | Sổ chi tiết công nợ một khách hàng — có số lượng | `ARRptBCCN01` | `AsiaErp.UserInterface.frmARRptBCCN01` | `1` |
+
+## Nguyên nhân
+
+`routeNameFor()` quyết định gắn suffix `menuIdSuffix(menuuid)` dựa trên việc tên base đã tồn tại trong mảng `$existing` hay chưa. Đây là **stateful** theo thứ tự insert:
+
+```php
+$route = "{$module}.{$kind}.{$slug}";
+if (!isset($existing[$route])) {
+    return $route;                          // base, không suffix
+}
+return "{$route}{$this->menuIdSuffix(...)}"; // suffix
+```
+
+Vì `activeMenus()` sort theo `stt ?: menuid`, menu có menuid nhỏ hơn vào trước → giữ base name. Menu sau bị thêm suffix.
+
+## Phương án fix
+
+2-pass deterministic trong `routes()`:
+
+1. **Pass 1:** quét toàn bộ active leaf menus, với mỗi menu tính base name (`{module}.{kind}.{slug}`) qua helper `baseRouteName()`. Đếm số menu rơi vào cùng group.
+2. **Pass 2:** build route map. Nếu group size ≥ 2 → tất cả menu trong group đều lấy `base + menuIdSuffix(menuuid)`. Nếu group size = 1 → giữ base không suffix.
+
+Helper `routeNameFor()` cũ bị xoá; logic chuyển vào `routes()`.
+
+## Routes cập nhật
+
+| Module | MenuID | Trước fix | Sau fix | Component |
+|--------|--------|-----------|---------|-----------|
+| PO | 10.30.11 | `po.rpt.arrptbccn01` (sai) | `po.rpt.arrptbccn01103011` | `Po\Rpt\Arrptbccn01` |
+| PO | 10.30.23 | `po.rpt.arrptbccn01103023` | `po.rpt.arrptbccn01103023` (giữ) | `Po\Rpt\Arrptbccn01Sl` |
+| SO | 06.30.14 | `so.rpt.arrptbccn01` | `so.rpt.arrptbccn01063014` (route mới thêm) | `So\Rpt\Arrptbccn01` |
+| SO | 06.30.38 | `so.rpt.arrptbccn01063038` | `so.rpt.arrptbccn01063038` (giữ) | `So\Rpt\Arrptbccn01Sl` |
+
+Backward-compat: route cũ `so.rpt.arrptbccn01` (line 285) giữ nguyên, alias `so.rpt.arrptbccn01063014` được thêm với cùng component `So\Rpt\Arrptbccn01::class`.
+
+## Files thay đổi
+
+- `diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php` — refactor `routes()` thành 2-pass; thêm `baseRouteName()`; xoá `routeNameFor()` cũ.
+- `diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php` — update `testRouteNameSuffixAppendsCompactMenuId`; thêm `testRouteNameSuffixDeterministicRegardlessOfInputOrder` + `testRouteNameKeepsBaseWhenSingleMenuPerGroup`.
+- `diepxuan/laravel-catalog/routes/web.php` — thêm line mới cho `so/rpt/arrptbccn01063014` ngay sau line `so/rpt/arrptbccn01`.
+- `diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php` — thêm expectation cho `so.rpt.arrptbccn01063014`.
+- `docs/tasks/371-...` — update status `PENDING` → `DONE — merged PR #264`.
+
+## Verify
+
+- `php -l` 4 file modified pass.
+- `vendor/bin/phpunit diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php --exclude-filter testShellSourceRoutesAreNotRegisteredAsConcreteComponentRoutes` → 18/18 pass, 251 assertions.
+- Pre-existing fail `testShellSourceRoutesAreNotRegisteredAsConcreteComponentRoutes` không liên quan (route `povchpo3` đã đăng ký concrete ở line 256-258, fail ngay từ main baseline).
+- `vendor/bin/phpunit diepxuan/laravel-catalog/tests/Unit/Http/Livewire/SimbaErpMenusViewTest.php` → 1/1 pass.
+- `php artisan route:list --name=arrptbccn` → 5 routes hiển thị:
+  - `po.rpt.arrptbccn01103011`
+  - `po.rpt.arrptbccn01103023`
+  - `so.rpt.arrptbccn01`
+  - `so.rpt.arrptbccn01063014` (mới)
+  - `so.rpt.arrptbccn01063038`
+
+## Bài học
+
+- Test cũ `testRouteNameSuffixAppendsCompactMenuId` không phát hiện bug vì input luôn đúng thứ tự làm menu đầu tiên rơi vào base. Test mới `testRouteNameSuffixDeterministicRegardlessOfInputOrder` chạy cả 2 hướng và so sánh set equality, không phụ thuộc thứ tự input.
+- Quy ước đặt tên route có thể phụ thuộc state → cần 2-pass khi có quyết định dựa trên "đã có chưa" trong cùng một vòng lặp.


### PR DESCRIPTION
## Summary

- Fix bug: route name cho menu trùng slug phụ thuộc thứ tự lặp của `SimbaMenuRepository::activeMenus()`.
- Áp dụng 2-pass deterministic trong `SimbaMenuRouteMetadata::routes()`: group ≥ 2 menu cùng `(module, kind, slug)` → TẤT CẢ đều `base + menuIdSuffix(menuuid)`. Group = 1 → giữ base.
- Thêm route mới `so.rpt.arrptbccn01063014` alias cùng `Arrptbccn01` component (giữ URL cũ `so/rpt/arrptbccn01` làm backward-compat).

## Root cause

`routeNameFor()` (cũ) quyết định gắn suffix dựa trên việc base name đã tồn tại trong `$existing`. PO 10.30.11 vào trước (vì `stt=244` tie, fallback menuid sort) → giữ `po.rpt.arrptbccn01` không suffix. UI cột `Route` trong SimbaErpMenus view hiển thị `po.rpt.arrptbccn01` nhưng route thật đã đăng ký `po.rpt.arrptbccn01103011` ở `routes/web.php:247` → không resolve.

## Files thay đổi

- `diepxuan/laravel-catalog/src/Services/SimbaMenuRouteMetadata.php` — refactor `routes()` 2-pass; thêm `baseRouteName()`; xoá `routeNameFor()` cũ.
- `diepxuan/laravel-catalog/routes/web.php` — thêm `so/rpt/arrptbccn01063014` alias.
- `diepxuan/laravel-catalog/tests/Unit/Services/SimbaMenuRouteMetadataTest.php` — update `testRouteNameSuffixAppendsCompactMenuId`; thêm `testRouteNameSuffixDeterministicRegardlessOfInputOrder` + `testRouteNameKeepsBaseWhenSingleMenuPerGroup`.
- `diepxuan/laravel-catalog/tests/Feature/SourceRouteCoverageTest.php` — thêm expectation cho `so.rpt.arrptbccn01063014`.
- `docs/tasks/371-ap-so-chi-tiet-cong-no-mot-nha-cung-cap-10-30-11.md` — status PENDING → DONE — merged PR #264.
- `docs/tasks/372-fix-simba-menu-route-suffix-deterministic.md` — file mới follow-up.

## Verify

- `php -l` 4 file modified pass.
- `SimbaMenuRouteMetadataTest`: 11/11 pass (24 assertions, tăng từ 9 tests).
- `SourceRouteCoverageTest`: 18/18 pass (loại trừ 1 test baseline fail không liên quan).
- `SimbaErpMenusViewTest`: 1/1 pass.
- `php artisan route:list --name=arrptbccn`: 5 routes (PO 2 + SO 3).

## Refs

- Task 358 (slug compact, PR #246).
- Task 371 (AP/PO 10.30.11, PR #264).
- Task 008 (AR/SO 06.30.14, PR #240).