### PR TITLE
feat(catalog): SO ARDMKH khách hàng canonical — So\Dict\ArdmkhForm (GĐ C, task 374)

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/so/dict/ardmkh-form.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/so/dict/ardmkh-form.blade.php
@@ -1,0 +1,107 @@
+<div class="so-ardmkh-form-container w-full">
+    <x-head-title>{{ $mode === 'create' ? 'Thêm khách hàng' : 'Sửa khách hàng' }}</x-head-title>
+    <x-slot name="header">
+        <div class="flex items-center gap-4">
+            <a href="{{ simbaroute('so.dict.ardmkh') }}" class="rounded-md bg-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-300">Quay lại</a>
+            <div>
+                <h2 class="text-xl font-semibold leading-tight text-gray-800">{{ $mode === 'create' ? 'Thêm khách hàng mới' : 'Sửa khách hàng: ' . $ma_kh }}</h2>
+                <p class="text-sm text-gray-500">ARDMKH — frmARDMKH — SO/AR customer context</p>
+            </div>
+        </div>
+    </x-slot>
+
+    <form wire:submit="save" class="mt-4 space-y-4">
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Thông tin cơ bản</h3></div>
+            <div class="grid grid-cols-1 gap-4 p-6 md:grid-cols-2">
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Mã KH <span class="text-red-500">*</span></span>
+                    <input wire:model="ma_kh" maxlength="50" @if($mode === 'edit') readonly @endif class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm @if($mode === 'edit') bg-gray-100 @endif" placeholder="VD: KH001" />
+                    @error('ma_kh') <span class="mt-1 block text-xs text-red-600">{{ $message }}</span> @enderror
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Tên khách hàng <span class="text-red-500">*</span></span>
+                    <input wire:model="ten_kh" maxlength="200" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Tên khách hàng" />
+                    @error('ten_kh') <span class="mt-1 block text-xs text-red-600">{{ $message }}</span> @enderror
+                </label>
+                <label class="block md:col-span-2">
+                    <span class="text-sm font-medium text-gray-700">Địa chỉ</span>
+                    <input wire:model="dia_chi" maxlength="500" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Địa chỉ" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Người giao dịch</span>
+                    <input wire:model="nguoi_gd" maxlength="100" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Người giao dịch" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Mã số thuế</span>
+                    <input wire:model="ma_so_thue" maxlength="50" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Mã số thuế" />
+                </label>
+            </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Liên hệ và thanh toán</h3></div>
+            <div class="grid grid-cols-1 gap-4 p-6 md:grid-cols-2">
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Điện thoại</span>
+                    <input wire:model="dien_thoai" maxlength="50" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Điện thoại" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Fax</span>
+                    <input wire:model="fax" maxlength="50" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Fax" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Email</span>
+                    <input wire:model="email" type="email" maxlength="100" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="email@example.com" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">TK công nợ</span>
+                    <input wire:model="tk_cn" maxlength="20" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="TK" />
+                </label>
+            </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Phân loại</h3></div>
+            <div class="grid grid-cols-1 gap-4 p-6 md:grid-cols-4">
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Phân loại 1</span>
+                    <input wire:model="ma_plkh1" maxlength="8" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="MA_PLKH1" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Phân loại 2</span>
+                    <input wire:model="ma_plkh2" maxlength="8" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="MA_PLKH2" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Phân loại 3</span>
+                    <input wire:model="ma_plkh3" maxlength="8" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="MA_PLKH3" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Nhóm KH</span>
+                    <select wire:model="ma_nhkh" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm">
+                        <option value="">— Chọn nhóm —</option>
+                        @foreach($nhomKhOptions as $nhom)
+                            <option value="{{ $nhom->ma_nhkh }}">{{ $nhom->ten_nhkh }}</option>
+                        @endforeach
+                    </select>
+                </label>
+            </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Ghi chú</h3></div>
+            <div class="p-6">
+                <textarea wire:model="ghi_chu" rows="3" maxlength="500" class="w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Ghi chú"></textarea>
+            </div>
+        </div>
+
+        @if ($errors->any())
+            <div class="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{{ $errors->first() }}</div>
+        @endif
+
+        <div class="flex justify-end gap-2">
+            <a href="{{ simbaroute('so.dict.ardmkh') }}" class="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">Hủy</a>
+            <button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">Lưu</button>
+        </div>
+    </form>
+</div>

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -17,6 +17,7 @@ use Diepxuan\Catalog\Http\Controllers\SystemUserController;
 use Diepxuan\Catalog\Http\Controllers\SystemWebsiteController;
 use Diepxuan\Catalog\Http\Livewire\AR\Danhmuc\Phanloaikhachhang;
 use Diepxuan\Catalog\Http\Livewire\Banhang\Hoadonbanhang;
+use Diepxuan\Catalog\Http\Livewire\So\Dict\ArdmkhForm as SoArdmkhForm;
 use Diepxuan\Catalog\Http\Livewire\Banhang\Khachhang;
 use Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc\Nhanvien;
 use Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc\NhanvienForm;
@@ -74,6 +75,10 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
     // Canonical CA ARDMKH dict routes (task 375)
     Route::get('/ca/dict/ardmkh/create', NhanvienForm::class)->name('ca.dict.ardmkh.create');
     Route::get('/ca/dict/ardmkh/{id}/edit', NhanvienForm::class)->name('ca.dict.ardmkh.edit');
+
+    // CANONICAL SO KHACH HANG (task 374)
+    Route::get('/so/dict/ardmkh/create', SoArdmkhForm::class)->name('so.dict.ardmkh.create');
+    Route::get('/so/dict/ardmkh/{id}/edit', SoArdmkhForm::class)->name('so.dict.ardmkh.edit');
 
     Route::resource('banhang/bangkebanhang', SellController::class)->names('sell.list');
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
@@ -90,12 +90,13 @@ class KhachhangForm extends Component
      */
     public function mount(?string $id = null): void
     {
-        $this->loadDropdowns();
-
-        if ($id) {
-            $this->mode = 'edit';
-            $this->loadKhachHang($id);
-        }
+        // @deprecated Redirect sang So\Dict\ArdmkhForm canonical
+        $this->redirect(
+            $id
+                ? simbaroute('so.dict.ardmkh.edit', ['id' => $id])
+                : simbaroute('so.dict.ardmkh.create'),
+            navigate: true,
+        );
     }
 
     /**

--- a/diepxuan/laravel-catalog/src/Http/Livewire/So/Dict/ArdmkhForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/So/Dict/ArdmkhForm.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Http\Livewire\So\Dict;
+
+use Diepxuan\Catalog\Http\Livewire\Po\Dict\ArdmkhForm as BaseForm;
+use Diepxuan\Catalog\Models\Simba\ArDmNhKh;
+use Diepxuan\Catalog\Models\Simba\ArDmPlKh;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+
+/**
+ * ARDMKH khách hàng (SO, module AR, pIskh=1).
+ * Kế thừa canonical pattern từ PO Dict\ArdmkhForm.
+ */
+class ArdmkhForm extends BaseForm
+{
+    public ?string $ma_plkh1 = null;
+    public ?string $ma_plkh2 = null;
+    public ?string $ma_plkh3 = null;
+    public ?string $ma_nhkh  = null;
+    public ?string $ma_nt    = 'VND';
+    public bool $isKh = true;
+    public bool $ksd  = false;
+
+    /** @var Collection */
+    public Collection $nhomKhOptions;
+    /** @var array<int, Collection> */
+    public array $plkhOptions = [];
+
+    protected $messages = [
+        'ma_kh.required'  => 'Mã khách hàng không được để trống.',
+        'ten_kh.required' => 'Tên khách hàng không được để trống.',
+        'email.email'     => 'Email không đúng định dạng.',
+    ];
+
+    public function mount(?string $id = null): void
+    {
+        $this->loadDropdowns();
+        if ($id) {
+            $this->mode = 'edit';
+            $this->loadDoiTuong($id);
+        }
+    }
+
+    public function loadDoiTuong(string $maKh): void
+    {
+        try {
+            $result = AsARGetDMKH::getCustomers(search: $maKh);
+            if ($result->isEmpty()) {
+                $this->dispatch('error', message: 'Không tìm thấy khách hàng.');
+                return;
+            }
+
+            $row = $result->first();
+            $_ = fn (string $lower, string $upper, mixed $default = null): mixed =>
+                $this->field($row, $lower, $upper, $default);
+
+            $this->ma_kh       = $_('ma_kh', 'MA_KH', $maKh);
+            $this->ten_kh      = $_('ten_kh', 'TEN_KH', '');
+            $this->dia_chi     = $_('dia_chi', 'DIA_CHI', '');
+            $this->ma_so_thue  = $_('ma_so_thue', 'MA_SO_THUE', '');
+            $this->dien_thoai  = $_('tel', 'TEL', '');
+            $this->fax         = $_('fax', 'FAX', '');
+            $this->email       = $_('email', 'EMAIL', '');
+            $this->ma_nt       = $_('ma_nt', 'MA_NT', 'VND');
+            $this->tk_cn       = $_('tk', 'TK');
+            $this->ma_plkh1    = $_('ma_plkh1', 'MA_PLKH1');
+            $this->ma_plkh2    = $_('ma_plkh2', 'MA_PLKH2');
+            $this->ma_plkh3    = $_('ma_plkh3', 'MA_PLKH3');
+            $this->ma_nhkh     = $_('ma_nhkh', 'MA_NHKH');
+            $this->nguoi_gd    = $_('nguoi_gd', 'NGUOI_GD');
+            $this->ghi_chu     = $_('ghi_chu', 'GHI_CHU');
+            $this->isKh        = (bool) $_('iskh', 'ISKH', true);
+            $this->ksd         = (bool) $_('ksd', 'KSD', false);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể tải khách hàng: ' . $e->getMessage());
+        }
+    }
+
+    public function render(): View
+    {
+        return view('catalog::so.dict.ardmkh-form', [
+            'nhomKhOptions' => $this->nhomKhOptions,
+            'plkhOptions'   => $this->plkhOptions,
+        ])->layout('catalog::layouts.app');
+    }
+
+    protected function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'ma_plkh1' => 'nullable|string|max:8',
+            'ma_plkh2' => 'nullable|string|max:8',
+            'ma_plkh3' => 'nullable|string|max:8',
+            'ma_nhkh'  => 'nullable|string|max:8',
+            'ma_nt'    => 'nullable|string|max:10',
+            'isKh'     => 'boolean',
+            'ksd'      => 'boolean',
+        ]);
+    }
+
+    protected function persist(string $procedureClass): void
+    {
+        $maKh = strtoupper(trim((string) $this->ma_kh));
+        $user = auth()->user()->name ?? 'system';
+
+        try {
+            $procedureClass::call([
+                'pMa_cty'       => \Diepxuan\Simba\SModel\SModel::CTY,
+                'pMa_kh'        => $maKh,
+                'pLoai'         => '1',
+                'pTen_kh'       => $this->ten_kh,
+                'pMa_so_thue'   => $this->ma_so_thue,
+                'pDia_chi'      => $this->dia_chi,
+                'pTel'          => $this->dien_thoai,
+                'pFax'          => $this->fax,
+                'pEmail'        => $this->email,
+                'pTk'           => $this->tk_cn,
+                'pMa_plkh1'     => $this->ma_plkh1,
+                'pMa_plkh2'     => $this->ma_plkh2,
+                'pMa_plkh3'     => $this->ma_plkh3,
+                'pMa_nhkh'      => $this->ma_nhkh,
+                'pNguoi_gd'     => $this->nguoi_gd,
+                'pGhi_chu'      => $this->ghi_chu,
+                'pIskh'         => 1,
+                'pIsncc'        => 0,
+                'pIsnv'         => 0,
+                'pKsd'          => $this->ksd ? 1 : 0,
+                'pLUser'        => $user,
+            ]);
+
+            $this->dispatch('khachhang-saved');
+            $this->dispatch('success', message: 'Đã lưu khách hàng ' . $maKh);
+            $this->redirect(simbaroute('so.dict.ardmkh'), navigate: true);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể lưu khách hàng: ' . $e->getMessage());
+        }
+    }
+
+    protected function loadDropdowns(): void
+    {
+        $this->nhomKhOptions = ArDmNhKh::orderBy('ma_nhkh')->get();
+        $this->plkhOptions[1] = ArDmPlKh::loai(1)->orderBy('ma_plkh')->get();
+        $this->plkhOptions[2] = ArDmPlKh::loai(2)->orderBy('ma_plkh')->get();
+        $this->plkhOptions[3] = ArDmPlKh::loai(3)->orderBy('ma_plkh')->get();
+    }
+}


### PR DESCRIPTION
## Tóm tắt

Giai đoạn C — SO Khách hàng canonical (task 374), khớp convention So\\Rpt\\Sorptbk01.

### Thay đổi
1. **So\\Dict\\ArdmkhForm** mới, kế thừa Po\\Dict\\ArdmkhForm canonical pattern
2. Route /so/dict/ardmkh/create + /so/dict/ardmkh/{id}/edit
3. loadDoiTuong(): getCustomers() + field() helper case-insensitive
4. persist(): đầy đủ tham số, pLoai='1', pKsd từ form checkbox, pIskh=1
5. View so/dict/ardmkh-form.blade.php — 3 section + dropdown nhóm KH
6. Banhang\\Kh Ahn hangForm mount() redirect về canonical (deprecation)

### Diff
- 4 files: +268/-6
- 2 new: So/Dict/Ar DarkhmForm.php + so/dict/ardm_kh-form.blade.php
- 2 mod: routes/web.php (2 routes+import) + Banhang/KhachhangForm phủ (redirect)