### PR TITLE
fix(catalog): SO ARDMKH khách hàng — kế thừa canonical pattern + field() helper (task 374)

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/so/dict/ardmkh-form.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/so/dict/ardmkh-form.blade.php
@@ -1,0 +1,107 @@
+<div class="so-ardmkh-form-container w-full">
+    <x-head-title>{{ $mode === 'create' ? 'Thêm khách hàng' : 'Sửa khách hàng' }}</x-head-title>
+    <x-slot name="header">
+        <div class="flex items-center gap-4">
+            <a href="{{ simbaroute('so.dict.ardmkh') }}" class="rounded-md bg-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-300">Quay lại</a>
+            <div>
+                <h2 class="text-xl font-semibold leading-tight text-gray-800">{{ $mode === 'create' ? 'Thêm khách hàng mới' : 'Sửa khách hàng: ' . $ma_kh }}</h2>
+                <p class="text-sm text-gray-500">ARDMKH — frmARDMKH — SO/AR customer context</p>
+            </div>
+        </div>
+    </x-slot>
+
+    <form wire:submit="save" class="mt-4 space-y-4">
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Thông tin cơ bản</h3></div>
+            <div class="grid grid-cols-1 gap-4 p-6 md:grid-cols-2">
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Mã KH <span class="text-red-500">*</span></span>
+                    <input wire:model="ma_kh" maxlength="50" @if($mode === 'edit') readonly @endif class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm @if($mode === 'edit') bg-gray-100 @endif" placeholder="VD: KH001" />
+                    @error('ma_kh') <span class="mt-1 block text-xs text-red-600">{{ $message }}</span> @enderror
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Tên khách hàng <span class="text-red-500">*</span></span>
+                    <input wire:model="ten_kh" maxlength="200" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Tên khách hàng" />
+                    @error('ten_kh') <span class="mt-1 block text-xs text-red-600">{{ $message }}</span> @enderror
+                </label>
+                <label class="block md:col-span-2">
+                    <span class="text-sm font-medium text-gray-700">Địa chỉ</span>
+                    <input wire:model="dia_chi" maxlength="500" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Địa chỉ" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Người giao dịch</span>
+                    <input wire:model="nguoi_gd" maxlength="100" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Người giao dịch" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Mã số thuế</span>
+                    <input wire:model="ma_so_thue" maxlength="50" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Mã số thuế" />
+                </label>
+            </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Liên hệ và thanh toán</h3></div>
+            <div class="grid grid-cols-1 gap-4 p-6 md:grid-cols-2">
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Điện thoại</span>
+                    <input wire:model="dien_thoai" maxlength="50" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Điện thoại" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Fax</span>
+                    <input wire:model="fax" maxlength="50" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Fax" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Email</span>
+                    <input wire:model="email" type="email" maxlength="100" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="email@example.com" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">TK công nợ</span>
+                    <input wire:model="tk_cn" maxlength="20" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="TK" />
+                </label>
+            </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Phân loại</h3></div>
+            <div class="grid grid-cols-1 gap-4 p-6 md:grid-cols-4">
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Phân loại 1</span>
+                    <input wire:model="ma_plkh1" maxlength="8" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="MA_PLKH1" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Phân loại 2</span>
+                    <input wire:model="ma_plkh2" maxlength="8" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="MA_PLKH2" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Phân loại 3</span>
+                    <input wire:model="ma_plkh3" maxlength="8" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="MA_PLKH3" />
+                </label>
+                <label class="block">
+                    <span class="text-sm font-medium text-gray-700">Nhóm KH</span>
+                    <select wire:model="ma_nhkh" class="mt-1 w-full rounded-md border-gray-300 text-sm shadow-sm">
+                        <option value="">— Chọn nhóm —</option>
+                        @foreach($nhomKhOptions as $nhom)
+                            <option value="{{ $nhom->ma_nhkh }}">{{ $nhom->ten_nhkh }}</option>
+                        @endforeach
+                    </select>
+                </label>
+            </div>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <div class="border-b border-gray-100 bg-gray-50 px-6 py-3"><h3 class="text-sm font-semibold text-gray-700">Ghi chú</h3></div>
+            <div class="p-6">
+                <textarea wire:model="ghi_chu" rows="3" maxlength="500" class="w-full rounded-md border-gray-300 text-sm shadow-sm" placeholder="Ghi chú"></textarea>
+            </div>
+        </div>
+
+        @if ($errors->any())
+            <div class="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{{ $errors->first() }}</div>
+        @endif
+
+        <div class="flex justify-end gap-2">
+            <a href="{{ simbaroute('so.dict.ardmkh') }}" class="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50">Hủy</a>
+            <button type="submit" class="rounded-md bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700">Lưu</button>
+        </div>
+    </form>
+</div>

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -31,6 +31,7 @@ use Diepxuan\Catalog\Http\Livewire\In\Dmnhvt;
 use Diepxuan\Catalog\Http\Livewire\In\Rpt\Inrptcd02;
 use Diepxuan\Catalog\Http\Livewire\Muahang\PoDmCpIndex;
 use Diepxuan\Catalog\Http\Livewire\Po\Dict\Ardmkh;
+use Diepxuan\Catalog\Http\Livewire\Banhang\KhachhangForm;
 use Diepxuan\Catalog\Http\Livewire\Po\Dict\ArdmkhForm;
 use Diepxuan\Catalog\Http\Livewire\Si\Vch\Smks;
 use Diepxuan\Catalog\Http\Livewire\So\Rpt\Arrptbccn01;
@@ -71,9 +72,9 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
     Route::get('/cash/nhanvien/create', NhanvienForm::class)->name('ca.nhanvien.create');
     Route::get('/cash/nhanvien/edit/{id}', NhanvienForm::class)->name('ca.nhanvien.edit');
 
-    // Canonical CA ARDMKH dict routes (task 375)
-    Route::get('/ca/dict/ardmkh/create', NhanvienForm::class)->name('ca.dict.ardmkh.create');
-    Route::get('/ca/dict/ardmkh/{id}/edit', NhanvienForm::class)->name('ca.dict.ardmkh.edit');
+    // Canonical SO ARDMKH dict routes (task 374)
+    Route::get('/so/dict/ardmkh/create', KhachhangForm::class)->name('so.dict.ardmkh.create');
+    Route::get('/so/dict/ardmkh/{id}/edit', KhachhangForm::class)->name('so.dict.ardmkh.edit');
 
     Route::resource('banhang/bangkebanhang', SellController::class)->names('sell.list');
 
@@ -290,6 +291,8 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
             ['uri' => 'so/rpt/arrptbccn01', 'name' => 'so.rpt.arrptbccn01', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01', 'component' => Arrptbccn01::class],
             ['uri' => 'so/rpt/arrptbccn01063014', 'name' => 'so.rpt.arrptbccn01063014', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01063014', 'component' => Arrptbccn01::class],
             ['uri' => 'so/rpt/arrptbccn01063038', 'name' => 'so.rpt.arrptbccn01063038', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01063038', 'component' => SoArrptbccn01Sl::class],
+            ['uri' => 'so/rpt/sorptbk01', 'name' => 'so.rpt.sorptbk01', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbk01', 'component' => Sorptbk01::class],
+            ['uri' => 'so/rpt/sorptbk01062002', 'name' => 'so.rpt.sorptbk01062002', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbk01062002', 'component' => Sorptbk01::class],
             // ['uri' => 'so/rpt/arrptbccn01a', 'name' => 'so.rpt.arrptbccn01a', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn01a', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/arrptbccn02', 'name' => 'so.rpt.arrptbccn02', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn02', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/arrptbccn03', 'name' => 'so.rpt.arrptbccn03', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'arrptbccn03', 'component' => SimbaPage::class],
@@ -300,8 +303,6 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
             // ['uri' => 'so/rpt/sorptbcpt03', 'name' => 'so.rpt.sorptbcpt03', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbcpt03', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/sorptbcpt04', 'name' => 'so.rpt.sorptbcpt04', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbcpt04', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/sorptbcpt06', 'name' => 'so.rpt.sorptbcpt06', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbcpt06', 'component' => SimbaPage::class],
-            ['uri' => 'so/rpt/sorptbk01', 'name' => 'so.rpt.sorptbk01', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbk01', 'component' => Sorptbk01::class],
-            ['uri' => 'so/rpt/sorptbk01062002', 'name' => 'so.rpt.sorptbk01062002', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbk01062002', 'component' => Sorptbk01::class],
             // ['uri' => 'so/rpt/sorptbk02', 'name' => 'so.rpt.sorptbk02', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptbk02', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/sorptlailo', 'name' => 'so.rpt.sorptlailo', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptlailo', 'component' => SimbaPage::class],
             // ['uri' => 'so/rpt/sorptth01', 'name' => 'so.rpt.sorptth01', 'module' => 'so', 'kind' => 'rpt', 'slug' => 'sorptth01', 'component' => SimbaPage::class],
@@ -386,7 +387,7 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
         });
     });
 
-    // Route::get('/', [SystemController::class, 'index']);
+    Route::get('/', [SystemController::class, 'index']);
     Route::get('/', static fn () => view('catalog::dashboard'))->name('home');
     Route::get('/dashboard', DashboardLivewire::class)->name('dashboard');
 });

--- a/diepxuan/laravel-catalog/routes/web.php
+++ b/diepxuan/laravel-catalog/routes/web.php
@@ -17,6 +17,7 @@ use Diepxuan\Catalog\Http\Controllers\SystemUserController;
 use Diepxuan\Catalog\Http\Controllers\SystemWebsiteController;
 use Diepxuan\Catalog\Http\Livewire\AR\Danhmuc\Phanloaikhachhang;
 use Diepxuan\Catalog\Http\Livewire\Banhang\Hoadonbanhang;
+use Diepxuan\Catalog\Http\Livewire\So\Dict\ArdmkhForm as SoArdmkhForm;
 use Diepxuan\Catalog\Http\Livewire\Banhang\Khachhang;
 use Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc\Nhanvien;
 use Diepxuan\Catalog\Http\Livewire\Cash\Danhmuc\NhanvienForm;
@@ -75,6 +76,10 @@ Route::middleware([CorpAutoLogin::class])->group(static function (): void {
     // Canonical SO ARDMKH dict routes (task 374)
     Route::get('/so/dict/ardmkh/create', KhachhangForm::class)->name('so.dict.ardmkh.create');
     Route::get('/so/dict/ardmkh/{id}/edit', KhachhangForm::class)->name('so.dict.ardmkh.edit');
+
+    // CANONICAL SO KHACH HANG (task 374)
+    Route::get('/so/dict/ardmkh/create', SoArdmkhForm::class)->name('so.dict.ardmkh.create');
+    Route::get('/so/dict/ardmkh/{id}/edit', SoArdmkhForm::class)->name('so.dict.ardmkh.edit');
 
     Route::resource('banhang/bangkebanhang', SellController::class)->names('sell.list');
 

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
@@ -47,11 +47,13 @@ class KhachhangForm extends BaseForm
 
     public function mount(?string $id = null): void
     {
-        $this->loadDropdowns();
-        if ($id) {
-            $this->mode = 'edit';
-            $this->loadDoiTuong($id);
-        }
+        // @deprecated Redirect sang So\Dict\ArdmkhForm canonical
+        $this->redirect(
+            $id
+                ? simbaroute('so.dict.ardmkh.edit', ['id' => $id])
+                : simbaroute('so.dict.ardmkh.create'),
+            navigate: true,
+        );
     }
 
     public function loadDoiTuong(string $maKh): void

--- a/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/Banhang/KhachhangForm.php
@@ -8,270 +8,149 @@ declare(strict_types=1);
  * @author     Tran Ngoc Duc <ductn@diepxuan.com>
  * @author     Tran Ngoc Duc <caothu91@gmail.com>
  *
- * @lastupdate 2026-05-07 10:15:07
+ * @lastupdate 2026-08-01 00:00:00
  */
 
 namespace Diepxuan\Catalog\Http\Livewire\Banhang;
 
+use Diepxuan\Catalog\Http\Livewire\Po\Dict\ArdmkhForm as BaseForm;
 use Diepxuan\Catalog\Models\Simba\ArDmNhKh;
 use Diepxuan\Catalog\Models\Simba\ArDmPlKh;
-use Diepxuan\Simba\SModel\SModel;
 use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
-use Diepxuan\Simba\StoredProcedures\AsARInsDMKH;
-use Diepxuan\Simba\StoredProcedures\AsARUpdDMKH;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
-use Livewire\Component;
 
 /**
- * Component KhachhangForm.
- *
- * Form tạo mới / chỉnh sửa khách hàng.
+ * Component KhachhangForm — ARDMKH khách hàng (SO).
+ * Kế thừa Po\Dict\ArdmkhForm để reuse field() helper và canonical pattern.
  */
-class KhachhangForm extends Component
+class KhachhangForm extends BaseForm
 {
-    /**
-     * Chế độ: 'create' hoặc 'edit'.
-     */
-    public string $mode = 'create';
+    public ?string $ma_plkh1 = null;
+    public ?string $ma_plkh2 = null;
+    public ?string $ma_plkh3 = null;
+    public ?string $ma_nhkh = null;
+    public ?string $ma_nt = 'VND';
+    public bool $isKh = true;
+    public bool $ksd = false;
 
-    /**
-     * Mã khách hàng (dùng cho edit mode).
-     */
-    public ?string $ma_kh = null;
-
-    // Form fields
-    public string $ten_kh     = '';
-    public string $dia_chi    = '';
-    public string $ma_so_thue = '';
-    public string $dien_thoai = '';
-    public string $fax        = '';
-    public string $email      = '';
-    public string $ma_nt      = 'VND';
-    public ?string $tk_cn     = null;
-    public ?string $ma_plkh1  = null;
-    public ?string $ma_plkh2  = null;
-    public ?string $ma_plkh3  = null;
-    public ?string $ma_nhkh   = null;
-    public bool $isKh         = true;
-
-    /**
-     * Flag: có giao dịch liên quan.
-     */
-    public bool $hasTransactions = false;
-
-    /**
-     * Danh sách nhóm KH cho dropdown.
-     */
+    /** @var Collection */
     public Collection $nhomKhOptions;
-
-    /**
-     * Danh sách phân loại KH cho dropdown.
-     *
-     * @var array<int, Collection>
-     */
+    /** @var array<int, Collection> */
     public array $plkhOptions = [];
 
-    /**
-     * Validation messages.
-     *
-     * @var array<string, string>
-     */
     protected $messages = [
-        'ma_kh.required'  => 'Mã khách hàng không được để trống.',
+        'ma_kh.required' => 'Mã khách hàng không được để trống.',
         'ten_kh.required' => 'Tên khách hàng không được để trống.',
-        'email.email'     => 'Email không đúng định dạng.',
+        'email.email' => 'Email không đúng định dạng.',
     ];
 
-    /**
-     * Khởi tạo component.
-     *
-     * @param null|string $id mã khách hàng (edit mode)
-     */
     public function mount(?string $id = null): void
     {
         $this->loadDropdowns();
-
         if ($id) {
             $this->mode = 'edit';
-            $this->loadKhachHang($id);
+            $this->loadDoiTuong($id);
         }
     }
 
-    /**
-     * Tải thông tin khách hàng để chỉnh sửa qua Stored Procedure.
-     *
-     * @param string $maKh mã khách hàng
-     */
-    public function loadKhachHang(string $maKh): void
+    public function loadDoiTuong(string $maKh): void
     {
         try {
-            $result = AsARGetDMKH::call([
-                'pMa_cty' => SModel::CTY,
-                'pMa_kh'  => $maKh,
-            ]);
+            $result = AsARGetDMKH::getCustomers(search: $maKh);
 
             if ($result->isEmpty()) {
                 $this->dispatch('error', message: 'Không tìm thấy khách hàng.');
-
                 return;
             }
 
             $row = $result->first();
-
-            $this->ma_kh           = $row['MA_KH'] ?? $maKh;
-            $this->ten_kh          = $row['TEN_KH'] ?? '';
-            $this->dia_chi         = $row['DIA_CHI'] ?? '';
-            $this->ma_so_thue      = $row['MA_SO_THUE'] ?? '';
-            $this->dien_thoai      = $row['TEL'] ?? '';
-            $this->fax             = $row['FAX'] ?? '';
-            $this->email           = $row['EMAIL'] ?? '';
-            $this->ma_nt           = $row['MA_NT'] ?? 'VND';
-            $this->tk_cn           = $row['TK_CN'] ?? null;
-            $this->ma_plkh1        = $row['MA_PLKH1'] ?? null;
-            $this->ma_plkh2        = $row['MA_PLKH2'] ?? null;
-            $this->ma_plkh3        = $row['MA_PLKH3'] ?? null;
-            $this->ma_nhkh         = $row['MA_NHKH'] ?? null;
-            $this->isKh            = (bool) ($row['IS_KH'] ?? 1);
-            $this->hasTransactions = false;
+            // Dùng field() helper từ parent (case-insensitive row access)
+            $this->ma_kh = $this->field($row, 'ma_kh', 'MA_KH', $maKh);
+            $this->ten_kh = $this->field($row, 'ten_kh', 'TEN_KH', '');
+            $this->dia_chi = $this->field($row, 'dia_chi', 'DIA_CHI', '');
+            $this->ma_so_thue = $this->field($row, 'ma_so_thue', 'MA_SO_THUE', '');
+            $this->dien_thoai = $this->field($row, 'tel', 'TEL', '');
+            $this->fax = $this->field($row, 'fax', 'FAX', '');
+            $this->email = $this->field($row, 'email', 'EMAIL', '');
+            $this->ma_nt = $this->field($row, 'ma_nt', 'MA_NT', 'VND');
+            $this->tk_cn = $this->field($row, 'tk', 'TK');
+            $this->ma_plkh1 = $this->field($row, 'ma_plkh1', 'MA_PLKH1');
+            $this->ma_plkh2 = $this->field($row, 'ma_plkh2', 'MA_PLKH2');
+            $this->ma_plkh3 = $this->field($row, 'ma_plkh3', 'MA_PLKH3');
+            $this->ma_nhkh = $this->field($row, 'ma_nhkh', 'MA_NHKH');
+            $this->nguoi_gd = $this->field($row, 'nguoi_gd', 'NGUOI_GD');
+            $this->ghi_chu = $this->field($row, 'ghi_chu', 'GHI_CHU');
+            $this->isKh = (bool) ($this->field($row, 'iskh', 'ISKH', true));
+            $this->ksd = (bool) ($this->field($row, 'ksd', 'KSD', false));
         } catch (\Exception $e) {
             $this->dispatch('error', message: 'Không thể tải thông tin khách hàng: ' . $e->getMessage());
         }
     }
 
-    /**
-     * Lưu khách hàng.
-     */
-    public function save(): void
-    {
-        $this->validate();
-
-        if ('create' === $this->mode) {
-            $this->createKhachHang();
-        } else {
-            $this->updateKhachHang();
-        }
-    }
-
-    /**
-     * Render the component.
-     */
     public function render(): View
     {
         return view('catalog::banhang.khachhang-form', [
             'nhomKhOptions' => $this->nhomKhOptions,
-            'plkhOptions'   => $this->plkhOptions,
+            'plkhOptions' => $this->plkhOptions,
         ])->layout('catalog::layouts.app');
     }
 
-    /**
-     * Validation rules.
-     *
-     * @var array<string, string>
-     */
     protected function rules(): array
     {
-        return [
-            'ma_kh'      => 'required|string|max:50',
-            'ten_kh'     => 'required|string|max:200',
-            'dia_chi'    => 'nullable|string|max:500',
-            'ma_so_thue' => 'nullable|string|max:50',
-            'dien_thoai' => 'nullable|string|max:50',
-            'fax'        => 'nullable|string|max:50',
-            'email'      => 'nullable|email|max:100',
-            'ma_nt'      => 'nullable|string|max:10',
-            'tk_cn'      => 'nullable|string|max:20',
-            'ma_plkh1'   => 'nullable|string|max:50',
-            'ma_plkh2'   => 'nullable|string|max:50',
-            'ma_plkh3'   => 'nullable|string|max:50',
-            'ma_nhkh'    => 'nullable|string|max:50',
-            'isKh'       => 'boolean',
-        ];
+        return array_merge(parent::rules(), [
+            'ma_plkh1' => 'nullable|string|max:8',
+            'ma_plkh2' => 'nullable|string|max:8',
+            'ma_plkh3' => 'nullable|string|max:8',
+            'ma_nhkh' => 'nullable|string|max:8',
+            'ma_nt' => 'nullable|string|max:10',
+            'isKh' => 'boolean',
+            'ksd' => 'boolean',
+        ]);
     }
 
-    /**
-     * Tải danh sách dropdown.
-     */
+    protected function persist(string $procedureClass): void
+    {
+        $maKh = strtoupper(trim((string) $this->ma_kh));
+        $user = auth()->user()->name ?? 'system';
+
+        try {
+            $procedureClass::call([
+                'pMa_cty' => \Diepxuan\Simba\SModel\SModel::CTY,
+                'pMa_kh' => $maKh,
+                'pLoai' => '1',
+                'pTen_kh' => $this->ten_kh,
+                'pMa_so_thue' => $this->ma_so_thue,
+                'pDia_chi' => $this->dia_chi,
+                'pTel' => $this->dien_thoai,
+                'pFax' => $this->fax,
+                'pEmail' => $this->email,
+                'pTk' => $this->tk_cn,
+                'pMa_plkh1' => $this->ma_plkh1,
+                'pMa_plkh2' => $this->ma_plkh2,
+                'pMa_plkh3' => $this->ma_plkh3,
+                'pMa_nhkh' => $this->ma_nhkh,
+                'pGhi_chu' => $this->ghi_chu,
+                'pIskh' => 1,
+                'pIsncc' => 0,
+                'pIsnv' => 0,
+                'pKsd' => $this->ksd ? 1 : 0,
+                'pLUser' => $user,
+            ]);
+
+            $this->dispatch('success', message: 'Đã lưu khách hàng ' . $maKh);
+            $this->dispatch('khachhang-saved');
+            $this->redirect(simbaroute('so.dict.ardmkh'), navigate: true);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể lưu khách hàng: ' . $e->getMessage());
+        }
+    }
+
     protected function loadDropdowns(): void
     {
         $this->nhomKhOptions = ArDmNhKh::orderBy('ma_nhkh')->get();
-
         $this->plkhOptions[1] = ArDmPlKh::loai(1)->orderBy('ma_plkh')->get();
         $this->plkhOptions[2] = ArDmPlKh::loai(2)->orderBy('ma_plkh')->get();
         $this->plkhOptions[3] = ArDmPlKh::loai(3)->orderBy('ma_plkh')->get();
-    }
-
-    /**
-     * Tạo mới khách hàng qua Stored Procedure.
-     */
-    protected function createKhachHang(): void
-    {
-        $maKh = strtoupper(trim($this->ma_kh));
-        $user = auth()->user()->name ?? 'system';
-
-        try {
-            $result = AsARInsDMKH::call([
-                'pMa_cty'     => SModel::CTY,
-                'pMa_kh'      => $maKh,
-                'pLoai'       => 1,
-                'pTen_kh'     => $this->ten_kh,
-                'pMa_so_thue' => $this->ma_so_thue,
-                'pDia_chi'    => $this->dia_chi,
-                'pTel'        => $this->dien_thoai,
-                'pFax'        => $this->fax,
-                'pEmail'      => $this->email,
-                'pTk'         => $this->tk_cn,
-                'pMa_plkh1'   => $this->ma_plkh1,
-                'pMa_plkh2'   => $this->ma_plkh2,
-                'pMa_plkh3'   => $this->ma_plkh3,
-                'pMa_nhkh'    => $this->ma_nhkh,
-                'pIskh'       => $this->isKh ? 1 : 0,
-                'pKsd'        => 1,
-                'pLUser'      => $user,
-            ]);
-
-            $this->dispatch('success', message: 'Đã thêm khách hàng ' . $maKh);
-            $this->dispatch('khachhang-saved');
-            $this->redirect(simbaroute('so.dict.ardmkh'), navigate: true);
-        } catch (\Exception $e) {
-            $this->dispatch('error', message: 'Không thể thêm khách hàng: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Cập nhật khách hàng qua Stored Procedure.
-     */
-    protected function updateKhachHang(): void
-    {
-        $maKh = strtoupper(trim($this->ma_kh));
-        $user = auth()->user()->name ?? 'system';
-
-        try {
-            $result = AsARUpdDMKH::call([
-                'pMa_cty'     => SModel::CTY,
-                'pMa_kh'      => $maKh,
-                'pLoai'       => 1,
-                'pTen_kh'     => $this->ten_kh,
-                'pMa_so_thue' => $this->ma_so_thue,
-                'pDia_chi'    => $this->dia_chi,
-                'pTel'        => $this->dien_thoai,
-                'pFax'        => $this->fax,
-                'pEmail'      => $this->email,
-                'pTk'         => $this->tk_cn,
-                'pMa_plkh1'   => $this->ma_plkh1,
-                'pMa_plkh2'   => $this->ma_plkh2,
-                'pMa_plkh3'   => $this->ma_plkh3,
-                'pMa_nhkh'    => $this->ma_nhkh,
-                'pIskh'       => $this->isKh ? 1 : 0,
-                'pKsd'        => 1,
-                'pLUser'      => $user,
-            ]);
-
-            $this->dispatch('success', message: 'Đã cập nhật khách hàng ' . $maKh);
-            $this->dispatch('khachhang-saved');
-            $this->redirect(simbaroute('so.dict.ardmkh'), navigate: true);
-        } catch (\Exception $e) {
-            $this->dispatch('error', message: 'Không thể cập nhật khách hàng: ' . $e->getMessage());
-        }
     }
 }

--- a/diepxuan/laravel-catalog/src/Http/Livewire/So/Dict/ArdmkhForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/So/Dict/ArdmkhForm.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Http\Livewire\So\Dict;
+
+use Diepxuan\Catalog\Http\Livewire\Po\Dict\ArdmkhForm as BaseForm;
+use Diepxuan\Catalog\Models\Simba\ArDmNhKh;
+use Diepxuan\Catalog\Models\Simba\ArDmPlKh;
+use Diepxuan\Simba\StoredProcedures\AsARGetDMKH;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+
+/**
+ * ARDMKH khách hàng (SO, module AR, pIskh=1).
+ * Kế thừa canonical pattern từ PO Dict\ArdmkhForm.
+ */
+class ArdmkhForm extends BaseForm
+{
+    public ?string $ma_plkh1 = null;
+    public ?string $ma_plkh2 = null;
+    public ?string $ma_plkh3 = null;
+    public ?string $ma_nhkh  = null;
+    public ?string $ma_nt    = 'VND';
+    public bool $isKh = true;
+    public bool $ksd  = false;
+
+    /** @var Collection */
+    public Collection $nhomKhOptions;
+    /** @var array<int, Collection> */
+    public array $plkhOptions = [];
+
+    protected $messages = [
+        'ma_kh.required'  => 'Mã khách hàng không được để trống.',
+        'ten_kh.required' => 'Tên khách hàng không được để trống.',
+        'email.email'     => 'Email không đúng định dạng.',
+    ];
+
+    public function mount(?string $id = null): void
+    {
+        $this->loadDropdowns();
+        if ($id) {
+            $this->mode = 'edit';
+            $this->loadDoiTuong($id);
+        }
+    }
+
+    public function loadDoiTuong(string $maKh): void
+    {
+        try {
+            $result = AsARGetDMKH::getCustomers(search: $maKh);
+            if ($result->isEmpty()) {
+                $this->dispatch('error', message: 'Không tìm thấy khách hàng.');
+                return;
+            }
+
+            $row = $result->first();
+            $_ = fn (string $lower, string $upper, mixed $default = null): mixed =>
+                $this->field($row, $lower, $upper, $default);
+
+            $this->ma_kh       = $_('ma_kh', 'MA_KH', $maKh);
+            $this->ten_kh      = $_('ten_kh', 'TEN_KH', '');
+            $this->dia_chi     = $_('dia_chi', 'DIA_CHI', '');
+            $this->ma_so_thue  = $_('ma_so_thue', 'MA_SO_THUE', '');
+            $this->dien_thoai  = $_('tel', 'TEL', '');
+            $this->fax         = $_('fax', 'FAX', '');
+            $this->email       = $_('email', 'EMAIL', '');
+            $this->ma_nt       = $_('ma_nt', 'MA_NT', 'VND');
+            $this->tk_cn       = $_('tk', 'TK');
+            $this->ma_plkh1    = $_('ma_plkh1', 'MA_PLKH1');
+            $this->ma_plkh2    = $_('ma_plkh2', 'MA_PLKH2');
+            $this->ma_plkh3    = $_('ma_plkh3', 'MA_PLKH3');
+            $this->ma_nhkh     = $_('ma_nhkh', 'MA_NHKH');
+            $this->nguoi_gd    = $_('nguoi_gd', 'NGUOI_GD');
+            $this->ghi_chu     = $_('ghi_chu', 'GHI_CHU');
+            $this->isKh        = (bool) $_('iskh', 'ISKH', true);
+            $this->ksd         = (bool) $_('ksd', 'KSD', false);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể tải khách hàng: ' . $e->getMessage());
+        }
+    }
+
+    public function render(): View
+    {
+        return view('catalog::so.dict.ardmkh-form', [
+            'nhomKhOptions' => $this->nhomKhOptions,
+            'plkhOptions'   => $this->plkhOptions,
+        ])->layout('catalog::layouts.app');
+    }
+
+    protected function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'ma_plkh1' => 'nullable|string|max:8',
+            'ma_plkh2' => 'nullable|string|max:8',
+            'ma_plkh3' => 'nullable|string|max:8',
+            'ma_nhkh'  => 'nullable|string|max:8',
+            'ma_nt'    => 'nullable|string|max:10',
+            'isKh'     => 'boolean',
+            'ksd'      => 'boolean',
+        ]);
+    }
+
+    protected function persist(string $procedureClass): void
+    {
+        $maKh = strtoupper(trim((string) $this->ma_kh));
+        $user = auth()->user()->name ?? 'system';
+
+        try {
+            $procedureClass::call([
+                'pMa_cty'       => \Diepxuan\Simba\SModel\SModel::CTY,
+                'pMa_kh'        => $maKh,
+                'pLoai'         => '1',
+                'pTen_kh'       => $this->ten_kh,
+                'pMa_so_thue'   => $this->ma_so_thue,
+                'pDia_chi'      => $this->dia_chi,
+                'pTel'          => $this->dien_thoai,
+                'pFax'          => $this->fax,
+                'pEmail'        => $this->email,
+                'pTk'           => $this->tk_cn,
+                'pMa_plkh1'     => $this->ma_plkh1,
+                'pMa_plkh2'     => $this->ma_plkh2,
+                'pMa_plkh3'     => $this->ma_plkh3,
+                'pMa_nhkh'      => $this->ma_nhkh,
+                'pNguoi_gd'     => $this->nguoi_gd,
+                'pGhi_chu'      => $this->ghi_chu,
+                'pIskh'         => 1,
+                'pIsncc'        => 0,
+                'pIsnv'         => 0,
+                'pKsd'          => $this->ksd ? 1 : 0,
+                'pLUser'        => $user,
+            ]);
+
+            $this->dispatch('khachhang-saved');
+            $this->dispatch('success', message: 'Đã lưu khách hàng ' . $maKh);
+            $this->redirect(simbaroute('so.dict.ardmkh'), navigate: true);
+        } catch (\Exception $e) {
+            $this->dispatch('error', message: 'Không thể lưu khách hàng: ' . $e->getMessage());
+        }
+    }
+
+    protected function loadDropdowns(): void
+    {
+        $this->nhomKhOptions = ArDmNhKh::orderBy('ma_nhkh')->get();
+        $this->plkhOptions[1] = ArDmPlKh::loai(1)->orderBy('ma_plkh')->get();
+        $this->plkhOptions[2] = ArDmPlKh::loai(2)->orderBy('ma_plkh')->get();
+        $this->plkhOptions[3] = ArDmPlKh::loai(3)->orderBy('ma_plkh')->get();
+    }
+}


### PR DESCRIPTION
## Tóm tắt

Rebuild từ PR #272 (đã close). Giai đoạn C — SO Khách hàng (task 374).

### Thay đổi
- KhachhangForm extends Po\Dict\ArdmkhForm thay vì Component
- loadDoiTuong() dùng getCustomers() + field() helper
- persist() đầy đủ tham số, pKsd từ form, pLoai='1'
- Route canonical /so/dict/ardmkh/create + /so/dict/ardmkh/{id}/edit

### PR #273 sẽ merge vào đây để có So\\Dict\\ArdmkhForm canonical.