### PR TITLE
fix(catalog): Timer predefined period tinh lai theo nam lam viec

### DIFF
--- a/diepxuan/laravel-catalog/docs/TIMER_SYSTEM.md
+++ b/diepxuan/laravel-catalog/docs/TIMER_SYSTEM.md
@@ -279,7 +279,11 @@ SESSION_DRIVER=file  # or database, redis
 
 ### Date range sai năm
 
-**Check**: Year session key set correctly?
+Period định sẵn (tháng/quý/nửa năm/cả năm) **luôn tính lại** theo năm làm việc
+hiện tại (`session('year')`) mỗi lần đọc, nên đổi năm ở header phản ánh ngay
+vào range. Chỉ **custom mode** (`c`) giữ cache `from`/`to` do user nhập.
+
+Nếu range vẫn sai năm, check year session key:
 ```php
 // In controller or middleware
 session(['year' => 2026]);

--- a/diepxuan/laravel-catalog/src/Config/TimerConfig.php
+++ b/diepxuan/laravel-catalog/src/Config/TimerConfig.php
@@ -57,8 +57,10 @@ class TimerConfig
             $from   = session('timeStart');
             $to     = session('timeEnd');
 
-            // Nếu chưa có session, tính toán mặc định
-            if (!$from || !$to) {
+            // Period định sẵn (tháng/quý/nửa năm/cả năm) luôn tính lại theo
+            // năm làm việc hiện tại (session('year')), để đổi năm ở header
+            // phản ánh ngay vào range. Chỉ custom mode giữ cache from/to.
+            if (!$from || !$to || !self::isCustom($timeId)) {
                 $result = self::calculateTimeRange($timeId);
                 $from   = $result['from'];
                 $to     = $result['to'];

--- a/diepxuan/laravel-catalog/tests/Unit/Config/TimerConfigWorkingYearTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Config/TimerConfigWorkingYearTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Tests\Unit\Config;
+
+use Diepxuan\Catalog\Config\TimerConfig;
+use Illuminate\Support\Facades\Session;
+
+/**
+ * Pin behavior: predefined period (thang/quy/nua nam/ca nam) luon tinh lai
+ * theo nam lam viec hien tai (session('year')); chi custom mode giu cache.
+ *
+ * @coversDefaultClass \Diepxuan\Catalog\Config\TimerConfig
+ */
+final class TimerConfigWorkingYearTest extends \Tests\TestCase
+{
+    /**
+     * @covers ::timer
+     */
+    public function testPredefinedPeriodRecalculatesWhenWorkingYearChanges(): void
+    {
+        Session::start();
+
+        // Luu timer thang 8 theo nam mac dinh (nam he thong)
+        TimerConfig::timer(['id' => 't08']);
+
+        // Sep doi nam lam viec sang 2025 qua header
+        session(['year' => 2025]);
+
+        $timer = TimerConfig::timer();
+
+        self::assertSame('t08', $timer['id']);
+        self::assertSame('2025-08-01', $timer['from']);
+        self::assertSame('2025-08-31', $timer['to']);
+    }
+
+    /**
+     * @covers ::timer
+     */
+    public function testYearPeriodFollowsWorkingYear(): void
+    {
+        Session::start();
+
+        session(['year' => 2025]);
+        TimerConfig::timer(['id' => 'y']);
+
+        // Doi nam lam viec -> range phai doi theo
+        session(['year' => 2026]);
+
+        $timer = TimerConfig::timer();
+
+        self::assertSame('y', $timer['id']);
+        self::assertSame('2026-01-01', $timer['from']);
+        self::assertSame('2026-12-31', $timer['to']);
+    }
+
+    /**
+     * @covers ::timer
+     */
+    public function testCustomModeKeepsUserRangeAfterYearChange(): void
+    {
+        Session::start();
+
+        TimerConfig::timer(['id' => 'c', 'from' => '2026-03-01', 'to' => '2026-03-31']);
+
+        session(['year' => 2025]);
+
+        $timer = TimerConfig::timer();
+
+        self::assertSame('c', $timer['id']);
+        self::assertSame('2026-03-01', $timer['from']);
+        self::assertSame('2026-03-31', $timer['to']);
+    }
+}


### PR DESCRIPTION
## Bug

Sau khi chon nam lam viec o header (vd 2025), form bao cao co Timer van hien thi range nam cu (2026).

## Root cause

Read mode `TimerConfig::timer()` chi tinh range khi session **chua co** `timeStart`/`timeEnd`. Sau khi doi nam lam viec o header (`session('year')`), range cu van duoc giu lai trong session -> form hien thi nam cu.

Khong phai regression tu #279/#280 — gap thiet ke co san tu commit `32fb215d5`/`ede2aa802`.

## Fix

Period dinh san (thang/quy/nua nam/ca nam) **luon tinh lai** theo `session('year')` hien tai moi lan doc. Chi **custom mode** (`c`) giu cache `from`/`to` do user nhap.

## Thay doi

- `TimerConfig::timer()` read mode: dieu kien tinh lai them `!isCustom(timeId)`.
- Test moi `TimerConfigWorkingYearTest` 3 case: doi nam -> range doi theo, year period follow working year, custom mode giu range user nhap.
- Cap nhat `docs/TIMER_SYSTEM.md` phan troubleshooting.

## Verification

- `php -l` sach.
- `TimerConfigWorkingYearTest` 3/3 pass, `TimerConfigTest` 10/10 pass (tong 13/13, 143 assertions).
- `CatalogServiceTimerTest` giu nguyen 9 error stale co san tu truoc fix (goi method `getTimer`/`setTimer` da bi xoa) — khong phai regression.