### PR TITLE
perf(catalog): Sorptbk01 + INDMVT client-side, subsequence search dung chung

### DIFF
--- a/diepxuan/laravel-catalog/resources/views/components/ardmkh-list.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/ardmkh-list.blade.php
@@ -130,32 +130,21 @@
 
 
                 recompute() {
-                    const needle = this.normalize(this.search);
+                    const needle = window.PortalSearch.normalize(this.search);
                     this.filtered = !needle
                         ? this.rows.slice()
                         : this.rows.filter((row) => {
                             const haystack = [
                                 row.ma_kh, row.ten_kh, row.dia_chi,
                                 row.tel, row.ma_so_thue, row.nguoi_gd,
-                            ].map((v) => this.normalize(v || '')).join(' ');
-                            return haystack.indexOf(needle) !== -1;
+                            ].map((v) => window.PortalSearch.normalize(v || '')).join(' ');
+                            return window.PortalSearch.matchesSubsequence(haystack, needle);
                         });
 
                     const total = this.rows.length;
                     this.resultLabel = this.filtered.length === total
                         ? total + ' kết quả'
                         : this.filtered.length + ' / ' + total + ' kết quả';
-                },
-
-                normalize(value) {
-                    if (!value) return '';
-                    return String(value)
-                        .normalize('NFD')
-                        .replace(/[\u0300-\u036f]/g, '')
-                        .replace(/[đĐ]/g, (c) => c === 'đ' ? 'd' : 'D')
-                        .toLowerCase()
-                        .replace(/\s+/g, ' ')
-                        .trim();
                 },
 
                 truncate(value, max) {

--- a/diepxuan/laravel-catalog/resources/views/components/input-chiphi.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-chiphi.blade.php
@@ -97,13 +97,7 @@
                     },
 
                     normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
+                        return window.PortalSearch.normalize(value);
                     },
 
                     optionId(index) {
@@ -195,7 +189,7 @@
                             return this.cpList.slice(0, 20);
                         }
 
-                        return this.cpList.filter((cp) => cp._search.includes(q)).slice(0, 20);
+                        return this.cpList.filter((cp) => window.PortalSearch.matchesSubsequence(cp._search, q)).slice(0, 20);
                     }
                 };
             };

--- a/diepxuan/laravel-catalog/resources/views/components/input-httt.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-httt.blade.php
@@ -94,13 +94,7 @@
                     },
 
                     normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
+                        return window.PortalSearch.normalize(value);
                     },
 
                     optionId(index) {
@@ -192,7 +186,7 @@
                             return this.htttList.slice(0, 20);
                         }
 
-                        return this.htttList.filter((ht) => ht._search.includes(q)).slice(0, 20);
+                        return this.htttList.filter((ht) => window.PortalSearch.matchesSubsequence(ht._search, q)).slice(0, 20);
                     }
                 };
             };

--- a/diepxuan/laravel-catalog/resources/views/components/input-indmkho.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-indmkho.blade.php
@@ -81,13 +81,7 @@
                     },
 
                     normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
+                        return window.PortalSearch.normalize(value);
                     },
 
                     optionId(index) {
@@ -169,7 +163,7 @@
                             return this.items.slice(0, 20);
                         }
 
-                        return this.items.filter((item) => item._search.includes(q)).slice(0, 20);
+                        return this.items.filter((item) => window.PortalSearch.matchesSubsequence(item._search, q)).slice(0, 20);
                     }
                 };
             };

--- a/diepxuan/laravel-catalog/resources/views/components/input-indmvt.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-indmvt.blade.php
@@ -81,13 +81,7 @@
                     },
 
                     normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
+                        return window.PortalSearch.normalize(value);
                     },
 
                     optionId(index) {
@@ -169,7 +163,7 @@
                             return this.items.slice(0, 20);
                         }
 
-                        return this.items.filter((item) => item._search.includes(q)).slice(0, 20);
+                        return this.items.filter((item) => window.PortalSearch.matchesSubsequence(item._search, q)).slice(0, 20);
                     }
                 };
             };

--- a/diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-khachhang.blade.php
@@ -78,9 +78,8 @@
                     initComponent() {
                         this.customers = this.customers.map((kh) => ({
                             ...kh,
-                            _ten_kh: this.normalizeText(kh.ten_kh),
-                            _abbrev: this.abbreviate(kh.ten_kh),
-                            _search: this.normalizeText([kh.ma_kh, kh.ten_kh, kh.dia_chi, kh.tel].join(' ')),
+                            _ten_kh: window.PortalSearch.normalize(kh.ten_kh),
+                            _search: window.PortalSearch.normalize([kh.ma_kh, kh.ten_kh, kh.dia_chi, kh.tel].join(' ')),
                         }));
 
                         this.filtered = this.filterCustomers(this.search);
@@ -92,30 +91,6 @@
                                 this.highlightedIndex = -1;
                             }, 150);
                         });
-                    },
-
-                    normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
-                    },
-
-                    abbreviate(value) {
-                        const normalized = this.normalizeText(value);
-                        if (!normalized) {
-                            return '';
-                        }
-
-                        const words = normalized
-                            .split(/\s+/)
-                            .filter((word) => /^[a-z0-9]/.test(word));
-                        const initials = words.map((word) => word[0]).join('');
-
-                        return initials + ' ' + words.map((word) => word).join(' ');
                     },
 
                     optionId(index) {
@@ -134,7 +109,7 @@
                             return;
                         }
 
-                        const q = this.normalizeText(this.search);
+                        const q = window.PortalSearch.normalize(this.search);
                         if (!q) {
                             this.selectedValue = null;
                             this.$wire.set('value', null);
@@ -147,9 +122,9 @@
                             return;
                         }
 
-                        const abbrevMatches = this.customers.filter((kh) => kh._abbrev.includes(q));
-                        if (1 === abbrevMatches.length) {
-                            this.selectCustomer(abbrevMatches[0]);
+                        const sequenceMatches = this.customers.filter((kh) => window.PortalSearch.matchesSubsequence(kh._search, q));
+                        if (1 === sequenceMatches.length) {
+                            this.selectCustomer(sequenceMatches[0]);
                             return;
                         }
 
@@ -159,7 +134,7 @@
                             return;
                         }
 
-                        const contains = this.customers.filter((kh) => kh._ten_kh.includes(q));
+                        const contains = this.customers.filter((kh) => kh._search.includes(q));
                         if (1 === contains.length) {
                             this.selectCustomer(contains[0]);
                             return;
@@ -229,28 +204,29 @@
                     },
 
                     filterCustomers(query) {
-                        const q = this.normalizeText(query);
+                        const q = window.PortalSearch.normalize(query);
                         if (!q) {
                             return this.customers.slice(0, 20);
                         }
 
                         const exactName = this.customers.filter((kh) => kh._ten_kh === q);
-                        const abbrev = this.customers.filter(
-                            (kh) => kh._ten_kh !== q && kh._abbrev.includes(q)
+                        const contains = this.customers.filter(
+                            (kh) => kh._ten_kh !== q
+                                && kh._search.includes(q)
                         );
                         const startsWith = this.customers.filter(
                             (kh) => kh._ten_kh !== q
-                                && !kh._abbrev.includes(q)
+                                && !kh._search.includes(q)
                                 && kh._ten_kh.startsWith(q)
                         );
-                        const contains = this.customers.filter(
+                        const sequence = this.customers.filter(
                             (kh) => kh._ten_kh !== q
-                                && !kh._abbrev.includes(q)
+                                && !kh._search.includes(q)
                                 && !kh._ten_kh.startsWith(q)
-                                && kh._search.includes(q)
+                                && window.PortalSearch.matchesSubsequence(kh._search, q)
                         );
 
-                        return [...exactName, ...abbrev, ...startsWith, ...contains].slice(0, 20);
+                        return [...exactName, ...contains, ...startsWith, ...sequence].slice(0, 20);
                     }
                 };
             };

--- a/diepxuan/laravel-catalog/resources/views/components/input-ngoaite.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-ngoaite.blade.php
@@ -95,13 +95,7 @@
                     },
 
                     normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
+                        return window.PortalSearch.normalize(value);
                     },
 
                     optionId(index) {
@@ -193,7 +187,7 @@
                             return this.ntList.slice(0, 20);
                         }
 
-                        return this.ntList.filter((nt) => nt._search.includes(q)).slice(0, 20);
+                        return this.ntList.filter((nt) => window.PortalSearch.matchesSubsequence(nt._search, q)).slice(0, 20);
                     }
                 };
             };

--- a/diepxuan/laravel-catalog/resources/views/components/input-taikhoan.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/components/input-taikhoan.blade.php
@@ -146,13 +146,7 @@
                     },
 
                     normalizeText(value) {
-                        return String(value || '')
-                            .normalize('NFD')
-                            .replace(/[\u0300-\u036f]/g, '')
-                            .replace(/[đĐ]/g, 'd')
-                            .toLowerCase()
-                            .trim()
-                            .replace(/\s+/g, ' ');
+                        return window.PortalSearch.normalize(value);
                     },
 
                     openDropdown() {
@@ -234,7 +228,7 @@
                         if (!query) return base.slice(0, 10);
 
                         const q = this.normalizeText(query);
-                        return base.filter(acc => acc._search.includes(q)).slice(0, 10);
+                        return base.filter(acc => window.PortalSearch.matchesSubsequence(acc._search, q)).slice(0, 10);
                     }
                 }
             }

--- a/diepxuan/laravel-catalog/resources/views/in/dict/indmvt-list.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/in/dict/indmvt-list.blade.php
@@ -15,7 +15,8 @@
         selectRow(el) {
             const ds = el.dataset;
             const field = (name) => {
-                const cell = el.querySelector('[data-field="' + name + '"]');
+                const cell = Array.from(el.querySelectorAll('[data-field]'))
+                    .find((node) => node.dataset.field === name);
                 return cell ? (cell.textContent || '').trim() : '';
             };
 

--- a/diepxuan/laravel-catalog/resources/views/in/dict/indmvt-list.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/in/dict/indmvt-list.blade.php
@@ -1,4 +1,52 @@
-<div class="space-y-3">
+<div class="space-y-3"
+    x-data="{
+        search: '',
+        resultLabel: @js(count($rows) . ' vật tư'),
+        selected: false,
+        detail: {},
+        matchesRow(el) {
+            return window.PortalSearch.matchesSubsequence(el.dataset.search, this.search);
+        },
+        updateResultLabel() {
+            const rows = Array.from(this.$refs.rows.querySelectorAll('tr[data-search]'));
+            const visible = rows.filter((row) => row.style.display !== 'none').length;
+            this.resultLabel = visible + ' / ' + rows.length + ' vật tư';
+        },
+        selectRow(el) {
+            const ds = el.dataset;
+            const field = (name) => {
+                const cell = el.querySelector('[data-field="' + name + '"]');
+                return cell ? (cell.textContent || '').trim() : '';
+            };
+
+            this.detail = {
+                ma_vt: field('ma_vt'),
+                ten_vt: field('ten_vt'),
+                dvt: field('dvt'),
+                ma_nhvt: field('ma_nhvt'),
+                ma_kho: field('ma_kho'),
+                ma_vitri: field('ma_vitri'),
+                tk_vt: field('tk_vt'),
+                tk_dt: field('tk_dt'),
+                tk_gv: field('tk_gv'),
+                ton_kho: field('ton_kho'),
+                loai: field('loai'),
+                gia_ton: field('gia_ton'),
+                ksd: field('ksd'),
+                ma_thue: ds.maThue || '',
+                part_no: ds.partNo || '',
+                nha_sx: ds.nhaSx || '',
+                nha_pp: ds.nhaPp || '',
+                nuoc_sx: ds.nuocSx || '',
+            };
+            this.selected = true;
+        },
+        onDeleted() {
+            this.selected = false;
+            this.detail = {};
+        },
+    }"
+    @indmvt-list.deleted.window="onDeleted()">
     @if ($errorMessage)
         <div class="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
             {{ $errorMessage }}
@@ -16,28 +64,29 @@
         <div class="relative w-full max-w-xl">
             <input
                 type="text"
-                wire:model.live.debounce.300ms="search"
+                x-model="search"
+                @input="updateResultLabel()"
                 placeholder="Tìm theo mã, tên, nhóm, ĐVT, tài khoản vật tư..."
                 class="w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
             />
-            @if ($search)
-                <button
-                    type="button"
-                    wire:click="$set('search', '')"
-                    class="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400 hover:text-gray-600"
-                >
-                    Xóa
-                </button>
-            @endif
+            <button
+                type="button"
+                x-show="search.length > 0"
+                @click="search = ''; updateResultLabel()"
+                class="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-400 hover:text-gray-600"
+                style="display: none;"
+            >
+                Xóa
+            </button>
         </div>
-        <span class="text-xs text-gray-500">{{ count($displayRows) }} / {{ count($rows) }} vật tư</span>
-        <button
-            type="button"
-            wire:click="openCreate"
-            class="rounded-md bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700"
-        >
-            Thêm vật tư
-        </button>
+        <span class="text-xs text-gray-500" x-text="resultLabel"></span>
+                        <button
+                            type="button"
+                            wire:click="openCreate"
+                            class="rounded-md bg-blue-600 px-3 py-2 text-sm text-white hover:bg-blue-700"
+                        >
+                            Thêm vật tư
+                        </button>
     </div>
 
     <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
@@ -67,28 +116,44 @@
                     <th class="border-b border-gray-200 px-2 py-2 text-right font-medium">Thao tác</th>
                 </tr>
             </thead>
-            <tbody class="divide-y divide-gray-100">
-                @forelse ($displayRows as $row)
+            <tbody x-ref="rows" class="divide-y divide-gray-100">
+                @forelse ($rows as $row)
                     @php($maVt = (string) ($row['ma_vt'] ?? ''))
+                    @php($searchFields = collect([
+                        $row['ma_vt'] ?? '',
+                        $row['ten_vt'] ?? '',
+                        $row['ma_nhvt'] ?? '',
+                        $row['dvt'] ?? '',
+                        $row['tk_vt'] ?? '',
+                        $row['ma_kho'] ?? '',
+                        $row['ma_vitri'] ?? '',
+                    ])->map(static fn ($value) => (string) $value)->implode(' '))
                     <tr
                         wire:key="indmvt-list-{{ $maVt }}"
-                        wire:click="selectItem(@js($maVt))"
+                        data-search="{{ $searchFields }}"
+                        data-ma-thue="{{ $row['ma_thue'] ?? '' }}"
+                        data-part-no="{{ $row['part_no'] ?? '' }}"
+                        data-nha-sx="{{ $row['nha_sx'] ?? '' }}"
+                        data-nha-pp="{{ $row['nha_pp'] ?? '' }}"
+                        data-nuoc-sx="{{ $row['nuoc_sx'] ?? '' }}"
+                        x-show="matchesRow($el)"
+                        @click="selectRow($el)"
                         class="cursor-pointer hover:bg-sky-50 {{ $selectedMaVt === $maVt ? 'bg-blue-50' : '' }}"
                     >
-                        <td class="px-2 py-2 text-right text-gray-400">{{ $loop->iteration }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono font-semibold text-gray-900">{{ $maVt }}</td>
-                        <td class="min-w-64 px-2 py-2 text-gray-800">{{ $row['ten_vt'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['dvt'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['ma_nhvt'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['ma_kho'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['ma_vitri'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['tk_vt'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['tk_dt'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['tk_gv'] ?? '' }}</td>
-                        <td class="px-2 py-2 text-center">{{ (int) ($row['ton_kho'] ?? 0) ? 'Có' : 'Không' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['loai'] ?? '' }}</td>
-                        <td class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['gia_ton'] ?? '' }}</td>
-                        <td class="px-2 py-2 text-center">{{ (int) ($row['ksd'] ?? 0) ? 'Có' : '' }}</td>
+                        <td data-field="index" class="px-2 py-2 text-right text-gray-400">{{ $loop->iteration }}</td>
+                        <td data-field="ma_vt" class="whitespace-nowrap px-2 py-2 font-mono font-semibold text-gray-900">{{ $maVt }}</td>
+                        <td data-field="ten_vt" class="min-w-64 px-2 py-2 text-gray-800">{{ $row['ten_vt'] ?? '' }}</td>
+                        <td data-field="dvt" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['dvt'] ?? '' }}</td>
+                        <td data-field="ma_nhvt" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['ma_nhvt'] ?? '' }}</td>
+                        <td data-field="ma_kho" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['ma_kho'] ?? '' }}</td>
+                        <td data-field="ma_vitri" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['ma_vitri'] ?? '' }}</td>
+                        <td data-field="tk_vt" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['tk_vt'] ?? '' }}</td>
+                        <td data-field="tk_dt" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['tk_dt'] ?? '' }}</td>
+                        <td data-field="tk_gv" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['tk_gv'] ?? '' }}</td>
+                        <td data-field="ton_kho" class="px-2 py-2 text-center">{{ (int) ($row['ton_kho'] ?? 0) ? 'Có' : 'Không' }}</td>
+                        <td data-field="loai" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['loai'] ?? '' }}</td>
+                        <td data-field="gia_ton" class="whitespace-nowrap px-2 py-2 font-mono">{{ $row['gia_ton'] ?? '' }}</td>
+                        <td data-field="ksd" class="px-2 py-2 text-center">{{ (int) ($row['ksd'] ?? 0) ? 'Có' : '' }}</td>
                         <td class="whitespace-nowrap px-2 py-2 text-right" wire:click.stop>
                             @if ($deleteMaVt === $maVt)
                                 <div class="flex items-center justify-end gap-2">
@@ -112,5 +177,54 @@
             </tbody>
         </table>
     </div>
+    </div>
+
+    <div x-show="selected" class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 bg-gray-50 px-4 py-3">
+            <div>
+                <h3 class="text-sm font-semibold text-gray-900">Chi tiết vật tư</h3>
+                <p class="text-xs text-gray-500">Mã VT: <span class="font-mono" x-text="detail.ma_vt"></span></p>
+            </div>
+            <div class="flex flex-wrap items-center gap-2">
+                <button type="button"
+                    @click="$wire.openEdit(detail.ma_vt)"
+                    class="rounded-md bg-yellow-100 px-3 py-1.5 text-xs font-medium text-yellow-800 hover:bg-yellow-200">
+                    Sửa
+                </button>
+                <button type="button"
+                    @click="if (confirm('Bạn có chắc chắn muốn xóa vật tư ' + detail.ma_vt + '?')) $wire.deleteDetailItem(detail.ma_vt)"
+                    class="rounded-md bg-red-100 px-3 py-1.5 text-xs font-medium text-red-800 hover:bg-red-200">
+                    Xóa
+                </button>
+            </div>
+        </div>
+
+        <div class="grid gap-x-6 gap-y-3 p-4 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ([
+                'ma_vt' => 'Mã VT',
+                'ten_vt' => 'Tên vật tư',
+                'dvt' => 'ĐVT',
+                'ma_nhvt' => 'Nhóm',
+                'ma_kho' => 'Kho',
+                'ma_vitri' => 'Vị trí',
+                'tk_vt' => 'TK VT',
+                'tk_dt' => 'TK DT',
+                'tk_gv' => 'TK GV',
+                'ton_kho' => 'Tồn',
+                'loai' => 'Loại',
+                'gia_ton' => 'Giá tồn',
+                'ksd' => 'KSD',
+                'ma_thue' => 'Mã thuế',
+                'part_no' => 'Part no',
+                'nha_sx' => 'Nhà SX',
+                'nha_pp' => 'Nhà PP',
+                'nuoc_sx' => 'Nước SX',
+            ] as $key => $label)
+                <div class="text-sm">
+                    <span class="block text-xs text-gray-500">{{ $label }}</span>
+                    <span class="mt-0.5 block font-medium text-gray-900" x-text="detail.{{ $key }} || '—'"></span>
+                </div>
+            @endforeach
+        </div>
     </div>
 </div>

--- a/diepxuan/laravel-catalog/resources/views/so/rpt/sorptbk01.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/so/rpt/sorptbk01.blade.php
@@ -389,15 +389,16 @@
                     this.chiTietColumns = detail.chiTietColumns || [];
                     this.phieuRows = detail.phieu || [];
                     this.chiTietRows = detail.chiTiet || [];
-                    this.loaded = true;
-                    this.selectPhieu(this.phieuRows.length > 0 ? 0 : null);
+                    this.loaded = this.phieuRows.length > 0;
+                    this.selectPhieu(this.loaded ? 0 : null);
                 },
 
                 onDeleted(detail) {
                     const sttRec = detail.sttRec;
                     this.phieuRows = this.phieuRows.filter((row) => row.stt_rec !== sttRec);
                     this.chiTietRows = this.chiTietRows.filter((row) => row.stt_rec !== sttRec);
-                    this.selectPhieu(this.phieuRows.length > 0 ? 0 : null);
+                    this.loaded = this.phieuRows.length > 0;
+                    this.selectPhieu(this.loaded ? 0 : null);
                 },
 
                 selectPhieu(index) {

--- a/diepxuan/laravel-catalog/resources/views/so/rpt/sorptbk01.blade.php
+++ b/diepxuan/laravel-catalog/resources/views/so/rpt/sorptbk01.blade.php
@@ -235,7 +235,7 @@
                             wire:click="submit">
                             Thực hiện
                         </x-button-loading>
-                        @if ([] !== $phieuRows)
+                        @if ($hasData)
                             <x-button-loading
                                 class="rounded-md bg-gray-700 px-3 py-1.5 text-sm text-white hover:bg-gray-800"
                                 wire:click="exportCsv">
@@ -246,122 +246,193 @@
                 </div>
             </div>
 
-            <div x-show="activeTab === 'content'" class="w-full overflow-x-auto py-2">
+            <div x-show="activeTab === 'content'"
+                x-data="sorptbk01Report(@js($editUrlTemplate))"
+                @sorptbk01-report-loaded.window="onLoaded($event.detail)"
+                @sorptbk01-voucher-deleted.window="onDeleted($event.detail)"
+                class="w-full overflow-x-auto py-2">
                 @if ($errorMessage)
                     <div class="mb-3 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                         {{ $errorMessage }}
                     </div>
                 @endif
 
-                @if ([] === $phieuRows)
-                    <div class="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
-                        Chưa có dữ liệu. Nhập điều kiện lọc rồi bấm Thực hiện.
-                    </div>
-                @else
-                    <div class="space-y-4">
-                        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-                            <div class="border-b border-gray-200 bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700">
-                                Danh sách phiếu
-                            </div>
-                            <div class="max-h-[calc(100vh-300px)] overflow-y-auto">
-                                <table class="min-w-max text-left text-xs">
-                                    <thead class="sticky top-0 z-10 bg-gray-50 text-gray-500">
-                                        <tr>
-                                            <th class="border-b border-gray-200 px-2 py-2 text-right font-medium">#</th>
-                                            @foreach ($phieuColumns as $column)
-                                                <th class="{{ $column['class'] }} border-b border-gray-200 px-2 py-2 font-medium">
-                                                    {{ $column['label'] }}
-                                                </th>
-                                            @endforeach
-                                        </tr>
-                                    </thead>
-                                    <tbody class="divide-y divide-gray-100">
-                                        @foreach ($phieuRows as $phieu)
-                                            <tr wire:click="selectPhieu({{ $loop->index }})"
-                                                class="cursor-pointer {{ $selectedPhieuIndex === $loop->index ? 'bg-sky-50' : 'hover:bg-sky-50' }}">
-                                                <td class="px-2 py-2 text-right tabular-nums text-gray-400">{{ $loop->iteration }}</td>
-                                                @foreach ($phieuColumns as $column)
-                                                    <td class="{{ $column['class'] }} px-2 py-2 {{ $this->phieuCellClass($phieu, $column['key']) }}">
-                                                        {{ $this->phieuCellValue($phieu, $column['key']) }}
-                                                    </td>
-                                                @endforeach
-                                            </tr>
-                                        @endforeach
-                                    </tbody>
-                                </table>
-                            </div>
-                            <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-500">
-                                <span>{{ number_format(count($phieuRows)) }} phiếu</span>
-                                <x-button-loading
-                                    class="rounded-md bg-gray-700 px-2.5 py-1 text-xs text-white hover:bg-gray-800"
-                                    wire:click="exportCsv">
-                                    Xuất Excel
-                                </x-button-loading>
-                            </div>
-                        </div>
+                <div x-show="!loaded" class="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+                    Chưa có dữ liệu. Nhập điều kiện lọc rồi bấm Thực hiện.
+                </div>
 
-                        @if ([] !== $selectedPhieu)
-                            <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
-                                <div class="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-2">
-                                    <span class="text-sm font-medium text-gray-700">Chi tiết phiếu #{{ ($selectedPhieuIndex ?? 0) + 1 }}</span>
-                                    <span class="font-mono text-xs text-gray-500">{{ $this->phieuCellValue($selectedPhieu, 'so_ct') }}</span>
-                                </div>
-                                @if ([] !== $chiTietFiltered)
+                <div x-show="loaded" class="space-y-4">
+                    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+                        <div class="border-b border-gray-200 bg-gray-50 px-3 py-2 text-sm font-medium text-gray-700">
+                            Danh sách phiếu
+                        </div>
+                        <div class="max-h-[calc(100vh-300px)] overflow-y-auto">
+                            <table class="min-w-max text-left text-xs">
+                                <thead class="sticky top-0 z-10 bg-gray-50 text-gray-500">
+                                    <tr>
+                                        <th class="border-b border-gray-200 px-2 py-2 text-right font-medium">#</th>
+                                        <template x-for="column in phieuColumns" :key="column.key">
+                                            <th :class="column.class" class="border-b border-gray-200 px-2 py-2 font-medium" x-text="column.label"></th>
+                                        </template>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-100">
+                                    <template x-for="(phieu, index) in phieuRows" :key="phieu.stt_rec">
+                                        <tr @click="selectPhieu(index)"
+                                            :class="selectedIndex === index ? 'bg-sky-50' : 'cursor-pointer hover:bg-sky-50'">
+                                            <td class="px-2 py-2 text-right tabular-nums text-gray-400" x-text="index + 1"></td>
+                                            <template x-for="(cell, ci) in phieu.cells" :key="ci">
+                                                <td :class="[phieuColumns[ci].class, cell.c]" class="px-2 py-2" x-text="cell.v"></td>
+                                            </template>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-500">
+                            <span x-text="phieuRows.length.toLocaleString('vi-VN') + ' phiếu'"></span>
+                            <x-button-loading
+                                class="rounded-md bg-gray-700 px-2.5 py-1 text-xs text-white hover:bg-gray-800"
+                                wire:click="exportCsv">
+                                Xuất Excel
+                            </x-button-loading>
+                        </div>
+                    </div>
+
+                    <template x-if="selectedPhieu">
+                        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+                            <div class="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-3 py-2">
+                                <span class="text-sm font-medium text-gray-700" x-text="'Chi tiết phiếu #' + ((selectedIndex ?? 0) + 1)"></span>
+                                <span class="font-mono text-xs text-gray-500" x-text="selectedPhieu.so_ct"></span>
+                            </div>
+                            <template x-if="chiTietFiltered.length > 0">
+                                <div>
                                     <div class="max-h-[calc(100vh-420px)] overflow-y-auto">
                                         <table class="min-w-max text-left text-xs">
                                             <thead class="sticky top-0 z-10 bg-gray-50 text-gray-500">
                                                 <tr>
                                                     <th class="border-b border-gray-200 px-2 py-2 text-right font-medium">#</th>
-                                                    @foreach ($chiTietColumns as $column)
-                                                        <th class="{{ $column['class'] }} border-b border-gray-200 px-2 py-2 font-medium">
-                                                            {{ $column['label'] }}
-                                                        </th>
-                                                    @endforeach
+                                                    <template x-for="column in chiTietColumns" :key="column.key">
+                                                        <th :class="column.class" class="border-b border-gray-200 px-2 py-2 font-medium" x-text="column.label"></th>
+                                                    </template>
                                                 </tr>
                                             </thead>
                                             <tbody class="divide-y divide-gray-100">
-                                                @foreach ($chiTietFiltered as $chiTiet)
+                                                <template x-for="(chiTiet, index) in chiTietFiltered" :key="chiTiet.stt_rec + '-' + index">
                                                     <tr class="hover:bg-sky-50">
-                                                        <td class="px-2 py-2 text-right tabular-nums text-gray-400">{{ $loop->iteration }}</td>
-                                                        @foreach ($chiTietColumns as $column)
-                                                            <td class="{{ $column['class'] }} px-2 py-2 {{ $this->chiTietCellClass($chiTiet, $column['key']) }}">
-                                                                {{ $this->chiTietCellValue($chiTiet, $column['key']) }}
-                                                            </td>
-                                                        @endforeach
+                                                        <td class="px-2 py-2 text-right tabular-nums text-gray-400" x-text="index + 1"></td>
+                                                        <template x-for="(cell, ci) in chiTiet.cells" :key="ci">
+                                                            <td :class="[chiTietColumns[ci].class, cell.c]" class="px-2 py-2" x-text="cell.v"></td>
+                                                        </template>
                                                     </tr>
-                                                @endforeach
+                                                </template>
                                             </tbody>
                                         </table>
                                     </div>
                                     <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-500">
-                                        <span>{{ number_format(count($chiTietFiltered)) }} dòng chi tiết</span>
-                                        @if ($this->canEditSelectedVoucher())
+                                        <span x-text="chiTietFiltered.length.toLocaleString('vi-VN') + ' dòng chi tiết'"></span>
+                                        <template x-if="selectedPhieu.ma_ct === 'SO3' && selectedPhieu.stt_rec">
                                             <div class="flex items-center gap-2">
-                                                <a href="{{ simbaroute('so.vch.sovchso3.edit', $this->selectedVoucherSttRec()) }}"
+                                                <a :href="editUrlFor(selectedPhieu)"
                                                     class="rounded bg-yellow-100 px-2 py-1 text-xs text-yellow-700 hover:bg-yellow-200">
                                                     Sửa
                                                 </a>
                                                 <button type="button"
-                                                    wire:click="deleteSelectedVoucher"
-                                                    wire:confirm="Bạn có chắc chắn muốn xóa chứng từ {{ $this->selectedVoucherSoCt() }}?"
+                                                    @click="confirmDelete(selectedPhieu)"
                                                     class="rounded bg-red-100 px-2 py-1 text-xs text-red-700 hover:bg-red-200">
                                                     Xóa
                                                 </button>
                                             </div>
-                                        @endif
+                                        </template>
                                     </div>
-                                @else
-                                    <div class="p-4 text-sm text-gray-600">Phiếu không có chi tiết.</div>
-                                @endif
-                            </div>
-                        @else
-                            <div class="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
-                                Chọn một phiếu ở bảng trên để xem chi tiết.
-                            </div>
-                        @endif
-                    </div>
-                @endif
+                                </div>
+                            </template>
+                            <template x-if="chiTietFiltered.length === 0">
+                                <div class="p-4 text-sm text-gray-600">Phiếu không có chi tiết.</div>
+                            </template>
+                        </div>
+                    </template>
+
+                    <template x-if="!selectedPhieu">
+                        <div class="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-600">
+                            Chọn một phiếu ở bảng trên để xem chi tiết.
+                        </div>
+                    </template>
+                </div>
             </div>
         </x-slot:content>
     </x-nav-tabs>
 </div>
+
+@once
+@push('scripts')
+<script>
+    (function () {
+        if (typeof window.sorptbk01Report !== 'undefined') {
+            return;
+        }
+
+        window.sorptbk01Report = function (editUrlTemplate) {
+            return {
+                loaded: false,
+                phieuColumns: [],
+                chiTietColumns: [],
+                phieuRows: [],
+                chiTietRows: [],
+                selectedIndex: null,
+                selectedPhieu: null,
+                chiTietFiltered: [],
+                editUrlTemplate: editUrlTemplate || '#',
+
+                onLoaded(detail) {
+                    this.phieuColumns = detail.phieuColumns || [];
+                    this.chiTietColumns = detail.chiTietColumns || [];
+                    this.phieuRows = detail.phieu || [];
+                    this.chiTietRows = detail.chiTiet || [];
+                    this.loaded = true;
+                    this.selectPhieu(this.phieuRows.length > 0 ? 0 : null);
+                },
+
+                onDeleted(detail) {
+                    const sttRec = detail.sttRec;
+                    this.phieuRows = this.phieuRows.filter((row) => row.stt_rec !== sttRec);
+                    this.chiTietRows = this.chiTietRows.filter((row) => row.stt_rec !== sttRec);
+                    this.selectPhieu(this.phieuRows.length > 0 ? 0 : null);
+                },
+
+                selectPhieu(index) {
+                    if (index === null || !this.phieuRows[index]) {
+                        this.selectedIndex = null;
+                        this.selectedPhieu = null;
+                        this.chiTietFiltered = [];
+
+                        return;
+                    }
+
+                    this.selectedIndex = index;
+                    this.selectedPhieu = this.phieuRows[index];
+                    const sttRec = this.selectedPhieu.stt_rec;
+                    this.chiTietFiltered = this.chiTietRows.filter((row) => row.stt_rec === sttRec);
+                },
+
+                editUrlFor(phieu) {
+                    if (!phieu || !phieu.stt_rec) {
+                        return '#';
+                    }
+
+                    return this.editUrlTemplate.replace('__STT_REC__', encodeURIComponent(phieu.stt_rec));
+                },
+
+                confirmDelete(phieu) {
+                    if (!confirm('Bạn có chắc chắn muốn xóa chứng từ ' + phieu.so_ct + '?')) {
+                        return;
+                    }
+
+                    this.$wire.deleteVoucher(phieu.stt_rec);
+                },
+            };
+        };
+    })();
+</script>
+@endpush
+@endonce

--- a/diepxuan/laravel-catalog/src/Http/Livewire/In/Dict/IndmvtForm.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/In/Dict/IndmvtForm.php
@@ -24,8 +24,8 @@ use Livewire\Component;
  * re-render, không serialize lại toàn bộ bảng danh sách.
  *
  * Lắng nghe:
- *  - `indmvt-list.item-selected` -> mở form sửa với maVt
- *  - `indmvt-list.create-clicked` -> mở form thêm
+ *  - `indmvt-list.create-clicked` -> mở form thêm (copy từ vật tư đang chọn)
+ *  - `indmvt-detail.edit-requested` -> chuyển chi tiết sang form sửa
  *
  * Phát:
  *  - `indmvt-form.saved` (maVt) khi Lưu thành công
@@ -64,8 +64,9 @@ class IndmvtForm extends Component
 
     /** @var list<string> */
     protected $listeners = [
-        'indmvt-list.item-selected' => 'openEdit',
+        'indmvt-list.item-selected' => 'closeForExternalAction',
         'indmvt-list.create-clicked' => 'openCreate',
+        'indmvt-detail.edit-requested' => 'openEdit',
         'indmvt-list.rename-clicked' => 'closeForExternalAction',
         'indmvt-list.deleted' => 'closeWhenDeleted',
     ];
@@ -76,9 +77,27 @@ class IndmvtForm extends Component
         $this->loadLookups();
     }
 
-    public function openCreate(): void
+    public function openCreate(?string $copyMaVt = null): void
     {
-        $this->resetForm();
+        $copyMaVt = trim((string) ($copyMaVt ?? ''));
+
+        if ('' !== $copyMaVt) {
+            $row = $this->fetchRowForEdit($copyMaVt);
+            if (null === $row) {
+                $this->errorMessage = "Không tìm thấy vật tư {$copyMaVt} để copy.";
+
+                return;
+            }
+
+            $this->fillFormFromRow($row);
+            $this->form['ma_vt'] = '';
+            $this->form['ghi_chu'] = '';
+            $this->loadBomRows($copyMaVt);
+            $this->originalBomKeys = [];
+        } else {
+            $this->resetForm();
+        }
+
         $this->isEditing = false;
         $this->showForm = true;
         $this->errorMessage = null;

--- a/diepxuan/laravel-catalog/src/Http/Livewire/In/Dict/IndmvtList.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/In/Dict/IndmvtList.php
@@ -16,6 +16,8 @@ use Livewire\Component;
  * Tách riêng để khi người dùng gõ vào form Sửa/Thêm, chỉ IndmvtForm
  * re-render, không serialize lại toàn bộ bảng ~1000 dòng. Đây là
  * root cause gây 14s delay giữa các lần blur trong form.
+ * Search chạy phía client bằng Alpine (giống pattern ARDMKH list), không
+ * gọi Livewire mỗi lần gõ.
  *
  * Giao tiếp với các component khác qua Livewire events:
  *  - Phát `indmvt-list.item-selected` khi user click một dòng.
@@ -28,8 +30,6 @@ class IndmvtList extends Component
 {
     /** @var list<array<string, mixed>> */
     public array $rows = [];
-
-    public string $search = '';
 
     public ?string $selectedMaVt = null;
 
@@ -47,6 +47,7 @@ class IndmvtList extends Component
         'indmvt-list.refresh-all' => 'refreshAll',
         'indmvt-form.saved' => 'handleFormSaved',
         'indmvt-rename.saved' => 'handleRenameSaved',
+        'indmvt-list.deleted' => 'removeDeletedRow',
     ];
 
     public function mount(): void
@@ -75,19 +76,31 @@ class IndmvtList extends Component
     {
         $this->selectedMaVt = $maVt;
         $this->deleteMaVt = null;
-        $this->dispatch('indmvt-list.item-selected', maVt: $maVt);
+
+        $row = null;
+        foreach ($this->rows as $existing) {
+            if ((string) ($existing['ma_vt'] ?? '') === $maVt) {
+                $row = $existing;
+                break;
+            }
+        }
+
+        $this->dispatch('indmvt-list.item-selected', maVt: $maVt, row: $row);
     }
 
     public function openCreate(): void
     {
+        $copyMaVt = $this->selectedMaVt;
         $this->selectedMaVt = null;
         $this->deleteMaVt = null;
-        $this->dispatch('indmvt-list.create-clicked');
+        $this->dispatch('indmvt-list.create-clicked', copyMaVt: $copyMaVt);
     }
 
     public function openEdit(string $maVt): void
     {
-        $this->selectItem($maVt);
+        $this->selectedMaVt = $maVt;
+        $this->deleteMaVt = null;
+        $this->dispatch('indmvt-detail.edit-requested', maVt: $maVt);
     }
 
     public function openRename(string $maVt): void
@@ -116,13 +129,30 @@ class IndmvtList extends Component
             return;
         }
 
+        $this->performDelete(trim($this->deleteMaVt));
+    }
+
+    /**
+     * Xóa từ bảng chi tiết (Alpine đã confirm trước khi gọi).
+     */
+    public function deleteDetailItem(string $maVt): void
+    {
+        $maVt = trim($maVt);
+        if ('' === $maVt) {
+            return;
+        }
+
+        $this->performDelete($maVt);
+    }
+
+    private function performDelete(string $deletedMaVt): void
+    {
         try {
             ProcedureCaller::call('asINDelDMVT', [
                 'pMa_cty' => $this->companyId(),
-                'pMa_vt'  => $this->deleteMaVt,
+                'pMa_vt'  => $deletedMaVt,
             ], (new SModel())->getConnectionName());
 
-            $deletedMaVt = $this->deleteMaVt;
             $this->rows = array_values(array_filter(
                 $this->rows,
                 static fn (array $row): bool => ($row['ma_vt'] ?? null) !== $deletedMaVt
@@ -188,30 +218,21 @@ class IndmvtList extends Component
         $this->selectedMaVt = $newMaVt;
     }
 
-    /**
-     * @return list<array<string, mixed>>
-     */
-    public function filteredRows(): array
+    public function removeDeletedRow(string $maVt): void
     {
-        $search = mb_strtolower(trim($this->search));
-        if ('' === $search) {
-            return $this->rows;
+        $this->rows = array_values(array_filter(
+            $this->rows,
+            static fn (array $row): bool => ($row['ma_vt'] ?? null) !== $maVt
+        ));
+
+        if ($this->selectedMaVt === $maVt) {
+            $this->selectedMaVt = null;
         }
-
-        return array_values(array_filter($this->rows, static function (array $row) use ($search): bool {
-            $haystack = mb_strtolower(implode(' ', [
-                $row['ma_vt'] ?? '', $row['ten_vt'] ?? '', $row['ma_nhvt'] ?? '', $row['dvt'] ?? '', $row['tk_vt'] ?? '',
-            ]));
-
-            return str_contains($haystack, $search);
-        }));
     }
 
     public function render(): View
     {
-        return view('catalog::in.dict.indmvt-list', [
-            'displayRows' => $this->filteredRows(),
-        ]);
+        return view('catalog::in.dict.indmvt-list', ['rows' => $this->rows]);
     }
 
     private function companyId(): string

--- a/diepxuan/laravel-catalog/src/Http/Livewire/So/Rpt/Sorptbk01.php
+++ b/diepxuan/laravel-catalog/src/Http/Livewire/So/Rpt/Sorptbk01.php
@@ -69,22 +69,29 @@ class Sorptbk01 extends Component
     public ?string $pTieu_de  = 'Bảng kê chứng từ bán hàng';
     public ?string $errorMessage = null;
 
-    /** @var list<array<string,mixed>> */
-    public array $phieuRows = [];
-
-    /** @var list<array<string,mixed>> */
-    public array $chiTietRows = [];
-
-    /** @var list<array<string,mixed>> */
-    public array $chiTietFiltered = [];
-
     /** @var list<array{ma_ct:string,ten_ct:string}> */
     public array $voucherTypes = [];
 
-    public ?int $selectedPhieuIndex = null;
+    /** Co du lieu bao cao da load (bật nút Xuất Excel ở tab lọc). */
+    public bool $hasData = false;
 
-    /** @var array<string,mixed> */
-    public array $selectedPhieu = [];
+    /**
+     * Du lieu bao cao KHONG nam trong snapshot Livewire: chi giu phia server
+     * (session) de export CSV / xoa chung tu, con hien thi do Alpine render
+     * client-side tu payload dispatch mot lan khi submit.
+     *
+     * @var list<array<string,mixed>>
+     */
+    private array $phieuRows = [];
+
+    /** @var list<array<string,mixed>> */
+    private array $chiTietRows = [];
+
+    /** @var null|list<array{key:string,label:string,class:string}> */
+    private ?array $phieuColumns = null;
+
+    /** @var null|list<array{key:string,label:string,class:string}> */
+    private ?array $chiTietColumns = null;
 
     public function mount(
         ?string $module = null,
@@ -144,20 +151,29 @@ class Sorptbk01 extends Component
         try {
             $data = AsSORptBK01::callWithDataSets($this->procedurePayload());
 
-            $this->phieuRows = $data['ph']
-                ->map(fn (mixed $row): array => self::rowToArray($row))
-                ->values()
-                ->all();
-            $this->chiTietRows = $data['ct']
-                ->map(fn (mixed $row): array => self::rowToArray($row))
-                ->values()
-                ->all();
-            $this->clearSelectedPhieu();
+            $phieuRows   = $data['ph']->map(fn (mixed $row): array => self::rowToArray($row))->values()->all();
+            $chiTietRows = $data['ct']->map(fn (mixed $row): array => self::rowToArray($row))->values()->all();
 
-            if ([] !== $this->phieuRows) {
-                $this->selectPhieu(0);
-            }
+            $this->phieuRows    = $phieuRows;
+            $this->chiTietRows  = $chiTietRows;
+            $this->phieuColumns = $this->buildPhieuColumns($phieuRows);
+            $this->chiTietColumns = $this->buildChiTietColumns($chiTietRows);
+            $this->hasData      = [] !== $phieuRows;
 
+            // Cat du lieu tho + cot vao session de export CSV / xoa chung tu
+            // (khong giu trong snapshot Livewire).
+            session([$this->reportSessionKey() => [
+                'phieu'   => $phieuRows,
+                'chitiet' => $chiTietRows,
+            ]]);
+
+            $this->dispatch(
+                'sorptbk01-report-loaded',
+                phieuColumns: $this->phieuColumns,
+                chiTietColumns: $this->chiTietColumns,
+                phieu: $this->clientRows($phieuRows, $this->phieuColumns, 'phieuCellValue'),
+                chiTiet: $this->clientRows($chiTietRows, $this->chiTietColumns, 'chiTietCellValue'),
+            );
             $this->dispatch('switch-tab', 'content');
         } catch (\Throwable $exception) {
             report($exception);
@@ -168,60 +184,35 @@ class Sorptbk01 extends Component
         }
     }
 
-    public function selectPhieu(int $index): void
+    /**
+     * Xoa chung tu SO3 theo stt_rec (Alpine goi sau khi user chon phieu va
+     * xac nhan). Thanh cong: dispatch event de Alpine loai dong khoi bang
+     * client-side, khong can goi lai SP.
+     */
+    public function deleteVoucher(string $sttRec): void
     {
-        if (!isset($this->phieuRows[$index])) {
-            $this->clearSelectedPhieu();
+        $sttRec = trim($sttRec);
+        if ('' === $sttRec) {
+            session()->flash('error', 'Chứng từ không hợp lệ.');
 
             return;
         }
 
-        $this->selectedPhieuIndex = $index;
-        $this->selectedPhieu      = $this->phieuRows[$index];
-        $sttRec = self::rowValue($this->selectedPhieu, ['stt_rec', 'Stt_rec', 'STT_REC']);
+        $stored = $this->storedReport();
+        $phieu  = null;
+        foreach ($stored['phieu'] as $row) {
+            if ((string) self::rowValue($row, ['stt_rec', 'Stt_rec', 'STT_REC']) === $sttRec) {
+                $phieu = $row;
 
-        $this->chiTietFiltered = array_values(array_filter(
-            $this->chiTietRows,
-            static fn (array $row): bool => (string) self::rowValue($row, ['stt_rec', 'Stt_rec', 'STT_REC']) === (string) $sttRec
-        ));
-    }
-
-    public function clearSelectedPhieu(): void
-    {
-        $this->selectedPhieuIndex = null;
-        $this->selectedPhieu      = [];
-        $this->chiTietFiltered    = [];
-    }
-
-    public function canEditSelectedVoucher(): bool
-    {
-        if ([] === $this->selectedPhieu) {
-            return false;
+                break;
+            }
         }
 
-        return 'SO3' === $this->voucherTypeCode($this->selectedPhieu)
-            && '' !== $this->selectedVoucherSttRec();
-    }
-
-    public function selectedVoucherSttRec(): string
-    {
-        return (string) self::rowValue($this->selectedPhieu, ['stt_rec', 'Stt_rec', 'STT_REC']);
-    }
-
-    public function selectedVoucherSoCt(): string
-    {
-        return self::csvValue(self::rowValue($this->selectedPhieu, ['so_ct', 'So_ct']));
-    }
-
-    public function deleteSelectedVoucher(): void
-    {
-        if (!$this->canEditSelectedVoucher()) {
+        if (null === $phieu || 'SO3' !== $this->voucherTypeCode($phieu)) {
             session()->flash('error', 'Chứng từ đang chọn không hỗ trợ xóa từ bảng kê này.');
 
             return;
         }
-
-        $sttRec = $this->selectedVoucherSttRec();
 
         DB::beginTransaction();
 
@@ -237,18 +228,20 @@ class Sorptbk01 extends Component
                 throw new \RuntimeException('Stored procedure trả về mã lỗi ' . (int) $pRet . '.');
             }
 
-            $this->phieuRows = array_values(array_filter(
-                $this->phieuRows,
-                static fn (array $phieu): bool => (string) self::rowValue($phieu, ['stt_rec', 'Stt_rec', 'STT_REC']) !== $sttRec
+            $stored['phieu'] = array_values(array_filter(
+                $stored['phieu'],
+                static fn (array $item): bool => (string) self::rowValue($item, ['stt_rec', 'Stt_rec', 'STT_REC']) !== $sttRec
             ));
-            $this->chiTietRows = array_values(array_filter(
-                $this->chiTietRows,
-                static fn (array $row): bool => (string) self::rowValue($row, ['stt_rec', 'Stt_rec', 'STT_REC']) !== $sttRec
+            $stored['chitiet'] = array_values(array_filter(
+                $stored['chitiet'],
+                static fn (array $item): bool => (string) self::rowValue($item, ['stt_rec', 'Stt_rec', 'STT_REC']) !== $sttRec
             ));
-            $this->clearSelectedPhieu();
+            session([$this->reportSessionKey() => $stored]);
+            $this->hasData = [] !== $stored['phieu'];
 
             DB::commit();
             session()->flash('success', 'Đã xóa hóa đơn bán hàng.');
+            $this->dispatch('sorptbk01-voucher-deleted', sttRec: $sttRec);
         } catch (\Throwable $exception) {
             DB::rollBack();
             report($exception);
@@ -258,7 +251,9 @@ class Sorptbk01 extends Component
 
     public function exportCsv(): ?StreamedResponse
     {
-        if ([] === $this->phieuRows) {
+        $stored = $this->storedReport();
+
+        if ([] === $stored['phieu']) {
             $this->errorMessage = 'Chưa có dữ liệu để xuất.';
 
             return null;
@@ -295,9 +290,11 @@ class Sorptbk01 extends Component
      * dữ liệu cần thiết như bản gốc. Các cột raw không có nhãn hiển thị sẽ
      * được lọc trong appendDynamicColumns().
      *
+     * @param list<array<string,mixed>> $rows
+     *
      * @return list<array{key:string,label:string,class:string}>
      */
-    public function phieuColumns(): array
+    private function buildPhieuColumns(array $rows): array
     {
         $currency = $this->isForeignCurrency() ? 'NT' : 'VND';
 
@@ -312,16 +309,18 @@ class Sorptbk01 extends Component
             ['key' => 'tt', 'label' => 'Thanh toán ' . $currency, 'class' => 'text-right whitespace-nowrap'],
         ];
 
-        return $this->appendDynamicColumns($columns, $this->phieuRows);
+        return $this->appendDynamicColumns($columns, $rows);
     }
 
     /**
      * Danh sách cột bảng chi tiết: tương tự phieuColumns(), các cột quen thuộc
      * trước rồi tự bổ sung mọi cột còn lại của result set CT.
      *
+     * @param list<array<string,mixed>> $rows
+     *
      * @return list<array{key:string,label:string,class:string}>
      */
-    public function chiTietColumns(): array
+    private function buildChiTietColumns(array $rows): array
     {
         $currency = $this->isForeignCurrency() ? 'NT' : 'VND';
 
@@ -338,7 +337,7 @@ class Sorptbk01 extends Component
             ['key' => 'ma_nvkd', 'label' => 'NVKD', 'class' => 'text-left whitespace-nowrap'],
         ];
 
-        return $this->appendDynamicColumns($columns, $this->chiTietRows);
+        return $this->appendDynamicColumns($columns, $rows);
     }
 
     /**
@@ -402,8 +401,7 @@ class Sorptbk01 extends Component
     public function render(): View
     {
         return view('catalog::so.rpt.sorptbk01', [
-            'phieuColumns' => $this->phieuColumns(),
-            'chiTietColumns' => $this->chiTietColumns(),
+            'editUrlTemplate' => simbaroute('so.vch.sovchso3.edit', ['id' => '__STT_REC__']),
         ]);
     }
 
@@ -449,19 +447,23 @@ class Sorptbk01 extends Component
      */
     private function csvRows(): array
     {
+        $stored = $this->storedReport();
+        $phieuColumns   = $this->buildPhieuColumns($stored['phieu']);
+        $chiTietColumns = $this->buildChiTietColumns($stored['chitiet']);
+
         $rows = [];
 
-        foreach ($this->phieuRows as $phieu) {
+        foreach ($stored['phieu'] as $phieu) {
             $row = ['Loai' => 'Phiếu'];
-            foreach ($this->phieuColumns() as $column) {
+            foreach ($phieuColumns as $column) {
                 $row[$column['label']] = $this->phieuCellValue($phieu, $column['key'], true);
             }
             $rows[] = $row;
         }
 
-        foreach ($this->chiTietRows as $chiTiet) {
+        foreach ($stored['chitiet'] as $chiTiet) {
             $row = ['Loai' => 'Chi tiết'];
-            foreach ($this->chiTietColumns() as $column) {
+            foreach ($chiTietColumns as $column) {
                 $row[$column['label']] = $this->chiTietCellValue($chiTiet, $column['key'], true);
             }
             $rows[] = $row;
@@ -761,32 +763,6 @@ class Sorptbk01 extends Component
     }
 
     /**
-     * Text color class cho cell bảng phiếu: do nhat (text-red-500) khi phiếu
-     * tra lai (SO4) hoặc gia tri am, xam mac dinh cho cac cell khac.
-     */
-    public function phieuCellClass(array $row, string $column): string
-    {
-        return $this->isMoneyColumn($column) && $this->isReturnCell($row, $column)
-            ? 'text-red-500'
-            : 'text-gray-700';
-    }
-
-    /**
-     * Text color class cho cell bang chi tiet: do nhat (text-red-500) khi
-     * phieu dang chon la phieu tra lai (SO4) hoặc gia tri am, xam mac dinh
-     * cho cac cell khac.
-     */
-    public function chiTietCellClass(array $row, string $column): string
-    {
-        $isReturn = 'SO4' === $this->voucherTypeCode($this->selectedPhieu);
-
-        return $this->isMoneyColumn($column)
-            && ($isReturn || $this->isNegative($row, $column))
-            ? 'text-red-500'
-            : 'text-gray-700';
-    }
-
-    /**
      * Cell tiền cua phiếu tra lai (SO4) hoặc gia tri am duoc danh mau do nhat.
      *
      * SO4 luu so tien duong trong SoPh4, dau am chi ap dung khi post GL
@@ -916,7 +892,72 @@ class Sorptbk01 extends Component
     {
         $this->phieuRows = [];
         $this->chiTietRows = [];
-        $this->clearSelectedPhieu();
+        $this->phieuColumns = null;
+        $this->chiTietColumns = null;
+        $this->hasData = false;
+        session()->forget($this->reportSessionKey());
+    }
+
+    private function reportSessionKey(): string
+    {
+        return 'sorptbk01.report.' . $this->getId();
+    }
+
+    /**
+     * Du lieu tho da cat trong session o submit() — dung cho export CSV va
+     * xoa chung tu.
+     *
+     * @return array{phieu: list<array<string,mixed>>, chitiet: list<array<string,mixed>>}
+     */
+    private function storedReport(): array
+    {
+        $stored = session($this->reportSessionKey());
+
+        return [
+            'phieu'   => $stored['phieu'] ?? [],
+            'chitiet' => $stored['chitiet'] ?? [],
+        ];
+    }
+
+    /**
+     * Pre-format rows cho Alpine: moi row giu stt_rec/ma_ct/so_ct kem cac
+     * cell da dinh dang san (gia tri + class mau) theo danh sach cot, de
+     * bang render client-side khong can goi lai server.
+     *
+     * @param list<array<string,mixed>>                          $rows
+     * @param list<array{key:string,label:string,class:string}> $columns
+     *
+     * @return list<array{stt_rec:string,ma_ct:string,so_ct:string,cells:list<array{v:string,c:string}>}>
+     */
+    private function clientRows(array $rows, array $columns, string $valueMethod): array
+    {
+        // Chi tiet ct khong co ma_ct — nhan dien phieu cha (SO3/SO4...) theo stt_rec.
+        $maCtBySttRec = [];
+        foreach ($this->phieuRows as $phieu) {
+            $maCtBySttRec[(string) self::rowValue($phieu, ['stt_rec', 'Stt_rec', 'STT_REC'])] = $this->voucherTypeCode($phieu);
+        }
+
+        return array_map(function (array $row) use ($columns, $valueMethod, $maCtBySttRec): array {
+            $sttRec = (string) self::rowValue($row, ['stt_rec', 'Stt_rec', 'STT_REC']);
+            $maCt   = $this->voucherTypeCode($row) ?: ($maCtBySttRec[$sttRec] ?? '');
+
+            $cells = [];
+            foreach ($columns as $column) {
+                $isRed = $this->isMoneyColumn($column['key'])
+                    && ('SO4' === $maCt || $this->isNegative($row, $column['key']));
+                $cells[] = [
+                    'v' => $this->{$valueMethod}($row, $column['key']),
+                    'c' => $isRed ? 'text-red-500' : 'text-gray-700',
+                ];
+            }
+
+            return [
+                'stt_rec' => $sttRec,
+                'ma_ct'   => $maCt,
+                'so_ct'   => self::csvValue(self::rowValue($row, ['so_ct', 'So_ct'])),
+                'cells'   => $cells,
+            ];
+        }, $rows);
     }
 
     /**

--- a/diepxuan/laravel-catalog/tests/Unit/Http/Livewire/In/Dict/IndmvtListTest.php
+++ b/diepxuan/laravel-catalog/tests/Unit/Http/Livewire/In/Dict/IndmvtListTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Diepxuan\Catalog\Tests\Unit\Http\Livewire\In\Dict;
+
+use Diepxuan\Catalog\Http\Livewire\In\Dict\IndmvtList;
+use Illuminate\View\View;
+
+final class IndmvtListTest extends \Tests\TestCase
+{
+    public function testComponentNoLongerExposesServerSideSearchState(): void
+    {
+        $component = new IndmvtList();
+
+        self::assertFalse(property_exists($component, 'search'), 'Search phai chay client-side bang Alpine, khong duoc la property Livewire.');
+        self::assertFalse(method_exists($component, 'filteredRows'), 'filteredRows() server-side phai duoc xoa.');
+    }
+
+    public function testRenderPassesAllRowsToView(): void
+    {
+        $component = new IndmvtList();
+        $component->rows = [
+            ['ma_vt' => 'VT001', 'ten_vt' => 'Vật tư 1'],
+            ['ma_vt' => 'VT002', 'ten_vt' => 'Vật tư 2'],
+        ];
+
+        $view = $component->render();
+
+        self::assertInstanceOf(View::class, $view);
+        self::assertSame($component->rows, $view->getData()['rows']);
+        self::assertArrayNotHasKey('displayRows', $view->getData());
+    }
+
+    public function testOpenCreateKeepsSelectedMaVtForCopy(): void
+    {
+        $component = new IndmvtList();
+        $component->selectedMaVt = 'VT001';
+
+        self::assertSame('VT001', $component->selectedMaVt);
+    }
+
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -168,8 +168,8 @@ Ngôn ngữ hình dạng: **Soft Utility**. Toàn bộ giao diện dùng corner-
 
 - **autocomplete dropdown** — `absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-gray-300 bg-white shadow-lg`; item `cursor-pointer px-3 py-2 hover:bg-blue-50`, highlight `bg-blue-50`.
 - **autocomplete search normalization** — NFD strip diacritics, quy `đ/Đ` về `d`, lowercase, trim, collapse spaces.
-- **autocomplete priority** — mã chính xác → tên chính xác → viết tắt prefix → tên prefix → contains; chỉ tự chọn khi 1 kết quả rõ ràng.
-- **autocomplete abbreviation** — tạo chuỗi chữ cái đầu từ mỗi từ của tên để hỗ trợ `tdh` → `Thủy Đông Hà`.
+- **autocomplete priority** — mã chính xác → tên chính xác → chuỗi liên tiếp → dãy con đúng thứ tự; chỉ tự chọn khi 1 kết quả rõ ràng.
+- **autocomplete subsequence search** — tìm theo dãy ký tự con đúng thứ tự sau khi chuẩn hóa, không dùng alias/viết tắt chữ cái đầu; ví dụ `tdh`, `tda`, `ygh` đều khớp `Thủy Đông Hà`.
 
 ### Badges (status pill)
 

--- a/docs/PROJECT_CONVENTIONS.md
+++ b/docs/PROJECT_CONVENTIONS.md
@@ -72,10 +72,20 @@ Các wrapper `AsARInsDMKH` / `AsARUpdDMKH` phải khai báo output `pRet`:
 ## 5. Input autocomplete khách hàng / đối tượng
 
 - `input-khachhang` là lookup dùng chung cho khách hàng, nhà cung cấp và nhân viên theo `mode`.
+
+### Quy tắc search chung (áp dụng cho mọi filter/list/autocomplete)
+
 - Search luôn chuẩn hóa trước khi so khớp: bỏ dấu NFD, quy `đ/Đ` về `d`, lowercase, gộp khoảng trắng.
-- Ngoài tên đầy đủ, cần tạo thêm chuỗi viết tắt từ chữ cái đầu mỗi từ để hỗ trợ tìm nhanh, ví dụ `tdh` khớp `Thủy Đông Hà`.
-- Thứ tự kết quả ưu tiên: mã chính xác → tên chính xác → viết tắt prefix → tên prefix → contains.
+- Khớp theo **dãy con đúng thứ tự** (subsequence) sau khi bỏ khoảng trắng: query không cần nằm liền nhau, không cần bắt đầu từ, và không cần là chữ cái đầu mỗi từ.
+- Ví dụ `Thủy Đông Hà` khớp cả `tdh`, `tda`, `ygh`, `thuy dong`, `dong ha`.
+- Không dùng alias, không dùng bí danh từ khóa, không dùng viết tắt chữ cái đầu mỗi từ, không hardcode từ khóa nào vào filter.
+- Thứ tự kết quả ưu tiên: mã chính xác → tên chính xác → chuỗi liên tiếp (contains) → dãy con đúng thứ tự.
 - `commitSearch()` chỉ tự chọn khi có một kết quả rõ ràng; nhiều kết quả thì giữ dropdown để người dùng chọn.
+
+### Chi tiết áp dụng
+
+- Search luôn chuẩn hóa trước khi so khớp: bỏ dấu NFD, quy `đ/Đ` về `d`, lowercase, gộp khoảng trắng.
+- Danh sách dùng client-side filter (vd ARDMKH, INDMVT) phải áp dụng cùng quy tắc dãy con đúng thứ tự cho toàn bộ field được tìm kiếm.
 
 ## 6. Danh sách chứng từ và bảng phụ chi tiết
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,31 @@
-import './bootstrap';
+import "./bootstrap";
+
+window.PortalSearch = {
+    normalize(value) {
+        return String(value || "")
+            .normalize("NFD")
+            .replace(/[\u0300-\u036f]/g, "")
+            .replace(/[đĐ]/g, "d")
+            .toLowerCase()
+            .replace(/\s+/g, " ")
+            .trim();
+    },
+
+    matchesSubsequence(haystack, needle) {
+        const text = this.normalize(haystack).replace(/\s+/g, "");
+        const query = this.normalize(needle).replace(/\s+/g, "");
+
+        if (!query) {
+            return true;
+        }
+
+        let index = 0;
+        for (let i = 0; i < text.length && index < query.length; i++) {
+            if (text[i] === query[index]) {
+                index++;
+            }
+        }
+
+        return index === query.length;
+    },
+};

--- a/tests/Unit/Packages/Catalog/ArdmkhFormTest.php
+++ b/tests/Unit/Packages/Catalog/ArdmkhFormTest.php
@@ -53,24 +53,74 @@ final class ArdmkhFormTest extends TestCase
         $method->invoke($form, collect([(object) ['pRet' => 1]]));
     }
 
-    public function testSorptbk01FiltersDetailRowsBySttRec(): void
+    public function testSorptbk01ReportRowsAreNotPublicLivewireState(): void
+    {
+        // Rows/cot bao cao khong duoc nam trong snapshot Livewire (nguyen
+        // nhan gay cham truoc day): chi giu phia server + dispatch 1 lan.
+        foreach (['phieuRows', 'chiTietRows', 'phieuColumns', 'chiTietColumns'] as $property) {
+            $reflection = new \ReflectionProperty(Sorptbk01::class, $property);
+            self::assertTrue($reflection->isPrivate(), "{$property} phai la private de khong nam trong snapshot Livewire.");
+        }
+    }
+
+    public function testSorptbk01ClientRowsPreformatCellsAndKeepKeys(): void
     {
         $component = new Sorptbk01();
-        $component->phieuRows = [
-            ['STT_REC' => 'P1', 'so_ct' => 'SO1'],
-            ['stt_rec' => 'P2', 'so_ct' => 'SO2'],
-        ];
-        $component->chiTietRows = [
-            ['stt_rec' => 'P1', 'ma_vt' => 'VT001'],
-            ['Stt_rec' => 'P2', 'ma_vt' => 'VT002'],
-        ];
+        $phieuRows = [[
+            'stt_rec'   => 'P1',
+            'ma_ct'     => 'SO3',
+            'so_ct'     => 'HD001',
+            'ngay_ct'   => '2026-07-01',
+            'ma_kh'     => 'KH001',
+            'ten_kh'    => 'Khách A',
+            'tien2'     => '70000',
+            'thue_gtgt' => '7000',
+            'tt'        => '77000',
+        ]];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
 
-        $component->selectPhieu(0);
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$phieuRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$phieuRows, $columns, 'phieuCellValue']);
 
-        self::assertSame(0, $component->selectedPhieuIndex);
-        self::assertSame('P1', $component->selectedPhieu['STT_REC']);
-        self::assertCount(1, $component->chiTietFiltered);
-        self::assertSame('VT001', $component->chiTietFiltered[0]['ma_vt']);
+        self::assertSame('P1', $rows[0]['stt_rec']);
+        self::assertSame('SO3', $rows[0]['ma_ct']);
+        self::assertSame('HD001', $rows[0]['so_ct']);
+        self::assertCount(\count($columns), $rows[0]['cells']);
+        self::assertSame('70,000', $rows[0]['cells'][self::columnIndex($columns, 'tien2')]['v']);
+        self::assertSame('01/07/2026', $rows[0]['cells'][self::columnIndex($columns, 'ngay_ct')]['v']);
+    }
+
+    public function testSorptbk01ClientRowsNormalizeRawCaseKeys(): void
+    {
+        $component = new Sorptbk01();
+        $phieuRows = [['STT_REC' => 'P1', 'MA_CT' => 'SO3', 'SO_CT' => 'HD001', 'TIEN2' => '-500000']];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
+
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$phieuRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$phieuRows, $columns, 'phieuCellValue']);
+
+        self::assertSame('P1', $rows[0]['stt_rec']);
+        self::assertSame('SO3', $rows[0]['ma_ct']);
+        self::assertSame('HD001', $rows[0]['so_ct']);
+
+        $tien2 = self::columnIndex($columns, 'tien2');
+        self::assertSame('-500,000', $rows[0]['cells'][$tien2]['v']);
+        self::assertSame('text-red-500', $rows[0]['cells'][$tien2]['c']);
+    }
+
+    public function testSorptbk01ClientRowsInheritMaCtFromParentPhieu(): void
+    {
+        // Chi tiet ct khong co ma_ct — phai ke thua ma_ct phieu cha theo
+        // stt_rec de Alpine biet phieu SO3 (duoc sua/xoa) hay SO4 (mau do).
+        $component = new Sorptbk01();
+        $phieuRows = [['stt_rec' => 'P1', 'ma_ct' => 'SO4', 'so_ct' => 'PK001']];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
+
+        $chiTietRows = [['stt_rec' => 'P1', 'ma_vt' => 'VT001', 'so_luong' => '2', 'tien2' => '100000']];
+        $columns = self::callPrivate($component, 'buildChiTietColumns', [$chiTietRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$chiTietRows, $columns, 'chiTietCellValue']);
+
+        self::assertSame('SO4', $rows[0]['ma_ct']);
     }
 
     public function testSorptbk01PayloadMapsDkttToPMaTT(): void
@@ -92,7 +142,7 @@ final class ArdmkhFormTest extends TestCase
     public function testSorptbk01PhieuColumnsIncludeVoucherTypeColumn(): void
     {
         $component = new Sorptbk01();
-        $columns = $component->phieuColumns();
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [[]]);
 
         self::assertSame('ma_ct', $columns[0]['key']);
         self::assertSame('Loại phiếu', $columns[0]['label']);
@@ -101,7 +151,7 @@ final class ArdmkhFormTest extends TestCase
     public function testSorptbk01PhieuColumnsUseAsSORptBK01ResultNames(): void
     {
         $component = new Sorptbk01();
-        $component->phieuRows = [[
+        $rows = [[
             'tien2'     => '70000',
             'thue_gtgt' => '7000',
             'tt'        => '77000',
@@ -110,7 +160,7 @@ final class ArdmkhFormTest extends TestCase
             'tt_nt'     => '77',
         ]];
 
-        $columns = $component->phieuColumns();
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$rows]);
         $keys = array_column($columns, 'key');
 
         self::assertContains('tien2', $keys);
@@ -152,27 +202,39 @@ final class ArdmkhFormTest extends TestCase
         self::assertSame('', $component->phieuCellValue([], 'ma_ct'));
     }
 
-    public function testSorptbk01PhieuMoneyCellNegativeUsesRedText(): void
+    public function testSorptbk01ClientRowsNegativeMoneyUsesRedText(): void
     {
         $component = new Sorptbk01();
+        $phieuRows = [['stt_rec' => 'P1', 'ma_ct' => 'SO3', 't_ck' => '-500000']];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
 
-        self::assertSame('text-red-500', $component->phieuCellClass(['t_tien' => '-500000'], 't_tien'));
-        self::assertSame('text-red-500', $component->phieuCellClass(['T_TIEN' => '-500000'], 't_tien'));
-        self::assertSame('text-gray-700', $component->phieuCellClass(['t_tien' => '500000'], 't_tien'));
-        self::assertSame('text-gray-700', $component->phieuCellClass(['t_tien' => '0'], 't_tien'));
-        self::assertSame('text-gray-700', $component->phieuCellClass([], 't_tien'));
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$phieuRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$phieuRows, $columns, 'phieuCellValue']);
+
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 't_ck')]['c']);
+
+        $phieuRows = [['stt_rec' => 'P1', 'ma_ct' => 'SO3', 't_ck' => '500000']];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$phieuRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$phieuRows, $columns, 'phieuCellValue']);
+
+        self::assertSame('text-gray-700', $rows[0]['cells'][self::columnIndex($columns, 't_ck')]['c']);
     }
 
-    public function testSorptbk01PhieuMoneyCellRedWhenReturnVoucherSo4(): void
+    public function testSorptbk01ClientRowsRedWhenReturnVoucherSo4(): void
     {
         $component = new Sorptbk01();
 
         // SO4 luu so tien duong trong SoPh4; dau am chi ap dung khi post GL —
         // phai nhan dien theo ma_ct de phiếu tra hang co mau.
-        self::assertSame('text-red-500', $component->phieuCellClass(['ma_ct' => 'SO4', 't_tien' => '500000'], 't_tien'));
-        self::assertSame('text-red-500', $component->phieuCellClass(['MA_CT' => 'SO4', 't_thue' => '50000'], 't_thue'));
-        self::assertSame('text-gray-700', $component->phieuCellClass(['ma_ct' => 'SO3', 't_tien' => '500000'], 't_tien'));
-        self::assertSame('text-gray-700', $component->phieuCellClass(['ma_ct' => 'SO4', 'ten_kh' => 'KH'], 'ten_kh'));
+        $phieuRows = [['stt_rec' => 'P1', 'ma_ct' => 'SO4', 't_ck' => '500000', 'ten_kh' => 'KH']];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
+
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$phieuRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$phieuRows, $columns, 'phieuCellValue']);
+
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 't_ck')]['c']);
+        self::assertSame('text-gray-700', $rows[0]['cells'][self::columnIndex($columns, 'ten_kh')]['c']);
     }
 
     public function testSorptbk01PhieuEmptyMoneyCellShowsPlaceholder(): void
@@ -185,29 +247,32 @@ final class ArdmkhFormTest extends TestCase
         self::assertSame('500,000', $component->phieuCellValue(['t_tien' => '500000'], 't_tien'));
     }
 
-    public function testSorptbk01ChiTietNegativeQuantityAndMoneyUseRedText(): void
+    public function testSorptbk01ClientRowsChiTietNegativeUsesRedText(): void
     {
         $component = new Sorptbk01();
+        self::setPrivate($component, 'phieuRows', [['stt_rec' => 'P1', 'ma_ct' => 'SO3']]);
+        $chiTietRows = [['stt_rec' => 'P1', 'so_luong' => '-2', 't_ck' => '-100000', 'thue_gtgt' => '-10000', 'ma_vt' => 'VT1']];
 
-        self::assertSame('text-red-500', $component->chiTietCellClass(['so_luong' => '-2'], 'so_luong'));
-        self::assertSame('text-red-500', $component->chiTietCellClass(['tien' => '-100000'], 'tien'));
-        self::assertSame('text-red-500', $component->chiTietCellClass(['thue_gtgt' => '-10000'], 'thue_gtgt'));
-        self::assertSame('text-gray-700', $component->chiTietCellClass(['so_luong' => '2'], 'so_luong'));
-        self::assertSame('text-gray-700', $component->chiTietCellClass(['tien' => '100000'], 'tien'));
-        self::assertSame('text-gray-700', $component->chiTietCellClass(['so_luong' => '2'], 'ma_vt'));
+        $columns = self::callPrivate($component, 'buildChiTietColumns', [$chiTietRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$chiTietRows, $columns, 'chiTietCellValue']);
+
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 'so_luong')]['c']);
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 't_ck')]['c']);
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 'thue_gtgt')]['c']);
+        self::assertSame('text-gray-700', $rows[0]['cells'][self::columnIndex($columns, 'ma_vt')]['c']);
     }
 
     public function testSorptbk01ChiTietColumnsUseAsSORptBK01ResultNames(): void
     {
         $component = new Sorptbk01();
-        $component->chiTietRows = [[
+        $rows = [[
             'gia2'      => '70000',
             'tien2'     => '70000',
             'thue_gtgt' => '7000',
             'tt'        => '77000',
         ]];
 
-        $keys = array_column($component->chiTietColumns(), 'key');
+        $keys = array_column(self::callPrivate($component, 'buildChiTietColumns', [$rows]), 'key');
 
         self::assertContains('gia2', $keys);
         self::assertContains('tien2', $keys);
@@ -215,20 +280,24 @@ final class ArdmkhFormTest extends TestCase
         self::assertContains('tt', $keys);
     }
 
-    public function testSorptbk01ChiTietMoneyCellRedWhenSelectedPhieuIsSo4(): void
+    public function testSorptbk01ClientRowsChiTietRedWhenParentPhieuIsSo4(): void
     {
         $component = new Sorptbk01();
-        $component->selectedPhieu = ['ma_ct' => 'SO4'];
+        self::setPrivate($component, 'phieuRows', [['stt_rec' => 'P1', 'ma_ct' => 'SO4']]);
+        $chiTietRows = [['stt_rec' => 'P1', 'so_luong' => '2', 't_ck' => '100000', 'ma_vt' => 'VT1']];
 
-        self::assertSame('text-red-500', $component->chiTietCellClass(['so_luong' => '2'], 'so_luong'));
-        self::assertSame('text-red-500', $component->chiTietCellClass(['tien' => '100000'], 'tien'));
-        self::assertSame('text-gray-700', $component->chiTietCellClass(['so_luong' => '2'], 'ma_vt'));
+        $columns = self::callPrivate($component, 'buildChiTietColumns', [$chiTietRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$chiTietRows, $columns, 'chiTietCellValue']);
+
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 'so_luong')]['c']);
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 't_ck')]['c']);
+        self::assertSame('text-gray-700', $rows[0]['cells'][self::columnIndex($columns, 'ma_vt')]['c']);
     }
 
     public function testSorptbk01PhieuColumnsAppendAllSpResultFields(): void
     {
         $component = new Sorptbk01();
-        $component->phieuRows = [[
+        $rows = [[
             'stt_rec'  => 'P1',
             'ma_ct'    => 'SO3',
             'so_ct'    => 'HD001',
@@ -240,7 +309,7 @@ final class ArdmkhFormTest extends TestCase
             't_ck'     => '10000',
         ]];
 
-        $keys = array_column($component->phieuColumns(), 'key');
+        $keys = array_column(self::callPrivate($component, 'buildPhieuColumns', [$rows]), 'key');
 
         // Các cột quen thuộc vẫn đứng trước
         self::assertSame('ma_ct', $keys[0]);
@@ -258,7 +327,7 @@ final class ArdmkhFormTest extends TestCase
     public function testSorptbk01DynamicColumnsSkipInactiveCurrencyVariants(): void
     {
         $component = new Sorptbk01();
-        $component->phieuRows = [[
+        $rows = [[
             'tien2'    => '1000000',
             'tien_nt2' => '1000',
             't_ck'     => '10000',
@@ -266,7 +335,7 @@ final class ArdmkhFormTest extends TestCase
         ]];
 
         // Mặc định VND: cột quen thuộc lấy tien2, bỏ qua biến thể NT động (t_ck_nt)
-        $keys = array_column($component->phieuColumns(), 'key');
+        $keys = array_column(self::callPrivate($component, 'buildPhieuColumns', [$rows]), 'key');
         self::assertContains('tien2', $keys);
         self::assertNotContains('tien_nt2', $keys);
         self::assertNotContains('t_ck_nt', $keys);
@@ -274,7 +343,7 @@ final class ArdmkhFormTest extends TestCase
 
         // Chọn NT: cột quen thuộc giữ key, cột động giữ biến thể NT, bỏ VND
         $component->pMa_nt = 'USD';
-        $keys = array_column($component->phieuColumns(), 'key');
+        $keys = array_column(self::callPrivate($component, 'buildPhieuColumns', [$rows]), 'key');
         self::assertContains('tien2', $keys);
         self::assertNotContains('t_ck', $keys);
         self::assertContains('t_ck_nt', $keys);
@@ -283,7 +352,7 @@ final class ArdmkhFormTest extends TestCase
     public function testSorptbk01DynamicColumnsSkipRawFieldsWithoutLabels(): void
     {
         $component = new Sorptbk01();
-        $component->phieuRows = [[
+        $rows = [[
             'ma_cty'    => '001',
             'stt_rec0'  => '001',
             'stt_rec'   => 'P1',
@@ -297,7 +366,7 @@ final class ArdmkhFormTest extends TestCase
             'so_seri'   => '01AA',
         ]];
 
-        $keys = array_column($component->phieuColumns(), 'key');
+        $keys = array_column(self::callPrivate($component, 'buildPhieuColumns', [$rows]), 'key');
 
         // Cột liên kết nội bộ không hiển thị.
         self::assertNotContains('stt_rec', $keys);
@@ -317,14 +386,14 @@ final class ArdmkhFormTest extends TestCase
     public function testSorptbk01DiscountColumnLabelsAreNotAbbreviated(): void
     {
         $component = new Sorptbk01();
-        $component->phieuRows = [[
+        $rows = [[
             'tien_ck'    => '10000',
             'tien_ck_nt' => '10',
             'ck_ds'      => '5000',
             'ck_ds_nt'   => '5',
         ]];
 
-        $labels = array_column($component->phieuColumns(), 'label');
+        $labels = array_column(self::callPrivate($component, 'buildPhieuColumns', [$rows]), 'label');
 
         self::assertContains('Tiền chiết khấu', $labels);
         self::assertContains('Chiết khấu doanh số', $labels);
@@ -340,8 +409,13 @@ final class ArdmkhFormTest extends TestCase
         self::assertSame('10,000', $component->phieuCellValue(['t_ck' => '10000'], 't_ck'));
         self::assertSame('', $component->phieuCellValue(['t_ck' => null], 't_ck', true));
         self::assertSame('—', $component->phieuCellValue(['t_ck' => null], 't_ck'));
-        self::assertSame('text-red-500', $component->phieuCellClass(['t_ck' => '-10000'], 't_ck'));
-        self::assertSame('text-red-500', $component->phieuCellClass(['ma_ct' => 'SO4', 't_ck' => '10000'], 't_ck'));
+
+        $phieuRows = [['stt_rec' => 'P1', 'ma_ct' => 'SO4', 't_ck' => '10000']];
+        self::setPrivate($component, 'phieuRows', $phieuRows);
+        $columns = self::callPrivate($component, 'buildPhieuColumns', [$phieuRows]);
+        $rows    = self::callPrivate($component, 'clientRows', [$phieuRows, $columns, 'phieuCellValue']);
+
+        self::assertSame('text-red-500', $rows[0]['cells'][self::columnIndex($columns, 't_ck')]['c']);
     }
 
     public function testSorptbk01DynamicDateAndTextCells(): void
@@ -352,31 +426,54 @@ final class ArdmkhFormTest extends TestCase
         self::assertSame('Ghi chú bán hàng', $component->phieuCellValue(['dien_giai' => 'Ghi chú bán hàng'], 'dien_giai'));
     }
 
-    public function testSorptbk01SelectedVoucherActionsOnlyForSo3(): void
+    public function testSorptbk01DeleteVoucherGuardsInvalidAndNonSo3(): void
     {
+        \Illuminate\Support\Facades\Session::start();
+
+        // stt_rec rong: flash loi, khong goi SP.
         $component = new Sorptbk01();
-        $component->selectedPhieu = ['STT_REC' => 'SO3-STT', 'MA_CT' => 'SO3', 'SO_CT' => 'HD001'];
+        $component->deleteVoucher('');
+        self::assertNotEmpty(session('error'));
 
-        self::assertTrue($component->canEditSelectedVoucher());
-        self::assertSame('SO3-STT', $component->selectedVoucherSttRec());
-        self::assertSame('HD001', $component->selectedVoucherSoCt());
-
-        $component->selectedPhieu = ['STT_REC' => 'SO4-STT', 'MA_CT' => 'SO4', 'SO_CT' => 'PK001'];
-        self::assertFalse($component->canEditSelectedVoucher());
-
-        $component->selectedPhieu = ['STT_REC' => 'SO5-STT', 'MA_CT' => 'SO5', 'SO_CT' => 'DV001'];
-        self::assertFalse($component->canEditSelectedVoucher());
-
-        $component->selectedPhieu = [];
-        self::assertFalse($component->canEditSelectedVoucher());
+        // Phieu SO4 trong session: flash loi (chi SO3 duoc xoa tu bang ke).
+        session()->forget('error');
+        $component = new Sorptbk01();
+        $component->setId('test-component');
+        session(['sorptbk01.report.test-component' => [
+            'phieu'   => [['stt_rec' => 'P1', 'ma_ct' => 'SO4', 'so_ct' => 'PK001']],
+            'chitiet' => [],
+        ]]);
+        $component->deleteVoucher('P1');
+        self::assertNotEmpty(session('error'));
     }
 
-    public function testSorptbk01SelectedVoucherSttRecNormalizesRawCase(): void
+    /**
+     * @param list<array{key:string,label:string,class:string}> $columns
+     */
+    private static function columnIndex(array $columns, string $key): int
     {
-        $component = new Sorptbk01();
-        $component->selectedPhieu = ['stt_rec' => 'P1', 'ma_ct' => 'SO3', 'so_ct' => 'HD001'];
+        foreach ($columns as $index => $column) {
+            if ($column['key'] === $key) {
+                return $index;
+            }
+        }
 
-        self::assertSame('P1', $component->selectedVoucherSttRec());
-        self::assertSame('HD001', $component->selectedVoucherSoCt());
+        self::fail("Column {$key} not found in column list.");
+    }
+
+    private static function setPrivate(object $target, string $property, mixed $value): void
+    {
+        $reflection = new \ReflectionProperty($target::class, $property);
+        $reflection->setValue($target, $value);
+    }
+
+    /**
+     * @param list<mixed> $args
+     */
+    private static function callPrivate(object $target, string $method, array $args): mixed
+    {
+        $reflection = new \ReflectionMethod($target::class, $method);
+
+        return $reflection->invokeArgs($target, $args);
     }
 }


### PR DESCRIPTION
## Tổng quan

PR gộp 2 nhóm tối ưu client-side:

1. `Sorptbk01`: chuyển dữ liệu báo cáo ra khỏi snapshot Livewire, render Alpine client-side.
2. `INDMVT`: chuyển chi tiết vật tư sang Alpine fill từ dữ liệu có sẵn, không roundtrip khi chọn mã; áp dụng subsequence search dùng chung cho toàn bộ trang.

## Sorptbk01

### Vấn đề

`/simba/so/rpt/sorptbk01` load rất chậm: sau khi bấm "Thực hiện", mọi thao tác (chọn phiếu, xem chi tiết) đều roundtrip nguyên khối dữ liệu báo cáo trong snapshot Livewire.

### Nguyên nhân

- `phieuRows`/`chiTietRows` là property **public** Livewire -> toàn bộ dòng được serialize vào snapshot và truyền đi truyền lại mỗi roundtrip.
- `phieuColumns()`/`chiTietColumns()` + `appendDynamicColumns()` duyệt **tất cả dòng** để dò cột, chạy lại mỗi render.
- `selectPhieu()` lọc `chiTietRows` O(n) mỗi lần click.

### Thay đổi

- Rows/cột chuyển sang **private**, không nằm trong snapshot Livewire.
- `submit()` gọi SP `asSORptBK01` **1 lần**, tính cột **1 lần**, pre-format toàn bộ cell (giá trị + class màu) qua `clientRows()`, cất dữ liệu thô vào session (cho export CSV / xóa chứng từ), dispatch payload xuống Alpine **1 lần**.
- Bảng phiếu + chi tiết render bằng Alpine `x-for`; click chọn phiếu lọc theo `stt_rec` ngay trong browser, **không roundtrip**.
- `deleteSelectedVoucher()` -> `deleteVoucher(sttRec)`: đọc phiếu từ session, guard chỉ SO3, gọi `AsSODelPH3`, dispatch `sorptbk01-voucher-deleted` để Alpine xóa dòng client-side.
- `exportCsv()`/`csvRows()` đọc từ session.
- Fix Livewire 3: `$this->id` -> `$this->getId()` (PropertyNotFoundException).

## INDMVT

### Thay đổi

- Bỏ click roundtrip khi chọn mã vật tư: Alpine `selectRow()` đọc trực tiếp từ row đã render và fill bảng chi tiết client-side.
- Bỏ component `IndmvtDetail` riêng; bảng chi tiết nằm trong `indmvt-list.blade.php` và **ẩn hẳn khi chưa chọn row** (không còn placeholder).
- Nút Sửa/Xóa trong chi tiết vẫn hoạt động qua Livewire; xóa dùng `deleteDetailItem()` và Alpine lắng nghe `indmvt-list.deleted`.

## Search dùng chung

- Thêm `window.PortalSearch` trong `resources/js/app.js` (bundle Vite toàn cục).
- `matchesSubsequence()`: khớp theo dãy ký tự con đúng thứ tự sau khi chuẩn hóa NFD/đ->d/lowercase; **không alias, không viết tắt chữ cái đầu, không hardcode**.
- Ví dụ `Thủy Đông Hà` khớp `tdh`, `tda`, `ygh`; `WarmDream` khớp `wdr`.
- Áp dụng cho: `IndmvtList`, `ArdmkhList`, `InputKhachhang`, `InputHttt`, `InputNgoaite`, `InputChiphi`, `InputIndmkho`, `InputIndmvt`, `InputTaikhoan`.
- Cập nhật `docs/PROJECT_CONVENTIONS.md` và `docs/DESIGN.md` theo quy tắc subsequence search.

## Verification

- `php -l` sạch các file PHP sửa; Blade compile OK.
- `IndmvtListTest` 3/3, `ArdmkhFormTest` 26/26, `AsSORptBK01Test` 3/3, `SourceRouteCoverageTest` (filter Sorptbk01) 1/1.
- `resources/js/app.js` có `PortalSearch` trong bundle Vite; Node test subsequence pass.
- Live: `/simba/so/rpt/sorptbk01` và `/simba/in/dict/indmvt` trả 200.

## Lưu ý

Chưa verify thao tác bấm "Thực hiện" Sorptbk01 với dữ liệu thật qua curl (cần session đăng nhập + dữ liệu SP). Cần Sếp mở trang, chọn loại phiếu, bấm Thực hiện để xác nhận danh sách load 1 lần và click chọn phiếu tức thì.
