### PR TITLE
fix(support): session cookie domain theo host cho ca 3 moi truong

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Diepxuan\Support\Http\Middleware\SessionDomain;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -13,6 +14,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->validateCsrfTokens(['simba/si/vch/year/select']);
+        // Cookie session/XSRF theo host: Portal chay tren ca
+        // portaldev.diepxuan.io.vn, portal.diepxuan.corp va portal.diepxuan.io.vn.
+        $middleware->append(SessionDomain::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/diepxuan/laravel-support/src/Http/Middleware/SessionDomain.php
+++ b/diepxuan/laravel-support/src/Http/Middleware/SessionDomain.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright  © 2019 Dxvn, Inc.
+ *
+ * @author     Tran Ngoc Duc <ductn@diepxuan.com>
+ * @author     Tran Ngoc Duc <caothu91@gmail.com>
+ *
+ * @lastupdate 2026-08-22 08:00:00
+ */
+
+namespace Diepxuan\Support\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tinh domain cookie session theo host cua request.
+ *
+ * Portal chay dong thoi tren 3 host: test `portaldev.diepxuan.io.vn`,
+ * dev `portal.diepxuan.corp` va public `portal.diepxuan.io.vn`. Mot gia tri
+ * `SESSION_DOMAIN` co dinh (vd `.diepxuan.io.vn`) khien browser tu choi
+ * cookie tren host khac zone (`portal.diepxuan.corp`): session khong duoc
+ * giu, moi Livewire POST bi 419 CSRF.
+ *
+ * Middleware dat `session.domain` theo zone cua host TRUOC khi
+ * StartSession / VerifyCsrfToken tao cookie (hai middleware nay doc
+ * `config('session')` luc ghi response), nen cookie session va XSRF-TOKEN
+ * luon co domain khop voi host dang phuc vu.
+ */
+class SessionDomain
+{
+    /**
+     * Cookie domain theo zone — chia se session giua cac subdomain trong
+     * cung zone (vd portaldev/portal/mcc cua diepxuan.io.vn).
+     */
+    private const ZONE_SUFFIXES = [
+        '.diepxuan.io.vn',
+        '.diepxuan.corp',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        config(['session.domain' => $this->domainForHost($request->getHost())]);
+
+        return $next($request);
+    }
+
+    /**
+     * Host thuoc zone nao tra ve cookie domain cua zone do; host khac
+     * (localhost, IP, domain ngoai...) tra ve null de cookie chi ap dung
+     * cho chinh host do (host-only cookie).
+     */
+    public function domainForHost(?string $host): ?string
+    {
+        $host = mb_strtolower(trim((string) $host));
+
+        foreach (self::ZONE_SUFFIXES as $suffix) {
+            if (str_ends_with($host, $suffix)) {
+                return $suffix;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Packages/Support/SessionDomainTest.php
+++ b/tests/Unit/Packages/Support/SessionDomainTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Packages\Support;
+
+use Diepxuan\Support\Http\Middleware\SessionDomain;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Cookie;
+use Tests\TestCase;
+
+final class SessionDomainTest extends TestCase
+{
+    #[DataProvider('hostProvider')]
+    public function testDomainForHostMapsZoneSuffix(string $host, ?string $expected): void
+    {
+        self::assertSame($expected, (new SessionDomain())->domainForHost($host));
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function hostProvider(): iterable
+    {
+        yield 'dev corp' => ['portal.diepxuan.corp', '.diepxuan.corp'];
+        yield 'test io.vn' => ['portaldev.diepxuan.io.vn', '.diepxuan.io.vn'];
+        yield 'public io.vn' => ['portal.diepxuan.io.vn', '.diepxuan.io.vn'];
+        yield 'subdomain io.vn' => ['mcc.diepxuan.io.vn', '.diepxuan.io.vn'];
+        yield 'uppercase host' => ['PORTAL.DIEPXUAN.CORP', '.diepxuan.corp'];
+        yield 'localhost' => ['localhost', null];
+        yield 'ip' => ['10.0.0.122', null];
+        yield 'external domain' => ['example.com', null];
+    }
+
+    public function testSessionCookieUsesCorpDomainOnDevHost(): void
+    {
+        $response = $this->get('http://portal.diepxuan.corp/login');
+
+        $response->assertOk();
+        self::assertSame('.diepxuan.corp', $this->cookieDomain($response->headers->getCookies(), 'portal_session'));
+        self::assertSame('.diepxuan.corp', $this->cookieDomain($response->headers->getCookies(), 'XSRF-TOKEN'));
+    }
+
+    public function testSessionCookieUsesIoVnDomainOnTestHost(): void
+    {
+        $response = $this->get('http://portaldev.diepxuan.io.vn/login');
+
+        $response->assertOk();
+        self::assertSame('.diepxuan.io.vn', $this->cookieDomain($response->headers->getCookies(), 'portal_session'));
+        self::assertSame('.diepxuan.io.vn', $this->cookieDomain($response->headers->getCookies(), 'XSRF-TOKEN'));
+    }
+
+    public function testSessionCookieUsesIoVnDomainOnPublicHost(): void
+    {
+        $response = $this->get('https://portal.diepxuan.io.vn/login');
+
+        $response->assertOk();
+        self::assertSame('.diepxuan.io.vn', $this->cookieDomain($response->headers->getCookies(), 'portal_session'));
+    }
+
+    /**
+     * @param list<Cookie> $cookies
+     */
+    private function cookieDomain(array $cookies, string $name): ?string
+    {
+        foreach ($cookies as $cookie) {
+            if ($cookie->getName() === $name) {
+                return $cookie->getDomain();
+            }
+        }
+
+        self::fail("Cookie {$name} khong ton tai trong response.");
+    }
+}


### PR DESCRIPTION
## Van de

Portal chay dong thoi tren 3 host:
- test: `portaldev.diepxuan.io.vn`
- dev: `portal.diepxuan.corp`
- public: `portal.diepxuan.io.vn`

`.env` dat `SESSION_DOMAIN=.diepxuan.io.vn` co dinh. Khi truy cap qua `portal.diepxuan.corp` (khac zone), browser tu choi cookie vi domain khong khop -> session khong duoc giu -> moi Livewire POST bi 419 CSRF (vd submit bao cao `/simba/so/rpt/sorptbk01`).

## Giai phap

Middleware `Diepxuan\Support\Http\Middleware\SessionDomain` dat `session.domain` theo zone cua host, chay truoc khi `StartSession`/`VerifyCsrfToken` ghi cookie:

| Host | Cookie domain |
|---|---|
| `*.diepxuan.io.vn` | `.diepxuan.io.vn` |
| `*.diepxuan.corp` | `.diepxuan.corp` |
| host ngoai zone (localhost, IP...) | `null` (host-only) |

Dang ky bang `$middleware->append()` trong `bootstrap/app.php`.

`.env` local da doi `SESSION_DOMAIN=null` (middleware tu quyet dinh; file khong track trong git).

## Verify

- PHPUnit: `SessionDomainTest` 11 tests / 16 assertions PASS (unit `domainForHost` + feature Set-Cookie 3 host).
- Live `Set-Cookie`:
  - `http://portal.diepxuan.corp` -> `domain=.diepxuan.corp`
  - `Host: portaldev.diepxuan.io.vn` (local) -> `domain=.diepxuan.io.vn`
- Browser E2E `/simba/so/rpt/sorptbk01` KHONG inject cookie: browser nhan cookie tu server, Livewire update 200, bao cao load 157 phieu / 648 chi tiet, 0 loi console/Alpine.

## Lien quan

Giai quyet loi 419 CSRF ghi nhan khi kiem tra task 201 (SORptBK01) — ban than task 201 khong co bug.